### PR TITLE
VerticalResults: pass resultsContext and noResults properly to embedd…

### DIFF
--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -218,9 +218,16 @@ export default class VerticalResultsComponent extends Component {
 
   addChild (data, type, opts) {
     if (type === MapComponent.type) {
-      const newOpts = Object.assign(
-        {}, this._config.mapConfig, { noResults: this._noResultsConfig }, opts);
-      return super.addChild({ map: data }, type, newOpts);
+      const _opts = {
+        noResults: this._noResultsConfig,
+        ...this._config.mapConfig,
+        ...opts
+      };
+      const _data = {
+        resultsContext: this.getState('resultsContext'),
+        map: data
+      };
+      return super.addChild(_data, type, _opts);
     } else if (type === CardComponent.type) {
       const updatedData = {
         result: this.results[opts._index],


### PR DESCRIPTION
…ed map

We need to pass resultsContext to noResults, otherwise we run into
a race condition between the map component's moduleId and the data
it receives from being a child of vertical results.

We also need to prioritize the noResults config specified in the mapConfig,
instead of forcing the embedded map to use the noResults config in vertical
results.

TEST=manual
in the map config for a vertical results component with includeMap = true
for each test below, also test that changing the page with pagination does
not mess things up (was causing the above mentioned race condition)

the below have no globalNoResults and verticalResults.noResults.displayAllResults = true

visible: false
displayAllResults: true
= no map

visible: true
displayAllResults: true
= map with pins

visible: false
displayAllResults: false
= no map

visible: true
displayAllResults: false
= empty map

visible: unset
displayAllResults: unset
= no map

visible: true
displayAllResults: unset
= empty map

visible: unset
displayAllResults: true
= empty map (this should be a map with pins - already being addressed in PR #805)


also check leaving things blank is fine

no global noResults, verticalResults noResults, or mapConfig noResults
= legacy no results (no map)

no global noResults, verticalResults noResults.displayAllResults = true, no mapConfig noResults
= new no results, no map