### PR TITLE
Pagination: Center chevron icons vertically

### DIFF
--- a/src/ui/sass/modules/_Pagination.scss
+++ b/src/ui/sass/modules/_Pagination.scss
@@ -55,4 +55,10 @@
   {
     margin-right: -4px;
   }
+
+  &-chevron,
+  &-doubleChevron
+  {
+    display: flex;
+  }
 }

--- a/src/ui/sass/modules/_Pagination.scss
+++ b/src/ui/sass/modules/_Pagination.scss
@@ -57,7 +57,9 @@
   }
 
   &-chevron,
-  &-doubleChevron
+  &-doubleChevron,
+  &-chevron--left,
+  &-doubleChevron--left
   {
     display: flex;
   }


### PR DESCRIPTION
In response to this issue (https://github.com/yext/answers/issues/766).

TEST=manual,visual

Test with local answers site. Add pagination component and visually test that the icons were vertically centered.