### PR TITLE
FilterBox: Add null check to filter event listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -848,7 +848,7 @@ ANSWERS.addComponent('FilterBox', {
   showCount: true,
   // Optional, execute a new search whenever a filter selection changes
   searchOnChange: false,
-  // Optional, show a reset button per filter group
+  // Optional, show a reset button per filter group, this will only display if searchOnChange is false
   resetFilter: false,
   // Optional, the label to use for the reset button above
   resetFilterLabel: 'reset',
@@ -868,7 +868,7 @@ ANSWERS.addComponent('FilterBox', {
   expand: true,
   // Optional, show the number of applied filter when a group is collapsed
   showNumberApplied: true,
-  // Optional, the label to show on the apply button
+  // Optional, the label to show on the apply button, this will only display if searchOnChange is false
   applyLabel: 'apply',
   // Optional, whether or not this filterbox contains dynamic filters, default false
   isDynamic: true

--- a/README.md
+++ b/README.md
@@ -846,15 +846,15 @@ ANSWERS.addComponent('FilterBox', {
   title: 'Filters',
   // Optional, show number of results for each filter
   showCount: true,
-  // Optional, execute a new search whenever a filter selection changes
+  // Optional, execute a new search whenever a filter selection changes. If true, the Apply and Reset buttons will not display
   searchOnChange: false,
   // Optional, show a reset button per filter group, this will only display if searchOnChange is false
   resetFilter: false,
-  // Optional, the label to use for the reset button above
+  // Optional, the label to use for the reset button above, this will only display if searchOnChange is false
   resetFilterLabel: 'reset',
-  // Optional, show a reset-all button for the filter control
+  // Optional, show a reset-all button for the filter control, this will only display if searchOnChange is false
   resetFilters: true,
-  // Optional, the label to use for the reset-all button above
+  // Optional, the label to use for the reset-all button above, this will only display if searchOnChange is false
   resetFiltersLabel: 'reset-all',
   // Optional, allow collapsing excess filter options after a limit
   showMore: true,

--- a/src/ui/components/filters/filterboxcomponent.js
+++ b/src/ui/components/filters/filterboxcomponent.js
@@ -227,10 +227,11 @@ export default class FilterBoxComponent extends Component {
 
     // Initialize reset button
     if (this.config.resetFilters) {
-      DOM.on(
-        DOM.query(this._container, '.js-yxt-FilterBox-reset'),
-        'click',
-        this.resetFilters.bind(this));
+      let resetEl = DOM.query(this._container, '.js-yxt-FilterBox-reset');
+
+      if (resetEl) {
+        DOM.on(resetEl, 'click', this.resetFilters.bind(this));
+      }
     }
   }
 

--- a/src/ui/components/filters/filterboxcomponent.js
+++ b/src/ui/components/filters/filterboxcomponent.js
@@ -226,12 +226,10 @@ export default class FilterBoxComponent extends Component {
     }
 
     // Initialize reset button
-    if (this.config.resetFilters) {
-      let resetEl = DOM.query(this._container, '.js-yxt-FilterBox-reset');
+    let resetEl = DOM.query(this._container, '.js-yxt-FilterBox-reset');
 
-      if (resetEl) {
-        DOM.on(resetEl, 'click', this.resetFilters.bind(this));
-      }
+    if (resetEl) {
+      DOM.on(resetEl, 'click', this.resetFilters.bind(this));
     }
   }
 


### PR DESCRIPTION
When using the `searchOnChange` config option, the reset button is not present, and we get a 'cannot addEventListener of null' error. Since `this.config.resetFilters` is true by default, implementers will see this error unless they specify false here, which seems incorrect. Adding a guard so that the SDK will only try to bind the click listener if the element exists. Solves this issue: (https://github.com/yext/answers/issues/509).

TEST=manual

Add a FilterBox component with the `searchOnChange` option, notice error before change. After change, notice that the apply button is missing and clicking options triggers a search.