### PR TITLE
Facets: hide facets for no results

### DIFF
--- a/README.md
+++ b/README.md
@@ -879,7 +879,7 @@ ANSWERS.addComponent('FilterBox', {
 
 This component is only for Vertical pages.
 
-The Facets component displays filters relevant to the current search, configured on the server, automatically.
+The Facets component displays filters relevant to the current search, configured on the server, automatically. The Facets component will hide itself when itself when displaying no results.
 
 ```html
 <div class="facets-container"></div>

--- a/README.md
+++ b/README.md
@@ -879,7 +879,7 @@ ANSWERS.addComponent('FilterBox', {
 
 This component is only for Vertical pages.
 
-The Facets component displays filters relevant to the current search, configured on the server, automatically. The Facets component will hide itself when itself when displaying no results.
+The Facets component displays filters relevant to the current search, configured on the server, automatically. The Facets component will be hidden when a query returns no results.
 
 ```html
 <div class="facets-container"></div>

--- a/src/core/models/dynamicfilters.js
+++ b/src/core/models/dynamicfilters.js
@@ -10,6 +10,12 @@ export default class DynamicFilters {
      * @type {{label: string, fieldId: string, options: object[]}}
      */
     this.filters = data.filters || [];
+
+    /**
+     * The {@link ResultsContext} of the facets.
+     * @type {ResultsContext}
+     */
+    this.resultsContext = data.resultsContext;
     Object.freeze(this);
   }
 
@@ -18,7 +24,8 @@ export default class DynamicFilters {
    * @param {Object} response dynamic filter response from the api
    * @returns {DynamicFilters}
    */
-  static from (facets) {
+  static from (response) {
+    const { facets, resultsContext } = response;
     const dynamicFilters = facets.map(f => ({
       label: f['displayName'],
       fieldId: f['fieldId'],
@@ -30,6 +37,9 @@ export default class DynamicFilters {
       }))
     }));
 
-    return new DynamicFilters({ filters: dynamicFilters });
+    return new DynamicFilters({
+      filters: dynamicFilters,
+      resultsContext: resultsContext
+    });
   }
 }

--- a/src/core/search/searchdatatransformer.js
+++ b/src/core/search/searchdatatransformer.js
@@ -37,7 +37,7 @@ export default class SearchDataTransformer {
       [StorageKeys.QUERY_ID]: response.queryId,
       [StorageKeys.NAVIGATION]: new Navigation(), // Vertical doesn't respond with ordering, so use empty nav.
       [StorageKeys.VERTICAL_RESULTS]: VerticalResults.from(response, formatters, verticalKey),
-      [StorageKeys.DYNAMIC_FILTERS]: DynamicFilters.from(response.facets),
+      [StorageKeys.DYNAMIC_FILTERS]: DynamicFilters.from(response),
       [StorageKeys.INTENTS]: SearchIntents.from(response.searchIntents),
       [StorageKeys.SPELL_CHECK]: SpellCheck.from(response.spellCheck),
       [StorageKeys.ALTERNATIVE_VERTICALS]: AlternativeVerticals.from(response, formatters),

--- a/src/ui/components/filters/facetscomponent.js
+++ b/src/ui/components/filters/facetscomponent.js
@@ -2,6 +2,7 @@
 
 import Component from '../component';
 import StorageKeys from '../../../core/storage/storagekeys';
+import ResultsContext from '../../../core/storage/resultscontext';
 
 class FacetsConfig {
   constructor (config) {
@@ -163,6 +164,13 @@ export default class FacetsComponent extends Component {
     return 'filters/facets';
   }
 
+  setState (data) {
+    return super.setState({
+      ...data,
+      isNoResults: data.resultsContext === ResultsContext.NO_RESULTS
+    });
+  }
+
   remove () {
     if (this._filterbox) {
       this._filterbox.remove();
@@ -177,9 +185,9 @@ export default class FacetsComponent extends Component {
       this._filterbox.remove();
     }
 
-    let { filters } = this._state.get();
+    let { filters, resultsContext } = this._state.get();
 
-    if (!filters) {
+    if (!filters || resultsContext === ResultsContext.NO_RESULTS) {
       return;
     }
 

--- a/src/ui/templates/filters/facets.hbs
+++ b/src/ui/templates/filters/facets.hbs
@@ -1,3 +1,5 @@
+{{#unless isNoResults}}
 <div class="js-yxt-Facets yxt-Facets-container">
 
 </div>
+{{/unless}}

--- a/tests/core/search/searchdatatransformer.js
+++ b/tests/core/search/searchdatatransformer.js
@@ -27,7 +27,7 @@ describe('tranform vertical search response', () => {
         [StorageKeys.QUERY_ID]: convertedResponse.queryId,
         [StorageKeys.NAVIGATION]: new Navigation(), // Vertical doesn't respond with ordering, so use empty nav.
         [StorageKeys.VERTICAL_RESULTS]: VerticalResults.from(convertedResponse, formatters),
-        [StorageKeys.DYNAMIC_FILTERS]: DynamicFilters.from(convertedResponse.facets),
+        [StorageKeys.DYNAMIC_FILTERS]: DynamicFilters.from(convertedResponse),
         [StorageKeys.INTENTS]: SearchIntents.from(convertedResponse.searchIntents),
         [StorageKeys.SPELL_CHECK]: SpellCheck.from(convertedResponse.spellCheck),
         [StorageKeys.ALTERNATIVE_VERTICALS]: AlternativeVerticals.from(convertedResponse, formatters),


### PR DESCRIPTION
When displaying no results, for now facets should not render.
TEST=manual
normal search: facets still render
no results search: no facets display on the page anymore, no container in the dom either