### PR TITLE
SortOptions: add null checking to onMount

### DIFF
--- a/src/ui/components/filters/sortoptionscomponent.js
+++ b/src/ui/components/filters/sortoptionscomponent.js
@@ -48,29 +48,42 @@ export default class SortOptionsComponent extends Component {
   onMount () {
     // Handle radio button selections
     const containerEl = DOM.query(this._container, '.yxt-SortOptions-fieldSet');
-    containerEl && DOM.on(containerEl, 'change', evt =>
-      this.handleOptionSelection(parseInt(evt.target.value))
+    containerEl && DOM.on(
+      containerEl,
+      'change',
+      evt => this.handleOptionSelection(parseInt(evt.target.value))
     );
 
     // Register more/less button
     if (this._config.showMore) {
       const toggleEl = DOM.query(this._container, '.yxt-SortOptions-showToggle');
-      toggleEl && DOM.on(toggleEl, 'click', () => {
-        this.hideExcessOptions = !this.hideExcessOptions;
-        this.setState();
-      });
+      toggleEl && DOM.on(
+        toggleEl,
+        'click', () => {
+          this.hideExcessOptions = !this.hideExcessOptions;
+          this.setState();
+        }
+      );
     }
 
     // Register show reset button
     if (this.showReset) {
       const resetEl = DOM.query(this._container, '.yxt-SortOptions-reset');
-      resetEl && DOM.on(resetEl, 'click', () => this.handleOptionSelection(0));
+      resetEl && DOM.on(
+        resetEl,
+        'click',
+        () => this.handleOptionSelection(0)
+      );
     }
 
     // Register apply button
     if (!this._config.searchOnChange) {
       const applyEl = DOM.query(this._container, '.yxt-SortOptions-apply');
-      applyEl && DOM.on(applyEl, 'click', () => this._sortResults());
+      applyEl && DOM.on(
+        applyEl,
+        'click',
+        () => this._sortResults()
+      );
     }
   }
 

--- a/src/ui/components/filters/sortoptionscomponent.js
+++ b/src/ui/components/filters/sortoptionscomponent.js
@@ -46,44 +46,31 @@ export default class SortOptionsComponent extends Component {
   }
 
   onMount () {
-    if (this.getState('resultsContext') === ResultsContext.NO_RESULTS) {
-      return;
-    }
     // Handle radio button selections
-    DOM.on(
-      DOM.query(this._container, '.yxt-SortOptions-fieldSet'),
-      'change',
-      evt => this.handleOptionSelection(parseInt(evt.target.value))
+    const containerEl = DOM.query(this._container, '.yxt-SortOptions-fieldSet');
+    containerEl && DOM.on(containerEl, 'change', evt =>
+      this.handleOptionSelection(parseInt(evt.target.value))
     );
 
     // Register more/less button
     if (this._config.showMore) {
-      DOM.on(
-        DOM.query(this._container, '.yxt-SortOptions-showToggle'),
-        'click',
-        () => {
-          this.hideExcessOptions = !this.hideExcessOptions;
-          this.setState();
-        }
-      );
+      const toggleEl = DOM.query(this._container, '.yxt-SortOptions-showToggle');
+      toggleEl && DOM.on(toggleEl, 'click', () => {
+        this.hideExcessOptions = !this.hideExcessOptions;
+        this.setState();
+      });
     }
 
     // Register show reset button
     if (this.showReset) {
-      DOM.on(
-        DOM.query(this._container, '.yxt-SortOptions-reset'),
-        'click',
-        () => this.handleOptionSelection(0)
-      );
+      const resetEl = DOM.query(this._container, '.yxt-SortOptions-reset');
+      resetEl && DOM.on(resetEl, 'click', () => this.handleOptionSelection(0));
     }
 
     // Register apply button
     if (!this._config.searchOnChange) {
-      DOM.on(
-        DOM.query(this._container, '.yxt-SortOptions-apply'),
-        'click',
-        () => this._sortResults()
-      );
+      const applyEl = DOM.query(this._container, '.yxt-SortOptions-apply');
+      applyEl && DOM.on(applyEl, 'click', () => this._sortResults());
     }
   }
 

--- a/src/ui/components/filters/sortoptionscomponent.js
+++ b/src/ui/components/filters/sortoptionscomponent.js
@@ -46,6 +46,9 @@ export default class SortOptionsComponent extends Component {
   }
 
   onMount () {
+    if (this.getState('resultsContext') === ResultsContext.NO_RESULTS) {
+      return;
+    }
     // Handle radio button selections
     DOM.on(
       DOM.query(this._container, '.yxt-SortOptions-fieldSet'),

--- a/tests/ui/components/filters/sortoptionscomponent.js
+++ b/tests/ui/components/filters/sortoptionscomponent.js
@@ -4,6 +4,7 @@ import { mount } from 'enzyme';
 import { AnswersBasicError } from '../../../../src/core/errors/errors';
 import mockManager from '../../../setup/managermocker';
 import StorageKeys from '../../../../src/core/storage/storagekeys';
+import ResultsContext from '../../../../src/core/storage/resultscontext';
 
 const mockedCore = () => {
   return {
@@ -186,5 +187,19 @@ describe('sort options component', () => {
     const wrapper = mount(component);
     expect(component._config.searchOnChange).toBeFalsy();
     expect(wrapper.find('.yxt-SortOptions-apply')).toHaveLength(1);
+  });
+
+  it('does not render for no results', () => {
+    const opts = {
+      ...defaultConfig,
+      options: threeOptions,
+      searchOnChange: false
+    };
+    const component = COMPONENT_MANAGER.create('SortOptions', opts);
+    component.setState({
+      resultsContext: ResultsContext.NO_RESULTS
+    });
+    const wrapper = mount(component);
+    expect(wrapper.text()).toEqual('');
   });
 });


### PR DESCRIPTION
The SortOptions component was throwing console errors because it was trying
to register listeners for undefined elements, since when no results are
returned from a search new behavior was added to hide the sort options component.

TEST=manual
no more console errors when loading a page with a search that returns no results