### PR TITLE
change yxt-Results-titleBar border to match cards border

### DIFF
--- a/src/ui/sass/modules/_Results.scss
+++ b/src/ui/sass/modules/_Results.scss
@@ -43,6 +43,12 @@
     padding-top: $base-spacing / 2;
     padding-bottom: $base-spacing / 2;
     background-color: $results-title-bar-background;
+    border: $border-default;
+    border-bottom: none;
+  }
+
+  .yxt-Accordion &-titleBar
+  {
     border: $border-legacy;
     border-bottom: none;
   }


### PR DESCRIPTION
merging into v1.1.1 because I think this is arguably a bugfix
TEST=manual
open a universal page with accordion results and vertical results
check that border matches for vertical results but accordion results is unchanged