### PR TITLE
MapboxMapProvider: use mapConfig.pin.svg for custom marker svg

### DIFF
--- a/src/ui/components/map/providers/mapboxmapprovider.js
+++ b/src/ui/components/map/providers/mapboxmapprovider.js
@@ -169,7 +169,7 @@ export class MapBoxMarkerConfig {
           marker);
       }
 
-      const wrapper = pinConfigObj.wrapper ? pinConfigObj.wrapper : null;
+      const wrapper = MapBoxMarkerConfig.buildWrapper(pinConfigObj);
       const staticMapPin = pinConfigObj.staticMapPin ? pinConfigObj.staticMapPin : null;
 
       mapboxMapMarkerConfigs.push(
@@ -187,5 +187,17 @@ export class MapBoxMarkerConfig {
     });
 
     return mapboxMapMarkerConfigs;
+  }
+
+  static buildWrapper (pinConfigObj) {
+    if (pinConfigObj.wrapper) {
+      return pinConfigObj.wrapper;
+    }
+    if (pinConfigObj.svg) {
+      let el = document.createElement('img');
+      el.src = `data:image/svg+xml;charset=utf-8, ${encodeURIComponent(pinConfigObj.svg)}`;
+      return el;
+    }
+    return null;
   }
 }

--- a/tests/ui/components/map/providers/mapboxmapprovider.js
+++ b/tests/ui/components/map/providers/mapboxmapprovider.js
@@ -163,3 +163,43 @@ describe('converts array of markers into MapboxMarkers', () => {
     expect(actual).toEqual(expected);
   });
 });
+
+describe('creates wrapper correctly', () => {
+  it('when svg is specified', () => {
+    const pinStyling = {
+      label: '1',
+      height: 26,
+      width: 22,
+      backgroundColor: 'red',
+      labelColor: 'white',
+      strokeColor: 'white'
+    };
+    const svg =
+      `<svg xmlns="http://www.w3.org/2000/svg"
+          width="${pinStyling.width}"
+          height="${pinStyling.height}"
+          viewBox="0 -1 22 28">
+        <g fill="none" fill-rule="evenodd">
+          <path fill="${pinStyling.backgroundColor}"
+                fill-rule="nonzero"
+                stroke="${pinStyling.strokeColor}"
+                d="M0 10.767c0 5.563 7.196 12.418 9.947 14.836.6.527 1.509.53 2.112.005C14.815 23.212 22 16.423 22 10.767 22 4.82 17.075 0 11 0S0 4.82 0 10.767"/>
+          <text fill="${pinStyling.labelColor}"
+                font-family="Arial-BoldMT,Arial"
+                font-size="12"
+                font-weight="bold">
+            <tspan x="50%" y="15" text-anchor="middle">${pinStyling.label}</tspan>
+          </text>
+        </g>
+      </svg>`;
+    const wrapper = MapBoxMarkerConfig.buildWrapper({ svg: svg });
+    expect(wrapper.src.includes('data:image/svg+xml;charset=utf-8')).toBeTruthy();
+    expect(wrapper.src.includes(encodeURIComponent(svg))).toBeTruthy();
+    expect(wrapper.tagName).toEqual('IMG');
+  });
+
+  it('with empty pin config', () => {
+    const wrapper = MapBoxMarkerConfig.buildWrapper({});
+    expect(wrapper).toBeNull();
+  });
+});


### PR DESCRIPTION
This commit allows people to specify a custom svg for their
mapbox map marker. This behavior already existed for google,
but not mapbox.
For more customization see https://docs.mapbox.com/help/tutorials/custom-markers-gl-js/

TEST=manual, auto
changed hitchhiker theme to point to local answers
checked that new custom map pins in the HH theme worked

opened universal page with maps (custom raw html site, not theme)
checked that by default would still use original map marker
checked that could specify an svg in mapConfig.pin function