### PR TITLE
Implement front-end killswitch for an Answers experience.

### DIFF
--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -165,7 +165,6 @@ class Answers {
 
     const masterSwitchApi = new MasterSwitchApi(globalStorage);
     masterSwitchApi.isDisabled(parsedConfig.apiKey, parsedConfig.experienceKey)
-      .then(isDisabled => { console.log(isDisabled); return isDisabled; })
       .then(isDisabled => !isDisabled && this._initInternal(parsedConfig, globalStorage, persistentStorage))
       .catch(() => this._initInternal(parsedConfig, globalStorage, persistentStorage));
   }

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -143,8 +143,10 @@ class Answers {
    * is ever called, a check to the relevant Answers Status page is made.
    *
    * @param {Object} config The Answers configuration.
+   * @param {Object} statusPage An override for the baseUrl and endpoint of the
+   *                            experience's Answers Status page.
    */
-  init (config) {
+  init (config, statusPage) {
     const parsedConfig = this.parseConfig(config);
     this.validateConfig(parsedConfig);
 
@@ -163,7 +165,10 @@ class Answers {
     globalStorage.set(StorageKeys.SESSIONS_OPT_IN, parsedConfig.sessionTrackingEnabled);
     parsedConfig.noResults && globalStorage.set(StorageKeys.NO_RESULTS_CONFIG, parsedConfig.noResults);
 
-    const masterSwitchApi = new MasterSwitchApi(globalStorage);
+    const masterSwitchApi = statusPage
+      ? new MasterSwitchApi({ apiKey: parsedConfig.apiKey, ...statusPage }, globalStorage)
+      : MasterSwitchApi.from(parsedConfig.apiKey, parsedConfig.experienceKey, globalStorage);
+
     masterSwitchApi.isDisabled(parsedConfig.apiKey, parsedConfig.experienceKey)
       .then(isDisabled => !isDisabled && this._initInternal(parsedConfig, globalStorage, persistentStorage))
       .catch(() => this._initInternal(parsedConfig, globalStorage, persistentStorage));

--- a/src/core/http/apirequest.js
+++ b/src/core/http/apirequest.js
@@ -76,12 +76,15 @@ export default class ApiRequest {
 
   /**
    * get creates a new `GET` request to the server using the configuration of the request class
+   *
+   * @param {Object} opts Any configuration options to use for the GET request.
    * @returns {Promise<Response>}
    */
-  get () {
+  get (opts) {
     return this._requester.get(
       this._baseUrl + this._endpoint,
-      Object.assign({}, this.baseParams(), this.sanitizeParams(this._params))
+      Object.assign({}, this.baseParams(), this.sanitizeParams(this._params)),
+      opts
     );
   }
 

--- a/src/core/search/autocompleteapi.js
+++ b/src/core/search/autocompleteapi.js
@@ -153,7 +153,7 @@ export default class AutoCompleteApi {
     };
     let request = new ApiRequest(requestConfig, this._globalStorage);
 
-    return request.get(queryString)
+    return request.get()
       .then(response => response.json())
       .then(response => AutoCompleteDataTransformer.universal(response.response))
       .catch(error => {

--- a/src/core/utils/masterswitchapi.js
+++ b/src/core/utils/masterswitchapi.js
@@ -6,8 +6,8 @@ import ApiRequest from '../http/apirequest';
  * due to back-end issues.
  */
 export default class MasterSwitchApi {
-  constructor (globalStorage) {
-    this._globalStorage = globalStorage;
+  constructor (requestConfig, globalStorage) {
+    this._request = new ApiRequest(requestConfig, globalStorage);
   }
 
   /**
@@ -16,24 +16,33 @@ export default class MasterSwitchApi {
    * issues with the resultant network call, those failures are caught. In this failure
    * case, the assumption is that things are enabled.
    *
-   * @param {string} apiKey The apiKey of the experience.
-   * @param {string} experienceKey The identifier of the experience.
    * @returns {Promise<boolean>} A Promise containing a boolean indicating if the front-end
    *                             should be disabled.
    */
-  isDisabled (apiKey, experienceKey) {
-    const requestConfig = {
-      apiKey,
-      baseUrl: 'https://answersstatus.pagescdn.com/',
-      endpoint: `${apiKey}/${experienceKey}/status.json`
-    };
-    const request = new ApiRequest(requestConfig, this._globalStorage);
+  isDisabled () {
     return new Promise((resolve, reject) => {
-      request.get({ 'credentials': 'omit' })
+      this._request.get({ credentials: 'omit' })
         .then(response => response.json())
         .then(status => status && status.disabled)
         .then(isDisabled => resolve(!!isDisabled))
         .catch(() => resolve(false));
     });
+  }
+
+  /**
+   * Creates a new {@link MasterSwitchApi} from the provided parameters.
+   *
+   * @param {string} apiKey The apiKey of the experience.
+   * @param {string} experienceKey The identifier of the experience.
+   * @param {GlobalStorage} globalStorage The {@link GlobalStorage} instance.
+   * @returns {MasterSwitchApi} The new {@link MasterSwitchApi} instance.
+   */
+  static from (apiKey, experienceKey, globalStorage) {
+    const requestConfig = {
+      apiKey,
+      baseUrl: 'https://answersstatus.pagescdn.com/',
+      endpoint: `${apiKey}/${experienceKey}/status.json`
+    };
+    return new MasterSwitchApi(requestConfig, globalStorage);
   }
 }

--- a/src/core/utils/masterswitchapi.js
+++ b/src/core/utils/masterswitchapi.js
@@ -1,0 +1,39 @@
+import ApiRequest from '../http/apirequest';
+
+/**
+ * This class provides access to the Answers Status page. This page indicates
+ * if the front-end for a particular experience should be temporarily disabled
+ * due to back-end issues.
+ */
+export default class MasterSwitchApi {
+  constructor (globalStorage) {
+    this._globalStorage = globalStorage;
+  }
+
+  /**
+   * Checks if the front-end for the given experience should be temporarily disabled.
+   * Note that this check errs on the side of enabling the front-end. If there are any
+   * issues with the resultant network call, those failures are caught. In this failure
+   * case, the assumption is that things are enabled.
+   *
+   * @param {string} apiKey The apiKey of the experience.
+   * @param {string} experienceKey The identifier of the experience.
+   * @returns {Promise<boolean>} A Promise containing a boolean indicating if the front-end
+   *                             should be disabled.
+   */
+  isDisabled (apiKey, experienceKey) {
+    const requestConfig = {
+      apiKey,
+      baseUrl: 'https://answersstatus.pagescdn.com/',
+      endpoint: `${apiKey}/${experienceKey}/status.json`
+    };
+    const request = new ApiRequest(requestConfig, this._globalStorage);
+    return new Promise((resolve, reject) => {
+      request.get({ 'credentials': 'omit' })
+        .then(response => response.json())
+        .then(status => status && status.disabled)
+        .then(isDisabled => resolve(!!isDisabled))
+        .catch(() => resolve(false));
+    });
+  }
+}

--- a/tests/core/search/searchapi.js
+++ b/tests/core/search/searchapi.js
@@ -29,7 +29,8 @@ describe('vertical searching', () => {
     result.then(results => {
       expect(mockedRequest).toBeCalledWith(
         expect.anything(),
-        expect.objectContaining({ input: 'query', verticalKey: 'vertical', sessionTrackingEnabled }));
+        expect.objectContaining({ input: 'query', verticalKey: 'vertical', sessionTrackingEnabled }),
+        undefined);
 
       expect(results.test).toBe('value');
     });
@@ -42,7 +43,8 @@ describe('vertical searching', () => {
     result.then(results => {
       expect(mockedRequest).toBeCalledWith(
         expect.anything(),
-        expect.objectContaining({ filters: filter, verticalKey: 'vertical', sessionTrackingEnabled }));
+        expect.objectContaining({ filters: filter, verticalKey: 'vertical', sessionTrackingEnabled }),
+        undefined);
 
       expect(results.test).toBe('value');
     });
@@ -55,7 +57,8 @@ describe('vertical searching', () => {
     result.then(results => {
       expect(mockedRequest).toBeCalledWith(
         expect.anything(),
-        expect.objectContaining({ input: 'word', filters: filter, verticalKey: 'vertical', sessionTrackingEnabled }));
+        expect.objectContaining({ input: 'word', filters: filter, verticalKey: 'vertical', sessionTrackingEnabled }),
+        undefined);
 
       expect(results.test).toBe('value');
     });
@@ -67,7 +70,8 @@ describe('vertical searching', () => {
     result.then(results => {
       expect(mockedRequest).toBeCalledWith(
         expect.anything(),
-        expect.objectContaining({ input: 'query', limit: 25, offset: 10, verticalKey: 'vertical', sessionTrackingEnabled }));
+        expect.objectContaining({ input: 'query', limit: 25, offset: 10, verticalKey: 'vertical', sessionTrackingEnabled }),
+        undefined);
 
       expect(results.test).toBe('value');
     });
@@ -85,7 +89,8 @@ describe('vertical searching', () => {
     result.then(results => {
       expect(mockedRequest).toBeCalledWith(
         expect.anything(),
-        expect.objectContaining({ input: 'query', limit: 25, offset: 10, verticalKey: 'vertical', queryId: '12345', sessionTrackingEnabled }));
+        expect.objectContaining({ input: 'query', limit: 25, offset: 10, verticalKey: 'vertical', queryId: '12345', sessionTrackingEnabled }),
+        undefined);
     });
   });
 });

--- a/tests/core/utils/masterswitchapi.js
+++ b/tests/core/utils/masterswitchapi.js
@@ -1,0 +1,65 @@
+import MasterSwitchApi from '../../../src/core/utils/masterswitchapi';
+import GlobalStorage from '../../../src/core/storage/globalstorage';
+import HttpRequester from '../../../src/core/http/httprequester';
+
+jest.mock('../../../src/core/http/httprequester');
+jest.mock('../../../src/core/storage/globalstorage');
+
+describe('checking Answers Status page', () => {
+  GlobalStorage.mockImplementation(() => {
+    return {
+      getState: jest.fn(stateVar => true)
+    };
+  });
+  const masterSwitchApi = new MasterSwitchApi(new GlobalStorage());
+
+  it('behaves correctly when JSON is present and disabled is true', () => {
+    const mockedResponse =
+      { json: jest.fn(() => Promise.resolve({ disabled: true })) };
+    const mockedRequest = jest.fn(() => Promise.resolve(mockedResponse));
+    HttpRequester.mockImplementation(() => {
+      return {
+        get: mockedRequest
+      };
+    });
+    return masterSwitchApi.isDisabled('abc123', 'someexperience')
+      .then(isDisabled => expect(isDisabled).toBeTruthy());
+  });
+
+  it('behaves correctly when JSON is present and disabled is false', () => {
+    const mockedResponse =
+      { json: jest.fn(() => Promise.resolve({ disabled: false })) };
+    const mockedRequest = jest.fn(() => Promise.resolve(mockedResponse));
+    HttpRequester.mockImplementation(() => {
+      return {
+        get: mockedRequest
+      };
+    });
+    return masterSwitchApi.isDisabled('abc123', 'someexperience')
+      .then(isDisabled => expect(isDisabled).toBeFalsy());
+  });
+
+  it('behaves correctly when status page contains JSON of empty object', () => {
+    const mockedResponse = { json: jest.fn(() => Promise.resolve({ })) };
+    const mockedRequest = jest.fn(() => Promise.resolve(mockedResponse));
+    HttpRequester.mockImplementation(() => {
+      return {
+        get: mockedRequest
+      };
+    });
+    return masterSwitchApi.isDisabled('abc123', 'someexperience')
+      .then(isDisabled => expect(isDisabled).toBeFalsy());
+  });
+
+  it('behaves correctly when network call results in an error', () => {
+    const mockedRequest =
+      jest.fn(() => Promise.reject(new Error('Page does not exist')));
+    HttpRequester.mockImplementation(() => {
+      return {
+        get: mockedRequest
+      };
+    });
+    return masterSwitchApi.isDisabled('abc123', 'someexperience')
+      .then(isDisabled => expect(isDisabled).toBeFalsy());
+  });
+});

--- a/tests/core/utils/masterswitchapi.js
+++ b/tests/core/utils/masterswitchapi.js
@@ -11,17 +11,13 @@ describe('checking Answers Status page', () => {
       getState: jest.fn(stateVar => true)
     };
   });
-  const masterSwitchApi = new MasterSwitchApi(new GlobalStorage());
 
   it('behaves correctly when JSON is present and disabled is true', () => {
     const mockedResponse =
       { json: jest.fn(() => Promise.resolve({ disabled: true })) };
     const mockedRequest = jest.fn(() => Promise.resolve(mockedResponse));
-    HttpRequester.mockImplementation(() => {
-      return {
-        get: mockedRequest
-      };
-    });
+    const masterSwitchApi = createMasterSwitchApi(mockedRequest);
+
     return masterSwitchApi.isDisabled('abc123', 'someexperience')
       .then(isDisabled => expect(isDisabled).toBeTruthy());
   });
@@ -30,11 +26,8 @@ describe('checking Answers Status page', () => {
     const mockedResponse =
       { json: jest.fn(() => Promise.resolve({ disabled: false })) };
     const mockedRequest = jest.fn(() => Promise.resolve(mockedResponse));
-    HttpRequester.mockImplementation(() => {
-      return {
-        get: mockedRequest
-      };
-    });
+    const masterSwitchApi = createMasterSwitchApi(mockedRequest);
+
     return masterSwitchApi.isDisabled('abc123', 'someexperience')
       .then(isDisabled => expect(isDisabled).toBeFalsy());
   });
@@ -42,11 +35,8 @@ describe('checking Answers Status page', () => {
   it('behaves correctly when status page contains JSON of empty object', () => {
     const mockedResponse = { json: jest.fn(() => Promise.resolve({ })) };
     const mockedRequest = jest.fn(() => Promise.resolve(mockedResponse));
-    HttpRequester.mockImplementation(() => {
-      return {
-        get: mockedRequest
-      };
-    });
+    const masterSwitchApi = createMasterSwitchApi(mockedRequest);
+
     return masterSwitchApi.isDisabled('abc123', 'someexperience')
       .then(isDisabled => expect(isDisabled).toBeFalsy());
   });
@@ -54,12 +44,23 @@ describe('checking Answers Status page', () => {
   it('behaves correctly when network call results in an error', () => {
     const mockedRequest =
       jest.fn(() => Promise.reject(new Error('Page does not exist')));
-    HttpRequester.mockImplementation(() => {
-      return {
-        get: mockedRequest
-      };
-    });
+    const masterSwitchApi = createMasterSwitchApi(mockedRequest);
+
     return masterSwitchApi.isDisabled('abc123', 'someexperience')
       .then(isDisabled => expect(isDisabled).toBeFalsy());
   });
 });
+
+/**
+ *
+ * @param {Function} mockedRequest
+ * @returns {MasterSwitchApi}
+ */
+function createMasterSwitchApi (mockedRequest) {
+  HttpRequester.mockImplementation(() => {
+    return {
+      get: mockedRequest
+    };
+  });
+  return MasterSwitchApi.from('apiKey', 'experienceKey', new GlobalStorage());
+}

--- a/tests/ui/components/search/autocompleteapi.js
+++ b/tests/ui/components/search/autocompleteapi.js
@@ -91,7 +91,7 @@ describe('querying and responding', () => {
         searchParameters: searchParameters
       });
       expect(mockedGet).toHaveBeenCalledTimes(1);
-      expect(mockedGet).toHaveBeenCalledWith(expectedUrl, expectedData);
+      expect(mockedGet).toHaveBeenCalledWith(expectedUrl, expectedData, undefined);
     });
 
     it('returns the right AutoCompleteData', () => {
@@ -123,7 +123,7 @@ describe('querying and responding', () => {
     it('creates a proper GET request for vertical search', () => {
       autocomplete.queryVertical('test', verticalKey);
       expect(mockedGet).toHaveBeenCalledTimes(1);
-      expect(mockedGet).toHaveBeenCalledWith(expectedUrl, expectedData);
+      expect(mockedGet).toHaveBeenCalledWith(expectedUrl, expectedData, undefined);
     });
 
     it('returns the right AutoCompleteData', () => {
@@ -151,7 +151,7 @@ describe('querying and responding', () => {
     it('creates a proper GET request for vertical search', () => {
       autocomplete.queryUniversal('test');
       expect(mockedGet).toHaveBeenCalledTimes(1);
-      expect(mockedGet).toHaveBeenCalledWith(expectedUrl, expectedData);
+      expect(mockedGet).toHaveBeenCalledWith(expectedUrl, expectedData, undefined);
     });
 
     it('returns the right AutoCompleteData', () => {


### PR DESCRIPTION
This PR adds a killswitch to the SDK that can disable the front-end of any
Answers experience. Essentially, the onReady supplied to Answers.init will not
be invoked. A disabled page will contain none of the SDK's components. To check
if the front-end for an experience should be disabled, the corresponding
AnswersStatus page is consulted. The SDK errs on the side of enabling the
experience's front-end in that any AnswersStatus request failure is treated
as disabled: false.

J=SPR-1974
TEST=auto, manual

Added unit tests for the different scenarios. Manually tested an experience
that had been explicitly enabled and disabled. Confirmed the correct behavior
for these scenarios. Also tested an experience that did not yet have a status
page to ensure that the 404 was handled as disabled: false.