### PR TITLE
Map: default noResults.visible to showEmptyMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1371,7 +1371,7 @@ ANSWERS.addComponent('Map', {
   zoom: 14,
   // Optional, the default coordinates to display if there are no results returned used if showEmptyMap is set to true
   defaultPosition: { lat: 37.0902, lng: -95.7129 },
-  // Optional, determines if an empty map should be shown when there are no results
+  // Optional, determines if an empty map should be shown when there are no results. Defaults to false.
   showEmptyMap: false,
   // Optional, callback to invoke when a pin is clicked. The clicked item(s) are passed to the callback
   onPinClick: null,
@@ -1381,7 +1381,7 @@ ANSWERS.addComponent('Map', {
   noResults: {
     // Optional, whether to display map pins for all possible results when no results are found. Defaults to false.
     displayAllResults: false,
-    // Optional, whether to display the map when no results are found, taking priority over showEmptyMap. If displayAllResults is false, this will be an empty map. Defaults to false.
+    // Optional, whether to display the map when no results are found, taking priority over showEmptyMap. If displayAllResults is false, this will be an empty map. Defaults to showEmptyMap's value.
     visible: false
   },
   // Optional, the custom configuration override to use for the map markers, function

--- a/src/ui/components/map/mapcomponent.js
+++ b/src/ui/components/map/mapcomponent.js
@@ -26,7 +26,7 @@ export default class MapComponent extends Component {
      * Configuration for the behavior when there are no vertical results.
      */
     this._noResults = Object.assign(
-      { displayAllResults: false, visible: false, template: '' },
+      { displayAllResults: false, visible: this._config.showEmptyMap, template: '' },
       opts.noResults || this.core.globalStorage.getState(StorageKeys.NO_RESULTS_CONFIG)
     );
 

--- a/src/ui/components/map/mapcomponent.js
+++ b/src/ui/components/map/mapcomponent.js
@@ -61,7 +61,11 @@ export default class MapComponent extends Component {
 
   // TODO(billy) Make ProviderTypes a factory class
   getProviderInstance (type) {
-    return new ProviderTypes[type.toLowerCase()](this._config);
+    const _config = {
+      ...this._config,
+      noResults: this._noResults
+    };
+    return new ProviderTypes[type.toLowerCase()](_config);
   }
 
   onCreate () {

--- a/src/ui/components/map/providers/mapprovider.js
+++ b/src/ui/components/map/providers/mapprovider.js
@@ -32,6 +32,7 @@ export default class MapProvider {
 
     /**
      * Configuration for the behavior when there are no vertical results.
+     * @type {Object}
      */
     this._noResults = config.noResults || {};
 
@@ -96,7 +97,7 @@ export default class MapProvider {
   }
 
   shouldHideMap (mapData, resultsContext) {
-    if (resultsContext === ResultsContext.NO_RESULTS && 'visible' in this._noResults) {
+    if (resultsContext === ResultsContext.NO_RESULTS) {
       return !this._noResults.visible;
     }
     const hasEmptyMap = !mapData || mapData.mapMarkers.length <= 0;

--- a/src/ui/components/map/providers/mapprovider.js
+++ b/src/ui/components/map/providers/mapprovider.js
@@ -96,7 +96,7 @@ export default class MapProvider {
   }
 
   shouldHideMap (mapData, resultsContext) {
-    if (resultsContext === ResultsContext.NO_RESULTS) {
+    if (resultsContext === ResultsContext.NO_RESULTS && 'visible' in this._noResults) {
       return !this._noResults.visible;
     }
     const hasEmptyMap = !mapData || mapData.mapMarkers.length <= 0;


### PR DESCRIPTION
If noResults.visible is not set, it should default to whatever
value is set to showEmptyMap, which defaults to undefined (falsy).

TEST=manual

- check that noResults.visible defaults to showEmptyMap's value
--
displayAllResults: false
noResults.visible not set
showEmptyMap: true
--
displayAllResults: false
noResults.visible not set
showEmptyMap: false

- check that noResults.visible has priority over showEmptyMap, and that noResults.visible only applies when no results are returned
--
displayAllResults: false
noResults.vislble: true
showEmptyMap: false
--
displayAllResults: false
noResults.visible: false
showEmptyMap: true
