### PR TITLE
DynamicFilters: null handling for response.facets

### DIFF
--- a/src/core/models/dynamicfilters.js
+++ b/src/core/models/dynamicfilters.js
@@ -25,7 +25,7 @@ export default class DynamicFilters {
    * @returns {DynamicFilters}
    */
   static from (response) {
-    const { facets, resultsContext } = response;
+    const facets = response.facets || [];
     const dynamicFilters = facets.map(f => ({
       label: f['displayName'],
       fieldId: f['fieldId'],
@@ -39,7 +39,7 @@ export default class DynamicFilters {
 
     return new DynamicFilters({
       filters: dynamicFilters,
-      resultsContext: resultsContext
+      resultsContext: response.resultsContext
     });
   }
 }


### PR DESCRIPTION
We aren't guaranteed to receive an allResultsForVertical.facets
or allResultsForVertical property in the vertical search response.

TEST=manual
copied rose's qa site with this issue
saw that no results query, with response missing allResultsForVertical,
renders no results correctly