### PR TITLE
MapComponent: add config.noResults.visible flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1376,8 +1376,11 @@ ANSWERS.addComponent('Map', {
   onLoaded: function () {},
   // Optional, configuration for the map's behavior when a query returns no results
   noResults: {
-    // Optional, whether to display all results in the vertical when no results are found. Defaults to false, in which case only the no results card will be shown.
-    displayAllResults: true
+    // Optional, whether the map should be visible when displaying no results.
+    // Defaults to false.
+    visible: false,
+    // DEPRECATED, please use 'visible' instead.
+    displayAllResults: false
   },
   // Optional, the custom configuration override to use for the map markers, function
   pin: function () {

--- a/README.md
+++ b/README.md
@@ -1376,11 +1376,10 @@ ANSWERS.addComponent('Map', {
   onLoaded: function () {},
   // Optional, configuration for the map's behavior when a query returns no results
   noResults: {
-    // Optional, whether the map should be visible when displaying no results.
-    // Defaults to false.
-    visible: false,
-    // DEPRECATED, please use 'visible' instead.
-    displayAllResults: false
+    // Optional, whether to display all results in the vertical when no results are found. Defaults to false, in which case only the no results card will be shown.
+    displayAllResults: false,
+    // Optional, whether the map should be visible when no results are returned. This takes priority over showEmptyMap. Defaults to false
+    visible: false
   },
   // Optional, the custom configuration override to use for the map markers, function
   pin: function () {

--- a/README.md
+++ b/README.md
@@ -1376,9 +1376,9 @@ ANSWERS.addComponent('Map', {
   onLoaded: function () {},
   // Optional, configuration for the map's behavior when a query returns no results
   noResults: {
-    // Optional, whether to display all results in the vertical when no results are found. Defaults to false, in which case only the no results card will be shown.
+    // Optional, whether to display map pins for all possible results when no results are found. Defaults to false.
     displayAllResults: false,
-    // Optional, whether the map should be visible when no results are returned. This takes priority over showEmptyMap. Defaults to false
+    // Optional, whether to display the map when no results are found, taking priority over showEmptyMap. If displayAllResults is false, this will be an empty map. Defaults to false.
     visible: false
   },
   // Optional, the custom configuration override to use for the map markers, function

--- a/src/ui/components/map/mapcomponent.js
+++ b/src/ui/components/map/mapcomponent.js
@@ -79,8 +79,11 @@ export default class MapComponent extends Component {
     if (Object.keys(data).length === 0) {
       return this;
     }
-
-    if (data.resultsContext === ResultsContext.NO_RESULTS && !this._noResults.displayAllResults) {
+    const isNoResults = data.resultsContext === ResultsContext.NO_RESULTS;
+    const isVisibleForNoResults = 'visible' in this._noResults
+      ? this._noResults.visible
+      : this._noResults.displayAllResults;
+    if (isNoResults && !isVisibleForNoResults) {
       data = {};
     }
 

--- a/src/ui/components/map/mapcomponent.js
+++ b/src/ui/components/map/mapcomponent.js
@@ -26,7 +26,7 @@ export default class MapComponent extends Component {
      * Configuration for the behavior when there are no vertical results.
      */
     this._noResults = Object.assign(
-      { displayAllResults: false, template: '' },
+      { displayAllResults: false, visible: false, template: '' },
       opts.noResults || this.core.globalStorage.getState(StorageKeys.NO_RESULTS_CONFIG)
     );
 

--- a/src/ui/components/map/mapcomponent.js
+++ b/src/ui/components/map/mapcomponent.js
@@ -71,7 +71,7 @@ export default class MapComponent extends Component {
 
   onMount () {
     this._map.onLoaded(() => {
-      this._map.init(this._container, this.getState('map'));
+      this._map.init(this._container, this.getState('map'), this.getState('resultsContext'));
     });
   }
 
@@ -79,12 +79,11 @@ export default class MapComponent extends Component {
     if (Object.keys(data).length === 0) {
       return this;
     }
-    const isNoResults = data.resultsContext === ResultsContext.NO_RESULTS;
-    const isVisibleForNoResults = 'visible' in this._noResults
-      ? this._noResults.visible
-      : this._noResults.displayAllResults;
-    if (isNoResults && !isVisibleForNoResults) {
-      data = {};
+
+    if (data.resultsContext === ResultsContext.NO_RESULTS && !this._noResults.displayAllResults) {
+      data = {
+        resultsContext: data.resultsContext
+      };
     }
 
     return super.setState(data, val);

--- a/src/ui/components/map/providers/googlemapprovider.js
+++ b/src/ui/components/map/providers/googlemapprovider.js
@@ -2,7 +2,6 @@
 
 import MapProvider from './mapprovider';
 import DOM from '../../../dom/dom';
-import ResultsContext from '../../../../core/storage/resultscontext';
 
 /* global google */
 

--- a/src/ui/components/map/providers/googlemapprovider.js
+++ b/src/ui/components/map/providers/googlemapprovider.js
@@ -2,6 +2,7 @@
 
 import MapProvider from './mapprovider';
 import DOM from '../../../dom/dom';
+import ResultsContext from '../../../../core/storage/resultscontext';
 
 /* global google */
 
@@ -74,8 +75,8 @@ export default class GoogleMapProvider extends MapProvider {
     return this._clientId;
   }
 
-  init (el, mapData) {
-    if ((!mapData || mapData.mapMarkers.length <= 0) && !this._showEmptyMap) {
+  init (el, mapData, resultsContext) {
+    if (this.shouldHideMap(mapData, resultsContext)) {
       this._map = null;
       return this;
     }

--- a/src/ui/components/map/providers/mapboxmapprovider.js
+++ b/src/ui/components/map/providers/mapboxmapprovider.js
@@ -2,6 +2,7 @@
 
 import MapProvider from './mapprovider';
 import DOM from '../../../dom/dom';
+import ResultsContext from '../../../../core/storage/resultscontext';
 
 /* global mapboxgl */
 
@@ -44,8 +45,8 @@ export default class MapBoxMapProvider extends MapProvider {
     DOM.append('body', script);
   }
 
-  init (el, mapData) {
-    if ((!mapData || mapData.mapMarkers.length <= 0) && !this._showEmptyMap) {
+  init (el, mapData, resultsContext) {    
+    if (this.shouldHideMap(mapData, resultsContext)) {
       this._map = null;
       return this;
     }

--- a/src/ui/components/map/providers/mapboxmapprovider.js
+++ b/src/ui/components/map/providers/mapboxmapprovider.js
@@ -2,7 +2,6 @@
 
 import MapProvider from './mapprovider';
 import DOM from '../../../dom/dom';
-import ResultsContext from '../../../../core/storage/resultscontext';
 
 /* global mapboxgl */
 
@@ -45,7 +44,7 @@ export default class MapBoxMapProvider extends MapProvider {
     DOM.append('body', script);
   }
 
-  init (el, mapData, resultsContext) {    
+  init (el, mapData, resultsContext) {
     if (this.shouldHideMap(mapData, resultsContext)) {
       this._map = null;
       return this;

--- a/src/ui/components/map/providers/mapprovider.js
+++ b/src/ui/components/map/providers/mapprovider.js
@@ -95,9 +95,9 @@ export default class MapProvider {
     };
   }
 
-  shouldHideMap(mapData, resultsContext) {
+  shouldHideMap (mapData, resultsContext) {
     if (resultsContext === ResultsContext.NO_RESULTS) {
-      return !this._noResults.visible
+      return !this._noResults.visible;
     }
     const hasEmptyMap = !mapData || mapData.mapMarkers.length <= 0;
     return hasEmptyMap && !this._showEmptyMap;

--- a/src/ui/components/map/providers/mapprovider.js
+++ b/src/ui/components/map/providers/mapprovider.js
@@ -1,5 +1,7 @@
 /** @module MapProvider */
 
+import ResultsContext from '../../../../core/storage/resultscontext';
+
 /**
  * A MapProvider is an interface that represents that should be implemented
  * in order to integrate with a Third Party Map provider for
@@ -27,6 +29,11 @@ export default class MapProvider {
      * @type {Object}
      */
     this._defaultPosition = config.defaultPosition || { lat: 37.0902, lng: -95.7129 };
+
+    /**
+     * Configuration for the behavior when there are no vertical results.
+     */
+    this._noResults = config.noResults || {};
 
     /**
      * Determines if an empty map should be shown when there are no results
@@ -86,6 +93,14 @@ export default class MapProvider {
       },
       labelType: 'numeric'
     };
+  }
+
+  shouldHideMap(mapData, resultsContext) {
+    if (resultsContext === ResultsContext.NO_RESULTS) {
+      return !this._noResults.visible
+    }
+    const hasEmptyMap = !mapData || mapData.mapMarkers.length <= 0;
+    return hasEmptyMap && !this._showEmptyMap;
   }
 
   onLoaded (cb) {


### PR DESCRIPTION
This commit adds the visible option to the map's noResults config.
This will take priority over showEmptyMap when no results are returned.

TEST=manual
tested show empty map works still
tested that noResults.visible takes priority over showEmptyMap for no results