### PR TITLE
SortOptions: hide when displaying no results

### DIFF
--- a/README.md
+++ b/README.md
@@ -1273,6 +1273,7 @@ ANSWERS.addComponent('LocationBias', {
 ## Sort Options Component
 
 The sort options component displays a list of radio buttons that allows users to sort the results of a vertical search.
+The Facets component will hide itself when itself when displaying no results.
 Currently, there may be only one sort options component per page.
 
 ```html

--- a/README.md
+++ b/README.md
@@ -1272,8 +1272,7 @@ ANSWERS.addComponent('LocationBias', {
 
 ## Sort Options Component
 
-The sort options component displays a list of radio buttons that allows users to sort the results of a vertical search.
-The sort options component will hide itself when itself when displaying no results.
+The sort options component displays a list of radio buttons that allows users to sort the results of a vertical search. When a query returns no results, the component will not be rendered on the page.
 Currently, there may be only one sort options component per page.
 
 ```html

--- a/README.md
+++ b/README.md
@@ -1273,7 +1273,7 @@ ANSWERS.addComponent('LocationBias', {
 ## Sort Options Component
 
 The sort options component displays a list of radio buttons that allows users to sort the results of a vertical search.
-The Facets component will hide itself when itself when displaying no results.
+The sort options component will hide itself when itself when displaying no results.
 Currently, there may be only one sort options component per page.
 
 ```html

--- a/src/ui/components/filters/sortoptionscomponent.js
+++ b/src/ui/components/filters/sortoptionscomponent.js
@@ -5,6 +5,7 @@ import { AnswersBasicError } from '../../../core/errors/errors';
 import DOM from '../../dom/dom';
 import StorageKeys from '../../../core/storage/storagekeys';
 import Filter from '../../../core/models/filter';
+import ResultsContext from '../../../core/storage/resultscontext';
 
 /**
  * Renders configuration options for sorting Vertical Results.
@@ -21,9 +22,16 @@ export default class SortOptionsComponent extends Component {
     this.options[this.selectedOptionIndex].isSelected = true;
     this.hideExcessOptions = this._config.showMore && this.selectedOptionIndex < this._config.showMoreLimit;
     this.showReset = this._config.showReset && this.selectedOptionIndex !== 0;
+
+    /**
+     * This component listens to updates to vertical results, and sets its state to it when
+     * an update occurs.
+     * @type {string}
+     */
+    this.moduleId = StorageKeys.VERTICAL_RESULTS;
   }
 
-  setState (data) {
+  setState (data = {}) {
     let options = this.options;
     if (this.hideExcessOptions) {
       options = this.options.slice(0, this._config.showMoreLimit);
@@ -32,7 +40,8 @@ export default class SortOptionsComponent extends Component {
       options,
       hideExcessOptions: this.hideExcessOptions,
       name: this.name,
-      showReset: this.showReset
+      showReset: this.showReset,
+      isNoResults: data.resultsContext === ResultsContext.NO_RESULTS
     }));
   }
 

--- a/src/ui/templates/controls/sortoptions.hbs
+++ b/src/ui/templates/controls/sortoptions.hbs
@@ -1,3 +1,4 @@
+{{#unless isNoResults}}
 <fieldset class='yxt-SortOptions-fieldSet'>
   <legend class='yxt-SortOptions-legend'>
     <div class='yxt-SortOptions-legendLabel'>
@@ -53,5 +54,6 @@
     </button>
   {{/unless}}
 </fieldset>
+{{/unless}}
 
 


### PR DESCRIPTION
This commit hides the sort options component when the
resultsContext is NO_RESULTS

TEST=manual
saw the sort options disappear for no results and reappear for normal results