### PR TITLE
SortOptions: Store label attribute in global storage

### DIFF
--- a/src/ui/components/filters/sortoptionscomponent.js
+++ b/src/ui/components/filters/sortoptionscomponent.js
@@ -22,6 +22,8 @@ export default class SortOptionsComponent extends Component {
     this.options[this.selectedOptionIndex].isSelected = true;
     this.hideExcessOptions = this._config.showMore && this.selectedOptionIndex < this._config.showMoreLimit;
     this.showReset = this._config.showReset && this.selectedOptionIndex !== 0;
+    const option = this.options[this.selectedOptionIndex];
+    this.core.setSortBys(option);
 
     /**
      * This component listens to updates to vertical results, and sets its state to it when
@@ -114,7 +116,9 @@ export default class SortOptionsComponent extends Component {
     // This was done to have a consistent option name between filters.
     this.core.persistentStorage.set(this.name, optionIndex);
     if (this._config.storeOnChange && optionIndex === 0) {
-      this.core.clearSortBys();
+      this.core.setSortBys({
+        label: this._config.defaultSortLabel
+      });
     } else if (this._config.storeOnChange) {
       this.core.setSortBys(option);
     }

--- a/tests/ui/components/filters/sortoptionscomponent.js
+++ b/tests/ui/components/filters/sortoptionscomponent.js
@@ -9,9 +9,8 @@ import ResultsContext from '../../../../src/core/storage/resultscontext';
 const mockedCore = () => {
   return {
     setSortBys: (...options) => {
-      options.forEach(opt => expect(opt).toHaveProperty('type'));
+      options.forEach(opt => expect(opt).toHaveProperty('label'));
     },
-    clearSortBys: () => {},
     verticalSearch: () => {},
     globalStorage: {
       on: () => {},


### PR DESCRIPTION
This commit updates sort options to always store some
'label' metadata in global storage. This will be used
when displaying applied filters

TEST=manual
Test that sorting still works properly, and that choosing the default
sort option, which before would clear the sortBys, now stores only label,
but this does not get sent in the search (which would cause an error)
Checked using ANSWERS.core.getSortBys() in the console, inspecting
networks tab, and that the returned results order is being changed