### PR TITLE
FilterOptions: appliedOnLoad setting for options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1072,6 +1072,9 @@ Filter components can be used in a FilterBox or on their own to affect a search.
 ### FilterOptions
 
 FilterOptions displays a set of filters with either checkboxes or radio buttons.
+As a user interacts with FilterOptions, information on which options are selected
+is stored in the url. Returning to that same url will load the page with those saved
+options already selected.
 
 ```html
 <div class="filter-container"></div>
@@ -1093,12 +1096,16 @@ ANSWERS.addComponent('FilterOptions', {
       // The api field to filter on, configured on the Yext platform
       field: 'c_openNow',
       // The value for the above field to filter by
-      value: true
+      value: true,
+      // Whether this option will be selected on page load. Selected options stored in the url
+      // will take priority over appliedOnLoad. Defaults to false.
+      appliedOnLoad: false
     },
     {
       label: 'Dog Friendly',
       field: 'c_dogFriendly',
-      value: true
+      value: true,
+      appliedOnLoad: true
     },
     {
       label: 'Megastores',

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -135,7 +135,7 @@ class FilterOptionsConfig {
   /**
    * If no previous options were stored in persistentStorage, default to options marked
    * as appliedOnLoad.
-   * @param {*} options 
+   * @param {*} options
    */
   setAppliedOnLoad (options) {
     if (this.control === 'singleoption') {
@@ -144,7 +144,7 @@ class FilterOptionsConfig {
       firstAppliedOption.selected = true;
       return _options;
     }
-    return options.map(o =>  ({
+    return options.map(o => ({
       ...o,
       selected: o.appliedOnLoad
     }));

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -110,36 +110,44 @@ class FilterOptionsConfig {
         config.previousOptions = [];
       }
     }
-    const previousOptions = config.previousOptions || [];
-    this.options = this.setDefaultSelectedValues(this.options, previousOptions);
+    // previousOptions will be null if there were no previousOptions in persistentStorage
+    const previousOptions = config.previousOptions;
+    if (previousOptions) {
+      this.options = this.setPreviousOptions(this.options, previousOptions || []);
+    } else {
+      this.options = this.setAppliedOnLoad(this.options);
+    }
   }
 
   /**
-   * Sets selected options on load based on options stored in persistent storage,
-   * and if persistent storage is empty then the appliedOnLoad flag.
+   * Sets selected options on load based on options stored in persistent storage.
    * @param {Array<Object>} options
    * @param {Array<string>} previousOptions
    * @returns {Array<Object>}
    */
-  setDefaultSelectedValues (options, previousOptions) {
-    if (previousOptions.length) {
-      return options.map(o => ({
-        ...o,
-        selected: previousOptions.length
-          ? previousOptions.includes(o.label)
-          : o.selected
-      }));
+  setPreviousOptions (options, previousOptions) {
+    return options.map(o => ({
+      ...o,
+      selected: previousOptions.includes(o.label)
+    }));
+  }
+
+  /**
+   * If no previous options were stored in persistentStorage, default to options marked
+   * as appliedOnLoad.
+   * @param {*} options 
+   */
+  setAppliedOnLoad (options) {
+    if (this.control === 'singleoption') {
+      const _options = options.map(o => ({ ...o }));
+      const firstAppliedOption = _options.find(o => o.appliedOnLoad);
+      firstAppliedOption.selected = true;
+      return _options;
     }
-    for (let o of options) {
-      if (!o.appliedOnLoad) {
-        continue;
-      }
-      o.selected = true;
-      if (this.control === 'singleoption') {
-        break;
-      }
-    }
-    return options;
+    return options.map(o =>  ({
+      ...o,
+      selected: o.appliedOnLoad
+    }));
   }
 
   getSelectedCount () {

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -110,17 +110,36 @@ class FilterOptionsConfig {
         config.previousOptions = [];
       }
     }
-    let selectedOptions = config.previousOptions || [];
-    this.options = this.setDefaultSelectedValues(this.options, selectedOptions);
+    const previousOptions = config.previousOptions || [];
+    this.options = this.setDefaultSelectedValues(this.options, previousOptions);
   }
 
-  setDefaultSelectedValues (options, selectedOptions) {
-    return options.map(o => ({
-      ...o,
-      selected: selectedOptions.length
-        ? selectedOptions.includes(o.label)
-        : o.selected
-    }));
+  /**
+   * Sets selected options on load based on options stored in persistent storage,
+   * and if persisten storage is empty then the appliedOnLoad flag.
+   * @param {Array<Object>} options
+   * @param {Array<string>} previousOptions
+   * @returns {Array<Object>}
+   */
+  setDefaultSelectedValues (options, previousOptions) {
+    if (previousOptions.length) {
+      return options.map(o => ({
+        ...o,
+        selected: previousOptions.length
+          ? previousOptions.includes(o.label)
+          : o.selected
+      }));
+    }
+    for (let o of options) {
+      if (!o.appliedOnLoad) {
+        continue;
+      }
+      o.selected = true;
+      if (this.control === 'singleoption') {
+        break;
+      }
+    }
+    return options;
   }
 
   getSelectedCount () {

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -146,7 +146,7 @@ class FilterOptionsConfig {
     }
     return options.map(o => ({
       ...o,
-      selected: o.appliedOnLoad
+      selected: o.appliedOnLoad || o.selected
     }));
   }
 

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -116,7 +116,7 @@ class FilterOptionsConfig {
 
   /**
    * Sets selected options on load based on options stored in persistent storage,
-   * and if persisten storage is empty then the appliedOnLoad flag.
+   * and if persistent storage is empty then the appliedOnLoad flag.
    * @param {Array<Object>} options
    * @param {Array<string>} previousOptions
    * @returns {Array<Object>}


### PR DESCRIPTION
This commit adds the appliedOnLoad flag for options.
Options with appliedOnLoad: true will be automatically
checked on page load, if no prior options were stored in persistent storage.
If the filteroptions mode is single-option, then only the first option
marked as appliedOnLoad will be selected.

TEST=manual
tested that for singleoption, only the first option marked as appliedOnLoad
   is selected
tested that for multioption, all options are selected
tested using both filterbox and filteroptions
tested that persistent storage will take priority by unchecking boxes and
   then refreshing the page, but refreshing the page AND erasing url params
   will result in the original appliedOnLoad options