### PR TITLE
SCSS: Move font-family top level instead of having it in text mixin

### DIFF
--- a/src/ui/components/component.js
+++ b/src/ui/components/component.js
@@ -236,6 +236,9 @@ export default class Component {
     });
 
     DOM.addClass(this._container, this._className);
+
+    // We use this class to scope some of our styling.
+    DOM.addClass(this._container, 'yxt-Container');
     return this;
   }
 

--- a/src/ui/components/component.js
+++ b/src/ui/components/component.js
@@ -238,7 +238,7 @@ export default class Component {
     DOM.addClass(this._container, this._className);
 
     // We use this class to scope some of our styling.
-    DOM.addClass(this._container, 'yxt-Container');
+    DOM.addClass(this._container, 'yxt-ComponentContainer');
     return this;
   }
 

--- a/src/ui/sass/_base.scss
+++ b/src/ui/sass/_base.scss
@@ -14,7 +14,7 @@ body
   -moz-osx-font-smoothing: grayscale;
 }
 
-.yxt-Container
+.yxt-ComponentContainer
 {
   font-family: $font-family;
 }

--- a/src/ui/sass/_base.scss
+++ b/src/ui/sass/_base.scss
@@ -13,3 +13,8 @@ body
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
+
+.yxt-Container
+{
+  font-family: $font-family;
+}

--- a/src/ui/sass/_mixins.scss
+++ b/src/ui/sass/_mixins.scss
@@ -5,7 +5,6 @@
   $style: normal,
   $color: $color-text-primary
 ) {
-  font-family: $font-family;
   font-size: $size;
   line-height: $line-height;
   font-weight: $weight;

--- a/src/ui/sass/modules/_AlternativeVerticals.scss
+++ b/src/ui/sass/modules/_AlternativeVerticals.scss
@@ -1,7 +1,6 @@
 /** @define AlternativeVerticals */
 .yxt-AlternativeVerticals
 {
-  font-family: $font-family;
   font-weight: $font-weight-light;
   background-color: $color-brand-white;
   border: $border-default;


### PR DESCRIPTION
TEST=manual

Test on a Jambo site in SGS that overriding the font-family overrides for the SDK on a vertical-map page as well as universal. Test that without a font-family override, the SDK default is displayed.