### PR TITLE
Add css-vars-ponyfill for css variables support on IE11

### DIFF
--- a/README.md
+++ b/README.md
@@ -1620,6 +1620,9 @@ The Answers SDK supports styling specific elements with CSS variables for runtim
 
 Most browsers have native css variable support. In legacy browsers, 
 we use the [css-vars-ponyfill](https://github.com/jhildenbiddle/css-vars-ponyfill).
+* The SDK will do automatic resolution of CSS variables on initialization. Variables should be loaded
+before initialization. Overrided variables should be loaded after sdk variables are loaded.
+* You can opt-out with the `disableCssVariablesPonyfill` flag in ANSWERS.init.
 * If you opt-out of automatic resolution of variables, you should call ANSWERS.ponyfillCssVariables()
 after css variables are loaded and before components are added.
 * If you change a css variable value after initialization and wish to see the change in variable
@@ -1628,11 +1631,8 @@ value in a legacy browser, you should call ANSWERS.ponyfillCssVariables() after 
 
 ```js
 ANSWERS.ponyfillCssVariables({
-        onBeforeSend: function() {},
         onError: function() {},
-        onWarning: function() {},
         onSuccess: function() {},
-        onComplete: function() {},
         onFinally: function() {},
 });
 ```

--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ function initAnswers() {
     onVerticalSearch: function() {},
     // Optional, analytics callback after a universal search, see onUniversalSearch Configuration for additional details
     onUniversalSearch: function() {},
+    // Optional, opt-out of automatic css variable resolution on init for legacy browsers
+    disableCssVariablesPolyfill: false,
   })
 }
 ```
@@ -1594,3 +1596,43 @@ ANSWERS.formatRichText(rtfFieldValue)
 ```
 
 For instance, this function can be used in the `dataMappings` of a Card to display an RTF attribute. When using this function, you must ensure that the relevant Handlebars template correctly unescapes the value's resultant HTML.
+
+# CSS Variable Styling
+
+The Answers SDK supports styling specific elements with CSS variables for runtime styling.
+* All sdk variables are exposed in the `:root` ruleset
+* All overridden variables must be included the `:root` ruleset
+* All overrides should be defined after Answers CSS is imported and before ANSWERS.init is called
+* To see available variables, see the scss modules in the SDK
+* For example, to override:
+
+```html
+<style>
+  :root {
+    --yxt-font-font-family: sans-serif;
+    --yxt-color-brand-primary: green;
+    --yxt-color-text-primary: #212121;
+    --yxt-searchbar-button-background-color-hover: red;
+    --yxt-nav-border-color: #e9e9e9;
+  }
+</style>
+```
+
+Most browsers have native css variable support. In legacy browsers, 
+we use the [css-vars-ponyfill](https://github.com/jhildenbiddle/css-vars-ponyfill).
+* If you opt-out of automatic resolution of variables, you should call ANSWERS.polyfillCssVariables()
+after css variables are loaded and before components are added.
+* If you change a css variable value after initialization and wish to see the change in variable
+value in a legacy browser, you should call ANSWERS.polyfillCssVariables() after the value is changed.
+* We support all callback functions, described [here](https://jhildenbiddle.github.io/css-vars-ponyfill/#/?id=onbeforesend)
+
+```js
+ANSWERS.polyfillCssVariables({
+        onBeforeSend: function() {},
+        onError: function() {},
+        onWarning: function() {},
+        onSuccess: function() {},
+        onComplete: function() {},
+        onFinally: function() {},
+});
+```

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ function initAnswers() {
     // Optional, analytics callback after a universal search, see onUniversalSearch Configuration for additional details
     onUniversalSearch: function() {},
     // Optional, opt-out of automatic css variable resolution on init for legacy browsers
-    disableCssVariablesPolyfill: false,
+    disableCssVariablesPonyfill: false,
   })
 }
 ```
@@ -1620,14 +1620,14 @@ The Answers SDK supports styling specific elements with CSS variables for runtim
 
 Most browsers have native css variable support. In legacy browsers, 
 we use the [css-vars-ponyfill](https://github.com/jhildenbiddle/css-vars-ponyfill).
-* If you opt-out of automatic resolution of variables, you should call ANSWERS.polyfillCssVariables()
+* If you opt-out of automatic resolution of variables, you should call ANSWERS.ponyfillCssVariables()
 after css variables are loaded and before components are added.
 * If you change a css variable value after initialization and wish to see the change in variable
-value in a legacy browser, you should call ANSWERS.polyfillCssVariables() after the value is changed.
+value in a legacy browser, you should call ANSWERS.ponyfillCssVariables() after the value is changed.
 * We support all callback functions, described [here](https://jhildenbiddle.github.io/css-vars-ponyfill/#/?id=onbeforesend)
 
 ```js
-ANSWERS.polyfillCssVariables({
+ANSWERS.ponyfillCssVariables({
         onBeforeSend: function() {},
         onError: function() {},
         onWarning: function() {},

--- a/package-lock.json
+++ b/package-lock.json
@@ -5290,6 +5290,11 @@
       "integrity": "sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY=",
       "dev": true
     },
+    "css-vars-ponyfill": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/css-vars-ponyfill/-/css-vars-ponyfill-2.3.1.tgz",
+      "integrity": "sha512-LHLFhKKQChkQz6nItHU1ZA/ABYJbw489eF0APx2a2FvjT32fAnbqriTLzKsl4KXowuVXcwoRWh8iQNO7wNzuGA=="
+    },
     "css-what": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@yext/rtf-converter": "^1.0.0",
     "core-js": "^3.6.5",
+    "css-vars-ponyfill": "^2.3.1",
     "handlebars": "^4.7.2",
     "kind-of": "^6.0.3",
     "regenerator-runtime": "^0.13.3",

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -173,6 +173,10 @@ class Answers {
     masterSwitchApi.isDisabled(parsedConfig.apiKey, parsedConfig.experienceKey)
       .then(isDisabled => !isDisabled && this._initInternal(parsedConfig, globalStorage, persistentStorage))
       .catch(() => this._initInternal(parsedConfig, globalStorage, persistentStorage));
+
+    if (!parsedConfig.disableCssVariablesPolyfill) {
+      this.polyfillCssVariables();
+    }
   }
 
   /**
@@ -392,15 +396,20 @@ class Answers {
 
   /*
    * Updates the css styles with new current variables. This is useful when the css
-   * variables are updated dynamically (e.g. through js).
+   * variables are updated dynamically (e.g. through js) or if the css variables are
+   * added after the ANSWERS.init
    * @param {Object} config Additional config to pass to the polyfill
    */
-  polyfillCssVariables (config) {
-    cssVars(Object.assign(
-      {},
-      { onlyLegacy: true },
-      config
-    ));
+  polyfillCssVariables (config = {}) {
+    cssVars({
+      onlyLegacy: true,
+      onBeforeSend: config.onBeforeSend || function() {},
+      onError: config.onError || function() {},
+      onWarning: config.onWarning || function() {},
+      onSuccess: config.onSuccess || function() {},
+      onComplete: config.onComplete || function() {},
+      onFinally: config.onFinally || function() {}
+    });
   }
 }
 

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -2,6 +2,7 @@
 
 import Core from './core/core';
 import RtfConverter from '@yext/rtf-converter';
+import cssVars from 'css-vars-ponyfill';
 
 import {
   DefaultTemplatesLoader,
@@ -387,6 +388,19 @@ class Answers {
     }
     this.core.globalStorage.set('queryTrigger', 'initialize');
     this.core.setQuery(searchConfig.defaultInitialSearch);
+  }
+
+  /*
+   * Updates the css styles with new current variables. This is useful when the css
+   * variables are updated dynamically (e.g. through js).
+   * @param {Object} config Additional config to pass to the polyfill
+   */
+  polyfillCssVariables (config) {
+    cssVars(Object.assign(
+      {},
+      { onlyLegacy: true },
+      config
+    ));
   }
 }
 

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -237,24 +237,12 @@ class Answers {
 
     this._onReady = parsedConfig.onReady || function () {};
 
-    const callPonyfillCssVariables = (callback) => {
-      if (!parsedConfig.disableCssVariablesPonyfill) {
-        this.ponyfillCssVariables({
-          onFinally: () => {
-            callback();
-          }
-        });
-      } else {
-        callback();
-      }
-    };
-
     if (parsedConfig.useTemplates === false || parsedConfig.templateBundle) {
       if (parsedConfig.templateBundle) {
         this.renderer.init(parsedConfig.templateBundle);
       }
 
-      callPonyfillCssVariables(this._onReady.bind(this));
+      this._handlePonyfillCssVariables(this._onReady.bind(this));
       return this;
     }
 
@@ -262,11 +250,23 @@ class Answers {
     // Future enhancement is to ship the components with templates in a separate bundle.
     this.templates = new DefaultTemplatesLoader(templates => {
       this.renderer.init(templates);
-      callPonyfillCssVariables(this._onReady.bind(this));
+      this._handlePonyfillCssVariables(this._onReady.bind(this));
     });
 
     return this;
   }
+
+  _handlePonyfillCssVariables (callback) {
+    if (!parsedConfig.disableCssVariablesPonyfill) {
+      this.ponyfillCssVariables({
+        onFinally: () => {
+          callback();
+        }
+      });
+    } else {
+      callback();
+    }
+  };
 
   domReady (cb) {
     DOM.onReady(cb);
@@ -411,11 +411,8 @@ class Answers {
   ponyfillCssVariables (config = {}) {
     cssVars({
       onlyLegacy: true,
-      onBeforeSend: config.onBeforeSend || function() {},
       onError: config.onError || function() {},
-      onWarning: config.onWarning || function() {},
       onSuccess: config.onSuccess || function() {},
-      onComplete: config.onComplete || function() {},
       onFinally: config.onFinally || function() {}
     });
   }

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -242,7 +242,7 @@ class Answers {
         this.renderer.init(parsedConfig.templateBundle);
       }
 
-      this._handlePonyfillCssVariables(parsedConfig, this._onReady.bind(this));
+      this._handlePonyfillCssVariables(parsedConfig.disableCssVariablesPonyfill, this._onReady.bind(this));
       return this;
     }
 
@@ -250,14 +250,20 @@ class Answers {
     // Future enhancement is to ship the components with templates in a separate bundle.
     this.templates = new DefaultTemplatesLoader(templates => {
       this.renderer.init(templates);
-      this._handlePonyfillCssVariables(parsedConfig, this._onReady.bind(this));
+      this._handlePonyfillCssVariables(parsedConfig.disableCssVariablesPonyfill, this._onReady.bind(this));
     });
 
     return this;
   }
 
-  _handlePonyfillCssVariables (parsedConfig, callback) {
-    if (!parsedConfig.disableCssVariablesPonyfill) {
+  /**
+   * Calls the CSS vars ponyfill, if opted-in, and invokes the callback
+   * regardless of if there was an error/success. If opted-out, only invokes the callback.
+   * @param {boolean} option to opt out of the css variables ponyfill
+   * @param callback {Function} always called after function
+   */
+  _handlePonyfillCssVariables (ponyfillDisabled, callback) {
+    if (!ponyfillDisabled) {
       this.ponyfillCssVariables({
         onFinally: () => {
           callback();

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -266,7 +266,7 @@ class Answers {
     } else {
       callback();
     }
-  };
+  }
 
   domReady (cb) {
     DOM.onReady(cb);
@@ -411,9 +411,9 @@ class Answers {
   ponyfillCssVariables (config = {}) {
     cssVars({
       onlyLegacy: true,
-      onError: config.onError || function() {},
-      onSuccess: config.onSuccess || function() {},
-      onFinally: config.onFinally || function() {}
+      onError: config.onError || function () {},
+      onSuccess: config.onSuccess || function () {},
+      onFinally: config.onFinally || function () {}
     });
   }
 }

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -242,7 +242,7 @@ class Answers {
         this.renderer.init(parsedConfig.templateBundle);
       }
 
-      this._handlePonyfillCssVariables(this._onReady.bind(this));
+      this._handlePonyfillCssVariables(parsedConfig, this._onReady.bind(this));
       return this;
     }
 
@@ -250,13 +250,13 @@ class Answers {
     // Future enhancement is to ship the components with templates in a separate bundle.
     this.templates = new DefaultTemplatesLoader(templates => {
       this.renderer.init(templates);
-      this._handlePonyfillCssVariables(this._onReady.bind(this));
+      this._handlePonyfillCssVariables(parsedConfig, this._onReady.bind(this));
     });
 
     return this;
   }
 
-  _handlePonyfillCssVariables (callback) {
+  _handlePonyfillCssVariables (parsedConfig, callback) {
     if (!parsedConfig.disableCssVariablesPonyfill) {
       this.ponyfillCssVariables({
         onFinally: () => {


### PR DESCRIPTION
Invoke the ponyfill only for legacy browsers (ie11 being the relevant
browser for us). The ponyfill will be invoked on an ANSWERS.init and
should happen /after/ the answers css variables have been loaded.

Expose an ANSWERS.polyfillCssVariables for updating dynamic css
variables

TEST=manual

Tested on a JAMBO site and an AEB site on our supported browsers
and on Windows, iOS, and Android through browserstack.