### PR TITLE
Map: correct hide map behavior when noResults.visible is undefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -1382,7 +1382,7 @@ ANSWERS.addComponent('Map', {
   noResults: {
     // Optional, whether to display map pins for all possible results when no results are found. Defaults to false.
     displayAllResults: false,
-    // Optional, whether to display the map when no results are found, taking priority over showEmptyMap. Defaults to true if showEmptyMap or noResults.displayAllResults are true, otherwise defaults to false.
+    // Optional, whether to display the map when no results are found, taking priority over showEmptyMap. If unset, a map will be visible if showEmptyMap is true OR if displayAllResults is true and alternative results are returned.
     visible: false
   },
   // Optional, the custom configuration override to use for the map markers, function

--- a/README.md
+++ b/README.md
@@ -1382,7 +1382,7 @@ ANSWERS.addComponent('Map', {
   noResults: {
     // Optional, whether to display map pins for all possible results when no results are found. Defaults to false.
     displayAllResults: false,
-    // Optional, whether to display the map when no results are found, taking priority over showEmptyMap. If displayAllResults is false, this will be an empty map. Defaults to showEmptyMap's value.
+    // Optional, whether to display the map when no results are found, taking priority over showEmptyMap. Defaults to true if showEmptyMap or noResults.displayAllResults are true, otherwise defaults to false.
     visible: false
   },
   // Optional, the custom configuration override to use for the map markers, function

--- a/src/ui/components/map/mapcomponent.js
+++ b/src/ui/components/map/mapcomponent.js
@@ -22,17 +22,14 @@ export default class MapComponent extends Component {
      */
     this.moduleId = StorageKeys.VERTICAL_RESULTS;
 
-    const noResults = opts.noResults ||
-      this.core.globalStorage.getState(StorageKeys.NO_RESULTS_CONFIG) ||
-      {};
     /**
      * Configuration for the behavior when there are no vertical results.
      */
     this._noResults = {
       displayAllResults: false,
-      visible: opts.showEmptyMap || noResults.displayAllResults,
+      visible: undefined,
       template: '',
-      ...noResults
+      ...(opts.noResults || this.core.globalStorage.getState(StorageKeys.NO_RESULTS_CONFIG))
     };
 
     /**

--- a/src/ui/components/map/mapcomponent.js
+++ b/src/ui/components/map/mapcomponent.js
@@ -22,13 +22,18 @@ export default class MapComponent extends Component {
      */
     this.moduleId = StorageKeys.VERTICAL_RESULTS;
 
+    const noResults = opts.noResults ||
+      this.core.globalStorage.getState(StorageKeys.NO_RESULTS_CONFIG) ||
+      {};
     /**
      * Configuration for the behavior when there are no vertical results.
      */
-    this._noResults = Object.assign(
-      { displayAllResults: false, visible: this._config.showEmptyMap, template: '' },
-      opts.noResults || this.core.globalStorage.getState(StorageKeys.NO_RESULTS_CONFIG)
-    );
+    this._noResults = {
+      displayAllResults: false,
+      visible: opts.showEmptyMap || noResults.displayAllResults,
+      template: '',
+      ...noResults
+    };
 
     /**
      * An aliased used to determine the type of map provider to use

--- a/src/ui/components/map/providers/googlemapprovider.js
+++ b/src/ui/components/map/providers/googlemapprovider.js
@@ -75,7 +75,7 @@ export default class GoogleMapProvider extends MapProvider {
   }
 
   init (el, mapData, resultsContext) {
-    if (this.shouldHideMap(mapData, resultsContext)) {
+    if (MapProvider.shouldHideMap(mapData, resultsContext, this._showEmptyMap, this._noResults.visible)) {
       this._map = null;
       return this;
     }

--- a/src/ui/components/map/providers/mapboxmapprovider.js
+++ b/src/ui/components/map/providers/mapboxmapprovider.js
@@ -45,7 +45,7 @@ export default class MapBoxMapProvider extends MapProvider {
   }
 
   init (el, mapData, resultsContext) {
-    if (this.shouldHideMap(mapData, resultsContext)) {
+    if (MapProvider.shouldHideMap(mapData, resultsContext, this._showEmptyMap, this._noResults.visible)) {
       this._map = null;
       return this;
     }

--- a/src/ui/components/map/providers/mapprovider.js
+++ b/src/ui/components/map/providers/mapprovider.js
@@ -96,12 +96,12 @@ export default class MapProvider {
     };
   }
 
-  shouldHideMap (mapData, resultsContext) {
-    if (resultsContext === ResultsContext.NO_RESULTS) {
-      return !this._noResults.visible;
+  static shouldHideMap (mapData, resultsContext, showEmptyMap, visibleForNoResults) {
+    if (resultsContext === ResultsContext.NO_RESULTS && visibleForNoResults !== undefined) {
+      return !visibleForNoResults;
     }
     const hasEmptyMap = !mapData || mapData.mapMarkers.length <= 0;
-    return hasEmptyMap && !this._showEmptyMap;
+    return hasEmptyMap && !showEmptyMap;
   }
 
   onLoaded (cb) {

--- a/tests/ui/components/map/mapcomponent.js
+++ b/tests/ui/components/map/mapcomponent.js
@@ -14,44 +14,6 @@ describe('map component config', () => {
     };
   });
 
-  describe('noResults.visible defaults to true if displayAllResults OR showEmptyMap are true', () => {
-    it('displayAllResults: true, showEmptyMap: unset', () => {
-      const config = {
-        noResults: {
-          displayAllResults: true
-        },
-        ...defaultConfig
-      };
-      const component = new MapComponent(config, systemConfig);
-      const { visible } = component._noResults;
-      expect(visible).toBeTruthy();
-    });
-
-    it('displayAllResults: unset, showEmptyMap: true', () => {
-      const config = {
-        showEmptyMap: true,
-        noResults: {},
-        ...defaultConfig
-      };
-      const component = new MapComponent(config, systemConfig);
-      const { visible } = component._noResults;
-      expect(visible).toBeTruthy();
-    });
-
-    it('displayAllResults: true, showEmptyMap: true', () => {
-      const config = {
-        showEmptyMap: true,
-        noResults: {
-          displayAllResults: true
-        },
-        ...defaultConfig
-      };
-      const component = new MapComponent(config, systemConfig);
-      const { visible } = component._noResults;
-      expect(visible).toBeTruthy();
-    });
-  });
-
   describe('noResults.visible has priority over displayAllResults and showEmptyMap', () => {
     it('visible: true, displayAllResults: false, showEmptyMap: false', () => {
       const config = {

--- a/tests/ui/components/map/mapcomponent.js
+++ b/tests/ui/components/map/mapcomponent.js
@@ -1,0 +1,92 @@
+import MapComponent from '../../../../src/ui/components/map/mapcomponent';
+
+describe('map component config', () => {
+  let defaultConfig;
+  const core = {
+    globalStorage: {
+      getState: () => {}
+    }
+  };
+  const systemConfig = { core };
+  beforeEach(() => {
+    defaultConfig = {
+      mapProvider: 'google'
+    };
+  });
+
+  describe('noResults.visible defaults to true if displayAllResults OR showEmptyMap are true', () => {
+    it('displayAllResults: true, showEmptyMap: unset', () => {
+      const config = {
+        noResults: {
+          displayAllResults: true
+        },
+        ...defaultConfig
+      };
+      const component = new MapComponent(config, systemConfig);
+      const { visible } = component._noResults;
+      expect(visible).toBeTruthy();
+    });
+
+    it('displayAllResults: unset, showEmptyMap: true', () => {
+      const config = {
+        showEmptyMap: true,
+        noResults: {},
+        ...defaultConfig
+      };
+      const component = new MapComponent(config, systemConfig);
+      const { visible } = component._noResults;
+      expect(visible).toBeTruthy();
+    });
+
+    it('displayAllResults: true, showEmptyMap: true', () => {
+      const config = {
+        showEmptyMap: true,
+        noResults: {
+          displayAllResults: true
+        },
+        ...defaultConfig
+      };
+      const component = new MapComponent(config, systemConfig);
+      const { visible } = component._noResults;
+      expect(visible).toBeTruthy();
+    });
+  });
+
+  describe('noResults.visible has priority over displayAllResults and showEmptyMap', () => {
+    it('visible: true, displayAllResults: false, showEmptyMap: false', () => {
+      const config = {
+        showEmptyMap: false,
+        noResults: {
+          visible: true,
+          displayAllResults: false
+        },
+        ...defaultConfig
+      };
+      const component = new MapComponent(config, systemConfig);
+      const { visible } = component._noResults;
+      expect(visible).toBeTruthy();
+    });
+
+    it('visible: false, displayAllResults: true, showEmptyMap: true', () => {
+      const config = {
+        showEmptyMap: true,
+        noResults: {
+          visible: false,
+          displayAllResults: true
+        },
+        ...defaultConfig
+      };
+      const component = new MapComponent(config, systemConfig);
+      const { visible } = component._noResults;
+      expect(visible).toBeFalsy();
+    });
+  });
+
+  it('does not break if given default config', () => {
+    const component = new MapComponent(defaultConfig, systemConfig);
+    const { displayAllResults, visible, template } = component._noResults;
+    expect(displayAllResults).toBeFalsy();
+    expect(visible).toBeFalsy();
+    expect(template).toEqual('');
+  });
+});

--- a/tests/ui/components/map/providers/mapprovider.js
+++ b/tests/ui/components/map/providers/mapprovider.js
@@ -1,4 +1,5 @@
 import MapProvider from '../../../../../src/ui/components/map/providers/mapprovider';
+import ResultsContext from '../../../../../src/core/storage/resultscontext';
 
 describe('collapsing markers', () => {
   it('collapses markers with the same lat/lng', () => {
@@ -43,5 +44,68 @@ describe('collapsing markers', () => {
       latitude: 234,
       longitude: 123
     });
+  });
+});
+
+describe('can show/hide map behavior for no results with blank map data', () => {
+  const resultsContext = ResultsContext.NO_RESULTS;
+  describe('when visibleForNoResults is undefined', () => {
+    const visibleForNoResults = undefined;
+    const mapData = { mapMarkers: [1] };
+    it('shows map if showEmptyMap is true and tehre is no mapt data', () => {
+      let showEmptyMap = true;
+      expect(MapProvider.shouldHideMap(null, resultsContext, showEmptyMap, visibleForNoResults)).toBeFalsy();
+    });
+
+    it('hides map if showEmptyMap is false and there is no map data', () => {
+      let showEmptyMap = false;
+      expect(MapProvider.shouldHideMap(null, resultsContext, showEmptyMap, visibleForNoResults)).toBeTruthy();
+    });
+
+    it('shows map when there is mapData', () => {
+      let showEmptyMap = true;
+      expect(MapProvider.shouldHideMap(mapData, resultsContext, showEmptyMap, visibleForNoResults)).toBeFalsy();
+      showEmptyMap = false;
+      expect(MapProvider.shouldHideMap(mapData, resultsContext, showEmptyMap, visibleForNoResults)).toBeFalsy();
+    });
+  });
+
+  it('hide map when visibleForNoResults = false', () => {
+    const visibleForNoResults = false;
+    let showEmptyMap = false;
+    expect(MapProvider.shouldHideMap(null, resultsContext, showEmptyMap, visibleForNoResults)).toBeTruthy();
+    showEmptyMap = true;
+    expect(MapProvider.shouldHideMap(null, resultsContext, showEmptyMap, visibleForNoResults)).toBeTruthy();
+  });
+
+  it('show map when visibleForNoResults = true', () => {
+    const visibleForNoResults = true;
+    let showEmptyMap = false;
+    expect(MapProvider.shouldHideMap(null, resultsContext, showEmptyMap, visibleForNoResults)).toBeFalsy();
+    showEmptyMap = true;
+    expect(MapProvider.shouldHideMap(null, resultsContext, showEmptyMap, visibleForNoResults)).toBeFalsy();
+  });
+});
+
+describe('can show/hide map for normal results', () => {
+  const resultsContext = ResultsContext.NORMAL;
+  it('hide the map when showEmptyMap = false and has empty map data', () => {
+    let visibleForNoResults = false;
+    const showEmptyMap = false;
+    expect(MapProvider.shouldHideMap(null, resultsContext, showEmptyMap, visibleForNoResults)).toBeTruthy();
+
+    // Should be unaffected by the no results config
+    visibleForNoResults = true;
+    expect(MapProvider.shouldHideMap(null, resultsContext, showEmptyMap, visibleForNoResults)).toBeTruthy();
+  });
+
+  it('show the map when showEmptyMap = true and has empty map data', () => {
+    let visibleForNoResults = false;
+    const showEmptyMap = true;
+    expect(MapProvider.shouldHideMap(null, resultsContext, showEmptyMap, visibleForNoResults)).toBeFalsy();
+
+    // Should be unaffected by the no results config
+    visibleForNoResults = true;
+    expect(MapProvider.shouldHideMap(null, resultsContext, showEmptyMap, visibleForNoResults)).toBeFalsy();
   });
 });


### PR DESCRIPTION
noResults.visible was defaulting to showEmptyMap before, meaning if noResults.displayAllResults
is true, showEmptyMap was false/unset, and noResults.visible was unset, no map would
display.

TEST=manual, auto
check that empty map displays when noResults.visible = undefined, noResults.displayAllResults = false, and showEmptyMap = true
check that map with pins displays when noResults.visible = undefined, noResults.displayAllResults = true, and showEmptyMap = false