### PR TITLE
SortOptions: only listen to completed vertical results updates

### DIFF
--- a/src/ui/components/filters/sortoptionscomponent.js
+++ b/src/ui/components/filters/sortoptionscomponent.js
@@ -6,6 +6,7 @@ import DOM from '../../dom/dom';
 import StorageKeys from '../../../core/storage/storagekeys';
 import Filter from '../../../core/models/filter';
 import ResultsContext from '../../../core/storage/resultscontext';
+import SearchStates from '../../../core/storage/searchstates';
 
 /**
  * Renders configuration options for sorting Vertical Results.
@@ -28,7 +29,11 @@ export default class SortOptionsComponent extends Component {
      * an update occurs.
      * @type {string}
      */
-    this.moduleId = StorageKeys.VERTICAL_RESULTS;
+    this.core.globalStorage.on('update', StorageKeys.VERTICAL_RESULTS, verticalResults => {
+      if (verticalResults.searchState === SearchStates.SEARCH_COMPLETE) {
+        this.setState(verticalResults);
+      }
+    });
   }
 
   setState (data = {}) {

--- a/tests/ui/components/filters/sortoptionscomponent.js
+++ b/tests/ui/components/filters/sortoptionscomponent.js
@@ -14,6 +14,7 @@ const mockedCore = () => {
     clearSortBys: () => {},
     verticalSearch: () => {},
     globalStorage: {
+      on: () => {},
       getState: storageKey => {
         expect(['SortOptions', StorageKeys.QUERY]).toContain(storageKey);
         return null;


### PR DESCRIPTION
Only update sort options component when the search is complete, instead
of when also when the search is loading. This avoids weird flickering
behavior when the user makes a search. (This now matches the behavior of the
pagination component, which has similar behavior)

TEST=manual
no more flickering, sort options still appear and disappear with no results
as before