### PR TITLE
Searchable Facets: Do not set state on option click

### DIFF
--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -342,12 +342,8 @@ export default class FilterOptionsComponent extends Component {
    * @returns {number}
    * @private
    */
-  _toggleResetIfPresent () {
+  _toggleReset () {
     const resetEl = DOM.query(this._container, '.js-yxt-FilterOptions-reset');
-    if (!resetEl) {
-      return;
-    }
-
     const selectedCount = this._getSelectedCount();
     if (selectedCount > 0) {
       resetEl.classList.remove('js-hidden');
@@ -447,7 +443,9 @@ export default class FilterOptionsComponent extends Component {
   }
 
   _updateOption (index, selected) {
-    this._toggleResetIfPresent();
+    if (this.config.showReset) {
+      this._toggleReset();
+    }
 
     if (this.config.control === 'singleoption') {
       this.config.options = this.config.options.map(o => Object.assign({}, o, { selected: false }));

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -137,7 +137,7 @@ class FilterOptionsConfig {
     }));
   }
 
-  getSelectedCount () {
+  getInitialSelectedCount () {
     return this.options.reduce(
       (numSelected, option) => option.selected ? numSelected + 1 : numSelected,
       0);
@@ -177,7 +177,7 @@ export default class FilterOptionsComponent extends Component {
       ...config
     });
 
-    const selectedCount = this.config.getSelectedCount();
+    const selectedCount = this.config.getInitialSelectedCount();
 
     /**
      * True if the option list is expanded and visible
@@ -200,7 +200,7 @@ export default class FilterOptionsComponent extends Component {
   }
 
   setState (data) {
-    const selectedCount = this.config.getSelectedCount();
+    const selectedCount = this.config.getInitialSelectedCount();
     super.setState(Object.assign({}, data, {
       name: this.name.toLowerCase(),
       ...this.config,
@@ -212,15 +212,20 @@ export default class FilterOptionsComponent extends Component {
   }
 
   onMount () {
+    const selectedEls = DOM.queryAll(this._container, '.js-yxt-FilterOptions-checkboxInput:checked');
+    const selectedCount = selectedEls && selectedEls.length;
+
     DOM.delegate(
       DOM.query(this._container, `.yxt-FilterOptions-options`),
       this.config.optionSelector,
       'click',
       event => {
+        let selectedCountEl = DOM.query(this._container, '.js-yxt-FilterOptions-selectedCount');
+        if (selectedCountEl) {
+          selectedCountEl.innerText = selectedCount;
+        }
         this._updateOption(parseInt(event.target.dataset.index), event.target.checked);
       });
-
-    const selectedCount = this.config.getSelectedCount();
 
     // reset button
     if (this.config.showReset && selectedCount > 0) {
@@ -420,7 +425,10 @@ export default class FilterOptionsComponent extends Component {
 
     this.config.options[index] = Object.assign({}, this.config.options[index], { selected });
     this.updateListeners();
-    this.setState();
+
+    if (this.config.storeOnChange) {
+      this.setState();
+    }
   }
 
   getFilter () {

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -212,7 +212,6 @@ export default class FilterOptionsComponent extends Component {
   }
 
   onMount () {
-
     DOM.delegate(
       DOM.query(this._container, `.yxt-FilterOptions-options`),
       this.config.optionSelector,
@@ -220,7 +219,7 @@ export default class FilterOptionsComponent extends Component {
       event => {
         let selectedCountEl = DOM.query(this._container, '.js-yxt-FilterOptions-selectedCount');
         if (selectedCountEl) {
-          selectedCountEl.innerText = this._getSelectedCount();;
+          selectedCountEl.innerText = this._getSelectedCount();
         }
         this._updateOption(parseInt(event.target.dataset.index), event.target.checked);
       });

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -212,17 +212,15 @@ export default class FilterOptionsComponent extends Component {
   }
 
   onMount () {
-    let selectedCount = this._getSelectedCount();
 
     DOM.delegate(
       DOM.query(this._container, `.yxt-FilterOptions-options`),
       this.config.optionSelector,
       'click',
       event => {
-        selectedCount = this._getSelectedCount();
         let selectedCountEl = DOM.query(this._container, '.js-yxt-FilterOptions-selectedCount');
         if (selectedCountEl) {
-          selectedCountEl.innerText = selectedCount;
+          selectedCountEl.innerText = this._getSelectedCount();;
         }
         this._updateOption(parseInt(event.target.dataset.index), event.target.checked);
       });

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -331,7 +331,7 @@ export default class FilterOptionsComponent extends Component {
    * @returns {number}
    * @private
    */
-  _getSelectedCount() {
+  _getSelectedCount () {
     const selectedEls = DOM.queryAll(this._container, '.js-yxt-FilterOptions-checkboxInput:checked');
     return selectedEls && selectedEls.length;
   }
@@ -345,7 +345,7 @@ export default class FilterOptionsComponent extends Component {
    * @returns {number}
    * @private
    */
-  _toggleResetIfPresent() {
+  _toggleResetIfPresent () {
     const resetEl = DOM.query(this._container, '.js-yxt-FilterOptions-reset');
     if (!resetEl) {
       return;

--- a/src/ui/sass/modules/_FilterOptions.scss
+++ b/src/ui/sass/modules/_FilterOptions.scss
@@ -91,6 +91,10 @@
   }
 
   &-reset {
+    &.js-hidden {
+      display: none;
+    }
+
     @include Text(
       $color: $color-brand-primary,
       $style: italic);

--- a/src/ui/sass/modules/_FilterOptions.scss
+++ b/src/ui/sass/modules/_FilterOptions.scss
@@ -52,6 +52,7 @@
     display: flex;
     align-items: flex-start;
     margin: 2px 0;
+    cursor: pointer;
 
     &.hidden
     {

--- a/src/ui/templates/controls/filteroptions.hbs
+++ b/src/ui/templates/controls/filteroptions.hbs
@@ -28,7 +28,7 @@
       {{/if}}
       {{#if showReset}}
         {{#unless showExpand}}
-          <button class="yxt-FilterOptions-reset yxt-FilterOptions-reset--right">{{resetLabel}}</button>
+          <button class="yxt-FilterOptions-reset js-yxt-FilterOptions-reset yxt-FilterOptions-reset--right{{#unless displayReset}} js-hidden{{/unless}}">{{resetLabel}}</button>
         {{/unless}}
       {{/if}}
     </div>
@@ -37,7 +37,7 @@
   <div class="yxt-FilterOptions-container js-yxt-FilterOptions-container{{#unless expanded}} yxt-FilterOptions--collapsed{{/unless}}">
     {{#if showReset}}
       {{#if showExpand}}
-        <button class="yxt-FilterOptions-reset">{{resetLabel}}</button>
+        <button class="yxt-FilterOptions-reset js-yxt-FilterOptions-reset{{#unless displayReset}} js-hidden{{/unless}}">{{resetLabel}}</button>
       {{/if}}
     {{/if}}
 

--- a/src/ui/templates/controls/filteroptions.hbs
+++ b/src/ui/templates/controls/filteroptions.hbs
@@ -26,24 +26,20 @@
         {{else}}
           <span class="yxt-FilterOptions-label">{{label}}</span>
       {{/if}}
-      {{#if showReset}}
-        {{#unless showExpand}}
-          <button class="yxt-FilterOptions-reset js-yxt-FilterOptions-reset yxt-FilterOptions-reset--right{{#unless displayReset}} js-hidden{{/unless}}">{{resetLabel}}</button>
-        {{/unless}}
-      {{/if}}
+      {{#unless showExpand}}
+        <button class="yxt-FilterOptions-reset js-yxt-FilterOptions-reset yxt-FilterOptions-reset--right{{#unless displayReset}} js-hidden{{/unless}}">{{resetLabel}}</button>
+      {{/unless}}
     </div>
   </legend>
 
   <div class="yxt-FilterOptions-container js-yxt-FilterOptions-container{{#unless expanded}} yxt-FilterOptions--collapsed{{/unless}}">
 
     <div class="yxt-FilterOptions-controls">
-      {{#if showReset}}
-        {{#if showExpand}}
+      {{#if showExpand}}
         <span class="yxt-FilterOptions-buttonWrapper">
           <button class="yxt-FilterOptions-reset js-yxt-FilterOptions-reset{{#unless displayReset}} js-hidden{{/unless}}">{{resetLabel}}</button>
         </span>
       {{/if}}
-    {{/if}}
 
     {{#if searchable}}
       <input type="text" class="yxt-FilterOptions-filter js-yxt-FilterOptions-filter" placeholder="{{placeholderText}}">

--- a/src/ui/templates/controls/filteroptions.hbs
+++ b/src/ui/templates/controls/filteroptions.hbs
@@ -8,7 +8,7 @@
             {{#if showNumberApplied}}
               {{#unless expanded}}
                 {{#if selectedCount}}
-                  <span class="yxt-FilterOptions-selectedCount">{{selectedCount}}</span>
+                  <span class="yxt-FilterOptions-selectedCount js-yxt-FilterOptions-selectedCount">{{selectedCount}}</span>
                 {{/if}}
               {{/unless}}
             {{/if}}
@@ -69,7 +69,7 @@
           <div class="multioption-option yxt-FilterOptions-option js-yxt-FilterOptions-option{{#ifgte @index ../showMoreLimit}} js-yxt-FilterOptions-aboveShowMoreLimit hidden{{/ifgte}}">
             <input
               type="checkbox"
-              class="js-yext-filter-option yxt-FilterOptions-input"
+              class="js-yext-filter-option yxt-FilterOptions-input yxt-FilterOptions-checkboxInput js-yxt-FilterOptions-checkboxInput"
               id="js-yext-checkbox-{{../name}}-{{@index}}"
               value="{{value}}"
               data-index="{{@index}}"


### PR DESCRIPTION
This fixes a bug where the options were re-rendered on click. When
that happened, the showMoreLimit would be reset, so if a user had
all options expanded, then clicked an option, it would collapse all
options. The re-render also caused a slight flash on click.

Options will still be re-rendered on click when the storeOnChange boolean
is true.

TEST=manual

Test by using the Facets component on my local machine and selecting
options. Note that they don't re-render on click. Clicking Apply correctly
applies the selected options. Test that options can be initialized properly
through config. Test with the `expanded: true` and with `expanded: false`
since there is branching logic in the template. Also test with `showReset: true`
and `showReset: false`. Confirmed that the reset button still appears when
greater than zero options are selected and the expand/collapse behavior is 
as expected.