### PR TITLE
Revert "SCSS: Move font-family top level instead of having it in text…

### DIFF
--- a/src/ui/components/component.js
+++ b/src/ui/components/component.js
@@ -236,9 +236,6 @@ export default class Component {
     });
 
     DOM.addClass(this._container, this._className);
-
-    // We use this class to scope some of our styling.
-    DOM.addClass(this._container, 'yxt-ComponentContainer');
     return this;
   }
 

--- a/src/ui/sass/_base.scss
+++ b/src/ui/sass/_base.scss
@@ -13,8 +13,3 @@ body
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
-
-.yxt-ComponentContainer
-{
-  font-family: $font-family;
-}

--- a/src/ui/sass/_mixins.scss
+++ b/src/ui/sass/_mixins.scss
@@ -5,6 +5,7 @@
   $style: normal,
   $color: $color-text-primary
 ) {
+  font-family: $font-family;
   font-size: $size;
   line-height: $line-height;
   font-weight: $weight;

--- a/src/ui/sass/modules/_AlternativeVerticals.scss
+++ b/src/ui/sass/modules/_AlternativeVerticals.scss
@@ -1,6 +1,7 @@
 /** @define AlternativeVerticals */
 .yxt-AlternativeVerticals
 {
+  font-family: $font-family;
   font-weight: $font-weight-light;
   background-color: $color-brand-white;
   border: $border-default;


### PR DESCRIPTION
… mixin (#771)"

This reverts commit 1eeef9a57d0d914c2706599368bf0aa18b95d9c9. Some elements in IE11 do not support font-family cascading. Going to investigate to ensure we target all offending elements, then re-merge into a later version.