### PR TITLE
Geolocation: add geolocationOptions and geolocationTimeoutAlert config

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,17 +398,17 @@ ANSWERS.addComponent('SearchBar', {
   useForm: 'true',
   // Optional, the input element used for searching and wires up the keyboard interaction
   inputEl: '.js-yext-query',  
-  // Optional, options to pass to the geolocation api.
+  // Optional, options to pass to the geolocation api, which is used to fetch the user's current location.
   // https://developer.mozilla.org/en-US/docs/Web/API/PositionOptions
   geolocationOptions: {
     // Optional, whether to improve accuracy at the cost of response time and/or power consumption, defaults to false.
     enableHighAccuracy: false,
-    // Optional, the maximum amount of time (in ms) a geolocation call is allowed to take before defaulting, defaults to 1000ms.
+    // Optional, the maximum amount of time (in ms) a geolocation call is allowed to take before defaulting, defaults to 1 second.
     timeout: 1000,
-    // Optional, the maximum amount of time (in ms) to cache a geolocation call, defaults to 300000ms (5 minutes).
+    // Optional, the maximum amount of time (in ms) to cache a geolocation call, defaults to 5 minutes.
     maximumAge: 300000,
   },
-  // Optional, options for the alert given when geolocation defaults.
+  // Optional, options for an alert when the geolocation call fails.
   geolocationTimeoutAlert: {
     // Optional, whether to display a window.alert() on the page, defaults to false.
     enabled: false,
@@ -1172,17 +1172,17 @@ ANSWERS.addComponent('GeoLocationFilter', {
       sectioned: false,
     }]
   },
-  // Optional, options to pass to the geolocation api.
+  // Optional, options to pass to the geolocation api, which is used to fetch the user's current location.
   // https://developer.mozilla.org/en-US/docs/Web/API/PositionOptions
   geolocationOptions: {
     // Optional, whether to improve accuracy at the cost of response time and/or power consumption, defaults to false.
     enableHighAccuracy: false,
-    // Optional, the maximum amount of time (in ms) a geolocation call is allowed to take before defaulting, defaults to 6000ms.
+    // Optional, the maximum amount of time (in ms) a geolocation call is allowed to take before defaulting, defaults to 6 seconds.
     timeout: 6000,
-    // Optional, the maximum amount of time (in ms) to cache a geolocation call, defaults to 300000ms (5 minutes).
+    // Optional, the maximum amount of time (in ms) to cache a geolocation call, defaults to 5 minutes.
     maximumAge: 300000,
   },
-  // Optional, options for the alert given when geolocation defaults.
+  // Optional, options for an alert when the geolocation call fails.
   geolocationTimeoutAlert: {
     // Optional, whether to display a window.alert() on the page, defaults to false.
     enabled: false,
@@ -1311,17 +1311,17 @@ ANSWERS.addComponent('LocationBias', {
   deviceAccuracyHelpText: 'based on your device',
   // Optional, text used for the button to update location
   updateLocationButtonText: 'Update your location',
-  // Optional, options to pass to the geolocation api.
+  // Optional, options to pass to the geolocation api, which is used to fetch the user's current location.
   // https://developer.mozilla.org/en-US/docs/Web/API/PositionOptions
   geolocationOptions: {
     // Optional, whether to improve accuracy at the cost of response time and/or power consumption, defaults to false.
     enableHighAccuracy: false,
-    // Optional, the maximum amount of time (in ms) a geolocation call is allowed to take before defaulting, defaults to 6000ms.
+    // Optional, the maximum amount of time (in ms) a geolocation call is allowed to take before defaulting, defaults to 6 seconds.
     timeout: 6000,
-    // Optional, the maximum amount of time (in ms) to cache a geolocation call, defaults to 300000ms (5 minutes).
+    // Optional, the maximum amount of time (in ms) to cache a geolocation call, defaults to 5 minutes.
     maximumAge: 300000,
   },
-  // Optional, options for the alert given when geolocation defaults.
+  // Optional, options for an alert when the geolocation call fails.
   geolocationTimeoutAlert: {
     // Optional, whether to display a window.alert() on the page, defaults to false.
     enabled: false,

--- a/README.md
+++ b/README.md
@@ -397,7 +397,24 @@ ANSWERS.addComponent('SearchBar', {
   // Note that WCAG compliance is not guaranteed if a form is not used as the context.
   useForm: 'true',
   // Optional, the input element used for searching and wires up the keyboard interaction
-  inputEl: '.js-yext-query'
+  inputEl: '.js-yext-query',  
+  // Optional, options to pass to the geolocation api.
+  // https://developer.mozilla.org/en-US/docs/Web/API/PositionOptions
+  geolocationOptions: {
+    // Optional, whether to improve accuracy at the cost of response time and/or power consumption, defaults to false.
+    enableHighAccuracy: false,
+    // Optional, the maximum amount of time (in ms) a geolocation call is allowed to take before defaulting, defaults to 1000ms.
+    timeout: 1000,
+    // Optional, the maximum amount of time (in ms) to cache a geolocation call, defaults to 300000ms (5 minutes).
+    maximumAge: 300000,
+  },
+  // Optional, options for the alert given when geolocation defaults.
+  geolocationTimeoutAlert: {
+    // Optional, whether to display a window.alert() on the page, defaults to false.
+    enabled: false,
+    // Optional, the message in the alert. Defaults to the below
+    message: "We are unable to determine your location"
+  }
 })
 ```
 
@@ -1155,6 +1172,23 @@ ANSWERS.addComponent('GeoLocationFilter', {
       sectioned: false,
     }]
   },
+  // Optional, options to pass to the geolocation api.
+  // https://developer.mozilla.org/en-US/docs/Web/API/PositionOptions
+  geolocationOptions: {
+    // Optional, whether to improve accuracy at the cost of response time and/or power consumption, defaults to false.
+    enableHighAccuracy: false,
+    // Optional, the maximum amount of time (in ms) a geolocation call is allowed to take before defaulting, defaults to 6000ms.
+    timeout: 6000,
+    // Optional, the maximum amount of time (in ms) to cache a geolocation call, defaults to 300000ms (5 minutes).
+    maximumAge: 300000,
+  },
+  // Optional, options for the alert given when geolocation defaults.
+  geolocationTimeoutAlert: {
+    // Optional, whether to display a window.alert() on the page, defaults to false.
+    enabled: false,
+    // Optional, the message in the alert. Defaults to the below
+    message: "We are unable to determine your location"
+  }
 });
 ```
 
@@ -1276,7 +1310,24 @@ ANSWERS.addComponent('LocationBias', {
   // Optional, help text to inform someone their device was used for location
   deviceAccuracyHelpText: 'based on your device',
   // Optional, text used for the button to update location
-  updateLocationButtonText: 'Update your location'
+  updateLocationButtonText: 'Update your location',
+  // Optional, options to pass to the geolocation api.
+  // https://developer.mozilla.org/en-US/docs/Web/API/PositionOptions
+  geolocationOptions: {
+    // Optional, whether to improve accuracy at the cost of response time and/or power consumption, defaults to false.
+    enableHighAccuracy: false,
+    // Optional, the maximum amount of time (in ms) a geolocation call is allowed to take before defaulting, defaults to 6000ms.
+    timeout: 6000,
+    // Optional, the maximum amount of time (in ms) to cache a geolocation call, defaults to 300000ms (5 minutes).
+    maximumAge: 300000,
+  },
+  // Optional, options for the alert given when geolocation defaults.
+  geolocationTimeoutAlert: {
+    // Optional, whether to display a window.alert() on the page, defaults to false.
+    enabled: false,
+    // Optional, the message in the alert. Defaults to the below
+    message: "We are unable to determine your location"
+  }
 })
 ```
 

--- a/src/ui/components/filters/geolocationcomponent.js
+++ b/src/ui/components/filters/geolocationcomponent.js
@@ -121,6 +121,27 @@ export default class GeoLocationComponent extends Component {
     this.core.globalStorage.on('update', `${StorageKeys.FILTER}.${this.name}`, f => { this.filter = f; });
 
     this.searchParameters = buildSearchParameters(config.searchParameters);
+
+    /**
+     * Options to pass to the geolocation api.
+     * @type {Object}
+     */
+    this._geolocationOptions = {
+      enableHighAccuracy: false,
+      timeout: 6000,
+      maximumAge: 300000,
+      ...config.geolocationOptions
+    };
+
+    /**
+     * Options for the geolocation timeout alert.
+     * @type {Object}
+     */
+    this._geolocationTimeoutAlert = {
+      enabled: false,
+      message: 'We are unable to determine your location',
+      ...config.geolocationTimeoutAlert
+    };
   }
 
   static get type () {
@@ -217,8 +238,17 @@ export default class GeoLocationComponent extends Component {
           this.core.persistentStorage.delete(`${StorageKeys.QUERY}.${this.name}`);
           this.core.persistentStorage.delete(`${StorageKeys.FILTER}.${this.name}`);
         },
-        () => this.setState({ geoError: true })
+        () => this._handleGeolocationError(),
+        this._geolocationOptions
       );
+    }
+  }
+
+  _handleGeolocationError () {
+    this.setState({ geoError: true });
+    const { enabled, message } = this._geolocationTimeoutAlert;
+    if (enabled) {
+      window.alert(message);
     }
   }
 

--- a/src/ui/components/search/locationbiascomponent.js
+++ b/src/ui/components/search/locationbiascomponent.js
@@ -46,6 +46,27 @@ export default class LocationBiasComponent extends Component {
     this._accuracy = '';
 
     this._allowUpdate = true;
+
+    /**
+     * Options to pass to the geolocation api.
+     * @type {Object}
+     */
+    this._geolocationOptions = {
+      enableHighAccuracy: false,
+      timeout: 6000,
+      maximumAge: 300000,
+      ...config.geolocationOptions
+    };
+
+    /**
+     * Options for the geolocation timeout alert.
+     * @type {Object}
+     */
+    this._geolocationTimeoutAlert = {
+      enabled: false,
+      message: 'We are unable to determine your location',
+      ...config.geolocationTimeoutAlert
+    };
   }
 
   static get type () {
@@ -70,14 +91,21 @@ export default class LocationBiasComponent extends Component {
             radius: position.coords.accuracy
           });
           this._doSearch();
-        }, (err) => {
-          if (err.code === 1) {
-            this._disableLocationUpdate();
-          }
-        });
+        }, (err) => this._handleGeolocationError(err),
+        this._geolocationOptions);
       }
       // TODO: Should we throw error or warning here if no geolocation?
     });
+  }
+
+  _handleGeolocationError (err) {
+    if (err.code === 1) {
+      this._disableLocationUpdate();
+    }
+    const { enabled, message } = this._geolocationTimeoutAlert;
+    if (enabled) {
+      window.alert(message);
+    }
   }
 
   setState (data, val) {

--- a/src/ui/components/search/locationbiascomponent.js
+++ b/src/ui/components/search/locationbiascomponent.js
@@ -91,7 +91,8 @@ export default class LocationBiasComponent extends Component {
             radius: position.coords.accuracy
           });
           this._doSearch();
-        }, (err) => this._handleGeolocationError(err),
+        },
+        (err) => this._handleGeolocationError(err),
         this._geolocationOptions);
       }
       // TODO: Should we throw error or warning here if no geolocation?

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -521,7 +521,8 @@ export default class SearchComponent extends Component {
                   if (enabled) {
                     window.alert(message);
                   }
-                }, this._geolocationOptions)
+                },
+                this._geolocationOptions)
             );
           } else {
             return this.search(query);

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -177,6 +177,27 @@ export default class SearchComponent extends Component {
      * @private
      */
     this._autoCompleteName = `${this.name}.autocomplete`;
+
+    /**
+     * Options to pass to the geolocation api.
+     * @type {Object}
+     */
+    this._geolocationOptions = {
+      enableHighAccuracy: false,
+      timeout: 1000,
+      maximumAge: 300000,
+      ...config.geolocationOptions
+    };
+
+    /**
+     * Options for the geolocation timeout alert.
+     * @type {Object}
+     */
+    this._geolocationTimeoutAlert = {
+      enabled: false,
+      message: 'We are unable to determine your location',
+      ...config.geolocationTimeoutAlert
+    };
   }
 
   static get type () {
@@ -494,7 +515,13 @@ export default class SearchComponent extends Component {
                   });
                   resolve(this.search(query));
                 },
-                () => resolve(this.search(query)))
+                () => {
+                  resolve(this.search(query));
+                  const { enabled, message } = this._geolocationTimeoutAlert;
+                  if (enabled) {
+                    window.alert(message);
+                  }
+                }, this._geolocationOptions)
             );
           } else {
             return this.search(query);


### PR DESCRIPTION
This commit adds the geolocationOptions, which directly set options
used by the geolocation api, and geolocationTimeoutAlert, which
sets whether a window.alert should appear when geolocation fails and
what message it contains.

Specaroni:
https://docs.google.com/document/d/1Dw69VKPn-tsrMy1hQNgFBZ5i4n1WN7UCkSSo0Dgs128/edit#

TEST=manual
Check that setting timeout 0, will cause geolocation to fail, and
that when this happens the window.alert is disabled by default, but can
be turned on, and the message will default correctly but can also be set.
Did not test maximumAge or enableHighAccuracy (not sure how?) but double
checked my spelling.
tested the above for all 3 components