### PR TITLE
Pagination: add config.noResults and 'visible' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -798,7 +798,13 @@ ANSWERS.addComponent('Pagination', {
   // Optional, display a double arrow allowing users to jump to the last page of results
   showLast: true,
   // Optional, label for a page of results
-  pageLabel: 'Page'
+  pageLabel: 'Page',
+  // Optional, configuration for the map's behavior when a query returns no results
+  noResults: {
+    // Optional, whether pagination should be visible when displaying no results.
+    // Defaults to false.
+    visible: false
+  }
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -799,7 +799,7 @@ ANSWERS.addComponent('Pagination', {
   showLast: true,
   // Optional, label for a page of results
   pageLabel: 'Page',
-  // Optional, configuration for the map's behavior when a query returns no results
+  // Optional, configuration for the pagination behavior when a query returns no results
   noResults: {
     // Optional, whether pagination should be visible when displaying no results.
     // Defaults to false.

--- a/src/ui/components/results/paginationcomponent.js
+++ b/src/ui/components/results/paginationcomponent.js
@@ -3,7 +3,7 @@
 import Component from '../component';
 import StorageKeys from '../../../core/storage/storagekeys';
 import DOM from '../../dom/dom';
-import { AnswersComponentError, AnswersConfigError } from '../../../core/errors/errors';
+import { AnswersComponentError } from '../../../core/errors/errors';
 import SearchStates from '../../../core/storage/searchstates';
 import ResultsContext from '../../../core/storage/resultscontext';
 
@@ -71,7 +71,9 @@ export default class PaginationComponent extends Component {
     /**
      * Configuration for the behavior when there are no vertical results.
      */
-    this._noResults = config.noResults || this.core.globalStorage.getState(StorageKeys.NO_RESULTS_CONFIG) || {};
+    this._noResults = config.noResults ||
+      this.core.globalStorage.getState(StorageKeys.NO_RESULTS_CONFIG) ||
+      {};
   }
 
   static get type () {

--- a/src/ui/components/results/paginationcomponent.js
+++ b/src/ui/components/results/paginationcomponent.js
@@ -71,13 +71,7 @@ export default class PaginationComponent extends Component {
     /**
      * Configuration for the behavior when there are no vertical results.
      */
-    this._noResults = config.noResults || this.core.globalStorage.getState(StorageKeys.NO_RESULTS_CONFIG);
-    if (typeof this._noResults !== 'object') {
-      throw new AnswersConfigError(
-        `No results config must be an object, received ${this._noResults}`,
-        'Pagination'
-      );
-    }
+    this._noResults = config.noResults || this.core.globalStorage.getState(StorageKeys.NO_RESULTS_CONFIG) || {};
   }
 
   static get type () {


### PR DESCRIPTION
This commit adds noResults config to the pagination component,
and allows pagination to accept a 'visible' option in this config.
Uses global noResults if none specified, and does not merge the two configs.

TEST=manual
for regular results, pagination still displays no matter what
for no results, check that will prioritize component level no results
over global no results without merging, and will use 'visible' property
if present otherwise will default to displayAllResults.