### PR TITLE
UniversalResults: view more link border

### DIFF
--- a/src/ui/sass/modules/_Results.scss
+++ b/src/ui/sass/modules/_Results.scss
@@ -86,9 +86,9 @@
     display: flex;
     padding: $base-spacing/2 $base-spacing;
     background-color: $results-filters-background;
-    border-right: $border-legacy;
-    border-left: $border-legacy;
-    border-bottom: none;
+    border-right: $border-default;
+    border-left: $border-default;
+    border-bottom: $border-default;
   }
 
   &-viewMore svg


### PR DESCRIPTION
The universal results update moved the view more link to the bottom
of the vertical results as a separate row. This was probably missed
in a merge somewhere, since the v0.13.2 compatibility fix this came
from (#650) was written after the universal results update.

TEST=manual
test that universal results has matching border in view more link