### PR TITLE
FilterOptions: filter by locationRadius w/ optionType RADIUS_FILTER

### DIFF
--- a/README.md
+++ b/README.md
@@ -1057,6 +1057,12 @@ ANSWERS.addComponent('FilterOptions', {
   container: '.filter-container',
   // Required, control type: 'singleoption' or 'multioption'
   control: 'singleoption',
+  // The type of options to filter by, either 'STATIC_FILTER' or 'RADIUS_FILTER'.
+  // Defaults to 'STATIC_FILTER'.
+  optionType: 'STATIC_FILTER',
+  // If true, the filter value is saved on change and sent with the next search.
+  // Defaults to false.
+  storeOnChange: true,
   // Required, list of options
   options: [
     /** Depends on the above optionType, either 'STATIC_FILTER' or 'RADIUS_FILTER', see below. **/

--- a/README.md
+++ b/README.md
@@ -1059,17 +1059,7 @@ ANSWERS.addComponent('FilterOptions', {
   control: 'singleoption',
   // Required, list of options
   options: [
-    {
-      // Required, label to show next to the filter option
-      label: 'Open Now',
-      // Required, the field's API name to filter on, configured in the Yext platform
-      field: 'c_openNow',
-      // Required, the value for the above field to filter by
-      value: true,
-      // Optional, whether the option is selected by default
-      selected: true,
-    },
-    ...
+    /** Depends on the above optionType, either 'STATIC_FILTER' or 'RADIUS_FILTER', see below. **/
   ],
   // Optional, if true, the filter value is saved on change and sent with the next search. Defaults to false.
   storeOnChange: false,
@@ -1098,6 +1088,74 @@ ANSWERS.addComponent('FilterOptions', {
   // Optional, the label to be used in the legend, defaults to 'Filters'
   label: 'Filters'
 });
+```
+
+The options config varies depending on whether the optionType is 'STATIC_FILTER' or 'RADIUS_FILTER'.
+
+##### STATIC_FILTER
+
+```js
+{
+  options: [
+    {
+      // Label to show next to the filter option
+      label: 'Open Now',
+      // The api field to filter on, configured on the Yext platform
+      field: 'c_openNow',
+      // The value for the above field to filter by
+      value: true,
+      // Whether this option will be selected on page load. Selected options stored in the url
+      // take priority over appliedOnLoad. Defaults to false.
+      appliedOnLoad: false
+    },
+    {
+      label: 'Dog Friendly',
+      field: 'c_dogFriendly',
+      value: true,
+      appliedOnLoad: true
+    },
+    {
+      label: 'Megastores',
+      field: 'c_storeType',
+      value: 'Megastore'
+    }
+  ]
+}
+```
+
+##### RADIUS_FILTER
+
+```js
+{    
+  options: [
+    {
+      // Label to show next to the filter option
+      label: '5 miles', 
+      // The value of the radius to apply (in meters). If this value is 0, will not filter by radius.
+      value: 8046.72,
+      // Whether this option will be selected on page load. Selected options stored in the url
+      // will take priority over appliedOnLoad. Defaults to false.
+      appliedOnLoad: false
+    },
+    {
+      label: '10 miles',
+      value: 16093.4,
+      appliedOnLoad: true
+    },
+    {
+      label: '25 miles',
+      value: 40233.6
+    },
+    { 
+      label: '50 miles',
+      value: 80467.2
+    },
+    {
+      label: "Do not filter by radius",
+      value: 0
+    }
+  ],
+}
 ```
 
 ### RangeFilter

--- a/README.md
+++ b/README.md
@@ -1111,14 +1111,14 @@ The options config varies depending on whether the optionType is 'STATIC_FILTER'
       // Optional, the label to show next to the filter option.
       label: 'Open Now',
       // Optional, whether this option will be selected on page load. Selected options stored in the url
-      // take priority over appliedOnLoad. Defaults to false.
-      appliedOnLoad: false
+      // take priority over this. Defaults to false.
+      selected: false
     },
     {
       field: 'c_dogFriendly',
       value: true,
       label: 'Dog Friendly',
-      appliedOnLoad: true
+      selected: true
     },
     {
       field: 'c_storeType',
@@ -1140,13 +1140,13 @@ The options config varies depending on whether the optionType is 'STATIC_FILTER'
       // Optional, the label to show next to the filter option.
       label: '5 miles',
       // Optional, whether this option will be selected on page load. Selected options stored in the url
-      // take priority over appliedOnLoad. Defaults to false.
-      appliedOnLoad: false
+      // take priority over this. Defaults to false.
+      selected: false
     },
     {
       value: 16093.4,
       label: '10 miles',
-      appliedOnLoad: true
+      selected: true
     },
     {
       value: 40233.6,

--- a/README.md
+++ b/README.md
@@ -1098,26 +1098,26 @@ The options config varies depending on whether the optionType is 'STATIC_FILTER'
 {
   options: [
     {
-      // Label to show next to the filter option
-      label: 'Open Now',
-      // The api field to filter on, configured on the Yext platform
+      // Required, the api field to filter on, configured on the Yext platform.
       field: 'c_openNow',
-      // The value for the above field to filter by
+      // Required, the value for the above field to filter by.
       value: true,
-      // Whether this option will be selected on page load. Selected options stored in the url
+      // Optional, the label to show next to the filter option.
+      label: 'Open Now',
+      // Optional, whether this option will be selected on page load. Selected options stored in the url
       // take priority over appliedOnLoad. Defaults to false.
       appliedOnLoad: false
     },
     {
-      label: 'Dog Friendly',
       field: 'c_dogFriendly',
       value: true,
+      label: 'Dog Friendly',
       appliedOnLoad: true
     },
     {
-      label: 'Megastores',
       field: 'c_storeType',
-      value: 'Megastore'
+      value: 'Megastore',
+      label: 'Megastores'
     }
   ]
 }
@@ -1129,30 +1129,30 @@ The options config varies depending on whether the optionType is 'STATIC_FILTER'
 {    
   options: [
     {
-      // Label to show next to the filter option
-      label: '5 miles', 
-      // The value of the radius to apply (in meters). If this value is 0, will not filter by radius.
+      // Required, the value of the radius to apply (in meters). If this value is 0, will not filter by radius.
       value: 8046.72,
-      // Whether this option will be selected on page load. Selected options stored in the url
-      // will take priority over appliedOnLoad. Defaults to false.
+      // Optional, the label to show next to the filter option.
+      label: '5 miles',
+      // Optional, whether this option will be selected on page load. Selected options stored in the url
+      // take priority over appliedOnLoad. Defaults to false.
       appliedOnLoad: false
     },
     {
-      label: '10 miles',
       value: 16093.4,
+      label: '10 miles',
       appliedOnLoad: true
     },
     {
-      label: '25 miles',
-      value: 40233.6
+      value: 40233.6,
+      label: '25 miles'
     },
     { 
-      label: '50 miles',
-      value: 80467.2
+      value: 80467.2,
+      label: '50 miles'
     },
     {
-      label: "Do not filter by radius",
-      value: 0
+      value: 0,
+      label: "Do not filter by radius"
     }
   ],
 }

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -153,7 +153,8 @@ export default class Core {
         skipSpellCheck: this.globalStorage.getState('skipSpellCheck'),
         queryTrigger: this.globalStorage.getState('queryTrigger'),
         sessionTrackingEnabled: this.globalStorage.getState(StorageKeys.SESSIONS_OPT_IN),
-        sortBys: this.globalStorage.getState(StorageKeys.SORT_BYS)
+        sortBys: this.globalStorage.getState(StorageKeys.SORT_BYS),
+        locationRadius: this.globalStorage.getState(StorageKeys.LOCATION_RADIUS)
       })
       .then(response => SearchDataTransformer.transformVertical(response, this._fieldFormatters, verticalKey))
       .then(data => {
@@ -358,6 +359,21 @@ export default class Core {
 
   setStaticFilterNodes (namespace, filterNode) {
     this.filterRegistry.setStaticFilterNodes(namespace, filterNode);
+  }
+
+  /**
+   * Sets the locationRadius param for vertical searches.
+   * @param {number} locationRadius
+   */
+  setLocationRadius (locationRadius) {
+    this.globalStorage.set(StorageKeys.LOCATION_RADIUS, locationRadius);
+  }
+
+  /**
+   * Clears the locationRadius param for vertical searches.
+   */
+  clearLocationRadius () {
+    this.globalStorage.delete(StorageKeys.LOCATION_RADIUS);
   }
 
   enableDynamicFilters () {

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -140,6 +140,8 @@ export default class Core {
       this.globalStorage.delete(StorageKeys.SEARCH_OFFSET);
     }
 
+    const locationRadiusFilterNode = this.filterRegistry.getFilterNodeByKey(StorageKeys.LOCATION_RADIUS);
+
     return this._searcher
       .verticalSearch(verticalKey, {
         limit: this.globalStorage.getState(StorageKeys.SEARCH_CONFIG).limit,
@@ -154,7 +156,7 @@ export default class Core {
         queryTrigger: this.globalStorage.getState('queryTrigger'),
         sessionTrackingEnabled: this.globalStorage.getState(StorageKeys.SESSIONS_OPT_IN),
         sortBys: this.globalStorage.getState(StorageKeys.SORT_BYS),
-        locationRadius: this.filterRegistry.getLocationRadiusPayload()
+        locationRadius: locationRadiusFilterNode ? locationRadiusFilterNode.getFilter().value : null
       })
       .then(response => SearchDataTransformer.transformVertical(response, this._fieldFormatters, verticalKey))
       .then(data => {

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -154,7 +154,7 @@ export default class Core {
         queryTrigger: this.globalStorage.getState('queryTrigger'),
         sessionTrackingEnabled: this.globalStorage.getState(StorageKeys.SESSIONS_OPT_IN),
         sortBys: this.globalStorage.getState(StorageKeys.SORT_BYS),
-        locationRadius: this.globalStorage.getState(StorageKeys.LOCATION_RADIUS)
+        locationRadius: this.filterRegistry.getLocationRadiusPayload()
       })
       .then(response => SearchDataTransformer.transformVertical(response, this._fieldFormatters, verticalKey))
       .then(data => {
@@ -362,18 +362,18 @@ export default class Core {
   }
 
   /**
-   * Sets the locationRadius param for vertical searches.
-   * @param {number} locationRadius
+   * Sets the locationRadius filterNode.
+   * @param {FilterNode} filterNode
    */
-  setLocationRadius (locationRadius) {
-    this.globalStorage.set(StorageKeys.LOCATION_RADIUS, locationRadius);
+  setLocationRadiusFilterNode (filterNode) {
+    this.filterRegistry.setLocationRadiusFilterNode(filterNode);
   }
 
   /**
-   * Clears the locationRadius param for vertical searches.
+   * Clears the locationRadius filterNode.
    */
-  clearLocationRadius () {
-    this.globalStorage.delete(StorageKeys.LOCATION_RADIUS);
+  clearLocationRadiusFilterNode () {
+    this.filterRegistry.clearLocationRadiusFilterNode();
   }
 
   enableDynamicFilters () {

--- a/src/core/filters/filterregistry.js
+++ b/src/core/filters/filterregistry.js
@@ -49,7 +49,6 @@ export default class FilterRegistry {
   /**
    * Gets the filter string to send in a search query.
    * TODO: move payload method logic into core.js, since it is only used there.
-   * Add something like a getFilterNodeByKey method.
    * @returns {string}
    */
   getStaticFilterPayload () {
@@ -79,13 +78,11 @@ export default class FilterRegistry {
   }
 
   /**
-   * Gets the locationRadius to send in a search query.
-   * @returns {number}
+   * Get the FilterNode with the corresponding key. Defaults to null.
+   * @param {string} key
    */
-  getLocationRadiusPayload () {
-    const filterNode =
-      this.globalStorage.getState(`${this.filterRegistryId}.${StorageKeys.LOCATION_RADIUS}`);
-    return filterNode.getFilter().value;
+  getFilterNodeByKey (key) {
+    return this.globalStorage.getState(`${this.filterRegistryId}.${key}`);
   }
 
   /**

--- a/src/core/filters/filterregistry.js
+++ b/src/core/filters/filterregistry.js
@@ -48,6 +48,8 @@ export default class FilterRegistry {
 
   /**
    * Gets the filter string to send in a search query.
+   * TODO: move payload method logic into core.js, since it is only used there.
+   * Add something like a getFilterNodeByKey method.
    * @returns {string}
    */
   getStaticFilterPayload () {

--- a/src/core/filters/filterregistry.js
+++ b/src/core/filters/filterregistry.js
@@ -77,6 +77,16 @@ export default class FilterRegistry {
   }
 
   /**
+   * Gets the locationRadius to send in a search query.
+   * @returns {number}
+   */
+  getLocationRadiusPayload () {
+    const filterNode =
+      this.globalStorage.getState(`${this.filterRegistryId}.${StorageKeys.LOCATION_RADIUS}`);
+    return filterNode.getFilter().value;
+  }
+
+  /**
    * Sets the specified {@link FilterNode} under the given key.
    * Will replace a preexisting node if there is one.
    * @param {string} key
@@ -98,5 +108,14 @@ export default class FilterRegistry {
   setFacetFilterNodes (availableFieldIds = [], filterNodes = []) {
     this.availableFieldIds = availableFieldIds;
     this.globalStorage.set(`${this.filterRegistryId}.${StorageKeys.FACET_FILTER_NODE}`, filterNodes);
+  }
+
+  /**
+   * Sets the locationRadius filterNode. There may only be one locationRadius active
+   * at a time.
+   * @param {FilterNode} filterNode
+   */
+  setLocationRadiusFilterNode (filterNode) {
+    this.globalStorage.set(`${this.filterRegistryId}.${StorageKeys.LOCATION_RADIUS}`, filterNode);
   }
 }

--- a/src/core/models/filter.js
+++ b/src/core/models/filter.js
@@ -193,13 +193,6 @@ export default class Filter {
   }
 
   /**
-   * Create a new RADIUS_FILTER.
-   * @param {number} radius
-   */
-  static locationRadius (radius) {
-  }
-
-  /**
    * Create a new filter with the given matcher
    * @private
    * @param {string} field The subject field of the filter

--- a/src/core/models/filter.js
+++ b/src/core/models/filter.js
@@ -193,6 +193,16 @@ export default class Filter {
   }
 
   /**
+   * Create a new RADIUS_FILTER.
+   * @param {number} radius
+   */
+  static locationRadius (radius) {
+    return new Filter({
+      value: radius
+    });
+  }
+
+  /**
    * Create a new filter with the given matcher
    * @private
    * @param {string} field The subject field of the filter

--- a/src/core/models/filter.js
+++ b/src/core/models/filter.js
@@ -197,9 +197,6 @@ export default class Filter {
    * @param {number} radius
    */
   static locationRadius (radius) {
-    return new Filter({
-      value: radius
-    });
   }
 
   /**

--- a/src/core/search/searchapi.js
+++ b/src/core/search/searchapi.js
@@ -66,7 +66,7 @@ export default class SearchApi {
   }
 
   /** @inheritdoc */
-  verticalSearch (verticalKey, { input, filter, facetFilter, limit, offset, id, geolocation, isDynamicFiltersEnabled, skipSpellCheck, queryTrigger, sessionTrackingEnabled, sortBys }) {
+  verticalSearch (verticalKey, { input, filter, facetFilter, limit, offset, id, geolocation, isDynamicFiltersEnabled, skipSpellCheck, queryTrigger, sessionTrackingEnabled, sortBys, locationRadius }) {
     if (limit > 50) {
       throw new AnswersCoreError('Provided search limit unsupported', 'SearchApi');
     }
@@ -91,7 +91,8 @@ export default class SearchApi {
         'skipSpellCheck': skipSpellCheck,
         'queryTrigger': queryTrigger,
         'sessionTrackingEnabled': sessionTrackingEnabled,
-        'sortBys': sortBys
+        'sortBys': sortBys,
+        'locationRadius': locationRadius
       }
     };
     let request = new ApiRequest(requestConfig, { getState: () => sessionTrackingEnabled });

--- a/src/core/storage/storagekeys.js
+++ b/src/core/storage/storagekeys.js
@@ -31,5 +31,6 @@ export default {
   VERTICAL_PAGES_CONFIG: 'vertical-pages-config',
   LOCALE: 'locale',
   SORT_BYS: 'sort-bys',
-  NO_RESULTS_CONFIG: 'no-results-config'
+  NO_RESULTS_CONFIG: 'no-results-config',
+  LOCATION_RADIUS: 'location-radius'
 };

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -43,7 +43,7 @@ class FilterOptionsConfig {
      * The list of filter options to display with checked status
      * @type {object[]}
      */
-    this.options = config.options;
+    this.options = config.options.map(o => ({ ...o }));
 
     /**
      * The label to be used in the legend
@@ -146,12 +146,10 @@ class FilterOptionsConfig {
       let hasSeenSelectedOption = false;
       return options.map(o => {
         if (previousOptions.includes(o.label) && !hasSeenSelectedOption) {
-          o.selected = true;
           hasSeenSelectedOption = true;
-        } else {
-          o.selected = false;
+          return { ...o, selected: true };
         }
-        return o;
+        return { ...o, selected: false };
       });
     } else if (previousOptions && this.control === 'multioption') {
       return options.map(o => ({
@@ -162,11 +160,11 @@ class FilterOptionsConfig {
       let hasSeenSelectedOption = false;
       return options.map(o => {
         if (hasSeenSelectedOption) {
-          o.selected = false;
+          return { ...o, selected: false };
         } else if (o.selected) {
           hasSeenSelectedOption = true;
         }
-        return o;
+        return { ...o };
       });
     }
     return options;

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -142,7 +142,18 @@ class FilterOptionsConfig {
    * @returns {Array<Object>}
    */
   setSelectedOptions (options, previousOptions) {
-    if (previousOptions) {
+    if (previousOptions && this.control === 'singleoption') {
+      let hasSeenSelectedOption = false;
+      return options.map(o => {
+        if (previousOptions.includes(o.label) && !hasSeenSelectedOption) {
+          o.selected = true;
+          hasSeenSelectedOption = true;
+        } else {
+          o.selected = false;
+        }
+        return o;
+      });
+    } else if (previousOptions && this.control === 'multioption') {
       return options.map(o => ({
         ...o,
         selected: previousOptions.includes(o.label)
@@ -151,10 +162,7 @@ class FilterOptionsConfig {
       let hasSeenSelectedOption = false;
       return options.map(o => {
         if (hasSeenSelectedOption) {
-          return {
-            ...o,
-            selected: false
-          };
+          o.selected = false;
         } else if (o.selected) {
           hasSeenSelectedOption = true;
         }

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -353,11 +353,6 @@ export default class FilterOptionsComponent extends Component {
   }
 
   apply () {
-    const filterNode = this.getFilterNode();
-    this.core.setStaticFilterNodes(this.name, filterNode);
-  }
-
-  apply () {
     switch (this.config.optionType) {
       case OptionTypes.RADIUS_FILTER:
         const selectedOption = this.config.options.find(o => o.selected);
@@ -368,8 +363,8 @@ export default class FilterOptionsComponent extends Component {
         }
         break;
       case OptionTypes.STATIC_FILTER:
-        const filter = this._buildFilter();
-        this.core.setFilter(this.name, filter);
+        const filterNode = this.getFilterNode();
+        this.core.setStaticFilterNodes(this.name, filterNode);
         break;
       default:
         throw new AnswersComponentError(`Unknown optionType ${this.config.optionType}`, 'FilterOptions');

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -156,12 +156,11 @@ class FilterOptionsConfig {
    */
   setAppliedOnLoad (options) {
     if (this.control === 'singleoption') {
-      const _options = options.map(o => ({ ...o }));
-      const firstAppliedOption = _options.find(o => o.appliedOnLoad);
+      const firstAppliedOption = options.find(o => o.appliedOnLoad);
       if (firstAppliedOption) {
         firstAppliedOption.selected = true;
       }
-      return _options;
+      return options;
     }
     return options.map(o => ({
       ...o,

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -325,6 +325,11 @@ export default class FilterOptionsComponent extends Component {
     this.core.setStaticFilterNodes(this.name, filterNode);
   }
 
+  apply () {
+    const filter = this._buildFilter();
+    this.core.setFilter(this.name, filter);
+  }
+
   /**
    * Clear all options
    * TODO(oshi): Investigate removing this, this is not referenced anywhere,

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -129,35 +129,25 @@ class FilterOptionsConfig {
     }
     // previousOptions will be null if there were no previousOptions in persistentStorage
     const previousOptions = config.previousOptions;
-    if (previousOptions) {
-      this.options = this.setPreviousOptions(this.options, previousOptions || []);
-    } else {
-      this.options = this.setSelected(this.options);
-    }
+    this.options = this.setSelectedOptions(this.options, previousOptions);
   }
 
   /**
-   * Sets selected options on load based on options stored in persistent storage.
+   * Sets selected options on load based on options stored in persistent storage and options with selected: true.
+   * If no previous options were stored in persistentStorage, default to options marked
+   * as selected. If multiple options are marked as selected for 'singleoption', only the
+   * first should be selected.
    * @param {Array<Object>} options
    * @param {Array<string>} previousOptions
    * @returns {Array<Object>}
    */
-  setPreviousOptions (options, previousOptions) {
-    return options.map(o => ({
-      ...o,
-      selected: previousOptions.includes(o.label)
-    }));
-  }
-
-  /**
-   * If no previous options were stored in persistentStorage, default to options marked
-   * as selected. If multiple options are marked as selected for 'singleoption', only the
-   * first should be selected.
-   * @param {*} options
-   * @returns {Array<Object>}
-   */
-  setSelected (options) {
-    if (this.control === 'singleoption') {
+  setSelectedOptions (options, previousOptions) {
+    if (previousOptions) {
+      return options.map(o => ({
+        ...o,
+        selected: previousOptions.includes(o.label)
+      }));
+    } else if (this.control === 'singleoption') {
       let hasSeenSelectedOption = false;
       return options.map(o => {
         if (hasSeenSelectedOption) {

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -398,7 +398,7 @@ export default class FilterOptionsComponent extends Component {
     if (selectedOption.value !== 0) {
       return FilterNodeFactory.from({
         metadata: metadata,
-        filter: Filter.locationRadius(selectedOption.value)
+        filter: { value: selectedOption.value }
       });
     } else {
       return FilterNodeFactory.from({

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -353,16 +353,10 @@ export default class FilterOptionsComponent extends Component {
   apply () {
     switch (this.config.optionType) {
       case OptionTypes.RADIUS_FILTER:
-        const selectedOption = this.config.options.find(o => o.selected);
-        if (selectedOption && selectedOption.value !== 0) {
-          this.core.setLocationRadius(selectedOption.value);
-        } else {
-          this.core.clearLocationRadius();
-        }
+        this.core.setLocationRadiusFilterNode(this.getLocationRadiusFilterNode());
         break;
       case OptionTypes.STATIC_FILTER:
-        const filterNode = this.getFilterNode();
-        this.core.setStaticFilterNodes(this.name, filterNode);
+        this.core.setStaticFilterNodes(this.name, this.getFilterNode());
         break;
       default:
         throw new AnswersComponentError(`Unknown optionType ${this.config.optionType}`, 'FilterOptions');
@@ -390,6 +384,28 @@ export default class FilterOptionsComponent extends Component {
       fieldName: this.config.label,
       displayValue: option.label
     });
+  }
+
+  getLocationRadiusFilterNode () {
+    const selectedOption = this.config.options.find(o => o.selected);
+    if (!selectedOption) {
+      return FilterNodeFactory.from();
+    }
+    const metadata = new FilterMetadata({
+      fieldName: this.config.label,
+      displayValue: selectedOption.label
+    });
+    if (selectedOption.value !== 0) {
+      return FilterNodeFactory.from({
+        metadata: metadata,
+        filter: Filter.locationRadius(selectedOption.value)
+      });
+    } else {
+      return FilterNodeFactory.from({
+        metadata: metadata,
+        filter: Filter.empty()
+      });
+    }
   }
 
   /**

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -132,7 +132,7 @@ class FilterOptionsConfig {
     if (previousOptions) {
       this.options = this.setPreviousOptions(this.options, previousOptions || []);
     } else {
-      this.options = this.setAppliedOnLoad(this.options);
+      this.options = this.setSelected(this.options);
     }
   }
 
@@ -151,21 +151,27 @@ class FilterOptionsConfig {
 
   /**
    * If no previous options were stored in persistentStorage, default to options marked
-   * as appliedOnLoad.
+   * as selected. If multiple options are marked as selected for 'singleoption', only the
+   * first should be selected.
    * @param {*} options
+   * @returns {Array<Object>}
    */
-  setAppliedOnLoad (options) {
+  setSelected (options) {
     if (this.control === 'singleoption') {
-      const firstAppliedOption = options.find(o => o.appliedOnLoad);
-      if (firstAppliedOption) {
-        firstAppliedOption.selected = true;
-      }
-      return options;
+      let hasSeenSelectedOption = false;
+      return options.map(o => {
+        if (hasSeenSelectedOption) {
+          return {
+            ...o,
+            selected: false
+          };
+        } else if (o.selected) {
+          hasSeenSelectedOption = true;
+        }
+        return o;
+      });
     }
-    return options.map(o => ({
-      ...o,
-      selected: o.appliedOnLoad || o.selected
-    }));
+    return options;
   }
 
   getSelectedCount () {

--- a/tests/core/filters/filterregistry.js
+++ b/tests/core/filters/filterregistry.js
@@ -4,6 +4,7 @@ import FilterNodeFactory from '../../../src/core/filters/filternodefactory';
 import Facet from '../../../src/core/models/facet';
 import Filter from '../../../src/core/models/filter';
 import GlobalStorage from '../../../src/core/storage/globalstorage';
+import FilterMetadata from '../../../src/core/filters/filtermetadata';
 
 describe('FilterRegistry', () => {
   let node1, node2, filter1, filter2, registry;
@@ -149,5 +150,21 @@ describe('FilterRegistry', () => {
     expect(expectedFacet).toEqual(expectedFacetRaw);
     expect(registry.availableFieldIds).toEqual(['random_field', 'another_field']);
     expect(JSON.parse(registry.getFacetFilterPayload())).toEqual(JSON.parse(JSON.stringify(expectedFacet)));
+  });
+
+  it('can set locationRadius FilterNodes', () => {
+    const metadata = new FilterMetadata({
+      fieldName: 'label1',
+      displayValue: 'displayvalue1'
+    });
+    const filter = Filter.locationRadius(1234);
+    const filterNode = FilterNodeFactory.from({
+      metadata: metadata,
+      filter: filter
+    });
+    registry.setLocationRadiusFilterNode(filterNode);
+    expect(registry.getLocationRadiusPayload()).toEqual(1234);
+    registry.setLocationRadiusFilterNode(FilterNodeFactory.from());
+    expect(registry.getLocationRadiusPayload()).toBeUndefined();
   });
 });

--- a/tests/core/filters/filterregistry.js
+++ b/tests/core/filters/filterregistry.js
@@ -157,7 +157,9 @@ describe('FilterRegistry', () => {
       fieldName: 'label1',
       displayValue: 'displayvalue1'
     });
-    const filter = Filter.locationRadius(1234);
+    const filter = new Filter({
+      value: 1234
+    });
     const filterNode = FilterNodeFactory.from({
       metadata: metadata,
       filter: filter

--- a/tests/core/filters/filterregistry.js
+++ b/tests/core/filters/filterregistry.js
@@ -5,6 +5,7 @@ import Facet from '../../../src/core/models/facet';
 import Filter from '../../../src/core/models/filter';
 import GlobalStorage from '../../../src/core/storage/globalstorage';
 import FilterMetadata from '../../../src/core/filters/filtermetadata';
+import StorageKeys from '../../../src/core/storage/storagekeys';
 
 describe('FilterRegistry', () => {
   let node1, node2, filter1, filter2, registry;
@@ -165,8 +166,10 @@ describe('FilterRegistry', () => {
       filter: filter
     });
     registry.setLocationRadiusFilterNode(filterNode);
-    expect(registry.getLocationRadiusPayload()).toEqual(1234);
+    let locationRadiusFilterNode = registry.getFilterNodeByKey(StorageKeys.LOCATION_RADIUS);
+    expect(locationRadiusFilterNode.getFilter().value).toEqual(1234);
     registry.setLocationRadiusFilterNode(FilterNodeFactory.from());
-    expect(registry.getLocationRadiusPayload()).toBeUndefined();
+    locationRadiusFilterNode = registry.getFilterNodeByKey(StorageKeys.LOCATION_RADIUS);
+    expect(locationRadiusFilterNode).toEqual(FilterNodeFactory.from());
   });
 });

--- a/tests/ui/components/filters/filteroptionscomponent.js
+++ b/tests/ui/components/filters/filteroptionscomponent.js
@@ -230,7 +230,7 @@ describe('filter options component', () => {
   });
 });
 
-describe('filter options component selected options', () => {
+describe('filter options when setting selected options in config', () => {
   let COMPONENT_MANAGER, defaultConfig;
 
   beforeEach(() => {
@@ -311,7 +311,7 @@ describe('filter options component selected options', () => {
     expect(options.filter(o => o.selected)).toHaveLength(0);
   });
 
-  it('can choose selected options for multioption', () => {
+  it('properly sets selected options for multioption', () => {
     const config = {
       ...defaultConfig,
       control: 'multioption'
@@ -326,7 +326,7 @@ describe('filter options component selected options', () => {
     expect(selectedOptions[1].label).toEqual('label4');
   });
 
-  it('prioritizes previous options over selected config for multioption', () => {
+  it('prioritizes previously selected options over config\'s selected options for multioption', () => {
     const config = {
       ...defaultConfig,
       name: 'test-previous-options',
@@ -342,7 +342,7 @@ describe('filter options component selected options', () => {
     expect(selectedOptions[1].label).toEqual('label2');
   });
 
-  it('can choose selected option for singleoption', () => {
+  it('properly sets selected option for singleoption', () => {
     const config = {
       ...defaultConfig,
       control: 'singleoption'
@@ -356,7 +356,7 @@ describe('filter options component selected options', () => {
     expect(selectedOptions[0].label).toEqual('label3');
   });
 
-  it('prioritizes previous options over selected config for singleoption', () => {
+  it('prioritizes previously selected option over config\'s selected options for singleoption', () => {
     const config = {
       ...defaultConfig,
       name: 'test-previous-options',
@@ -372,7 +372,7 @@ describe('filter options component selected options', () => {
   });
 });
 
-describe('filter options component - works with different optionTypes', () => {
+describe('filter options works with different optionTypes', () => {
   let COMPONENT_MANAGER, defaultConfig, setLocationRadius, clearLocationRadius, setStaticFilterNodes;
 
   beforeEach(() => {

--- a/tests/ui/components/filters/filteroptionscomponent.js
+++ b/tests/ui/components/filters/filteroptionscomponent.js
@@ -8,6 +8,7 @@ import Filter from 'src/core/models/filter';
 describe('filter options component', () => {
   DOM.setup(document, new DOMParser());
   let COMPONENT_MANAGER, defaultConfig, setStaticFilterNodes;
+
   const options = [
     {
       label: 'ciri',
@@ -75,7 +76,7 @@ describe('filter options component', () => {
     defaultConfig = {
       container: '#test-component',
       control: 'singleoption',
-      options: [],
+      options: options,
       label: filterOptionsLabel
     };
   });
@@ -89,8 +90,7 @@ describe('filter options component', () => {
   it('renders correct number of options + show more with default showMoreLimit of 5', () => {
     const config = {
       ...defaultConfig,
-      control: 'multioption',
-      options: options
+      control: 'multioption'
     };
     const component = COMPONENT_MANAGER.create('FilterOptions', config);
     const wrapper = mount(component);
@@ -103,7 +103,6 @@ describe('filter options component', () => {
     const config = {
       ...defaultConfig,
       control: 'multioption',
-      options: options,
       showMoreLimit: options.length
     };
     const component = COMPONENT_MANAGER.create('FilterOptions', config);
@@ -116,7 +115,6 @@ describe('filter options component', () => {
     const config = {
       ...defaultConfig,
       control: 'multioption',
-      options: options,
       showMoreLimit: options.length
     };
     const component = COMPONENT_MANAGER.create('FilterOptions', config);
@@ -194,7 +192,6 @@ describe('filter options component', () => {
     const config = {
       ...defaultConfig,
       control: 'singleoption',
-      options: options,
       showMoreLimit: options.length
     };
     const component = COMPONENT_MANAGER.create('FilterOptions', config);
@@ -206,7 +203,6 @@ describe('filter options component', () => {
     const config = {
       ...defaultConfig,
       control: 'singleoption',
-      options: options,
       showMoreLimit: options.length
     };
     const component = COMPONENT_MANAGER.create('FilterOptions', config);
@@ -377,7 +373,7 @@ describe('filter options component selected options', () => {
 });
 
 describe('filter options component - works with different optionTypes', () => {
-  let COMPONENT_MANAGER, defaultConfig, setLocationRadius, clearLocationRadius, setFilter;
+  let COMPONENT_MANAGER, defaultConfig, setLocationRadius, clearLocationRadius, setStaticFilterNodes;
 
   beforeEach(() => {
     const bodyEl = DOM.query('body');
@@ -385,7 +381,7 @@ describe('filter options component - works with different optionTypes', () => {
     DOM.append(bodyEl, DOM.createEl('div', { id: 'test-component' }));
     setLocationRadius = jest.fn();
     clearLocationRadius = jest.fn();
-    setFilter = jest.fn();
+    setStaticFilterNodes = jest.fn();
 
     COMPONENT_MANAGER = mockManager(
       {
@@ -398,7 +394,7 @@ describe('filter options component - works with different optionTypes', () => {
         },
         setLocationRadius,
         clearLocationRadius,
-        setFilter
+        setStaticFilterNodes
       },
       FilterOptionsComponent.defaultTemplateName()
     );
@@ -422,11 +418,11 @@ describe('filter options component - works with different optionTypes', () => {
     };
 
     const component = COMPONENT_MANAGER.create('FilterOptions', config);
-    expect(setFilter.mock.calls).toHaveLength(0);
+    expect(setStaticFilterNodes.mock.calls).toHaveLength(0);
     expect(setLocationRadius.mock.calls).toHaveLength(0);
     expect(clearLocationRadius.mock.calls).toHaveLength(0);
     component.apply();
-    expect(setFilter.mock.calls).toHaveLength(1);
+    expect(setStaticFilterNodes.mock.calls).toHaveLength(1);
     expect(setLocationRadius.mock.calls).toHaveLength(0);
     expect(clearLocationRadius.mock.calls).toHaveLength(0);
   });
@@ -446,14 +442,38 @@ describe('filter options component - works with different optionTypes', () => {
     };
 
     const component = COMPONENT_MANAGER.create('FilterOptions', config);
-    expect(setFilter.mock.calls).toHaveLength(0);
+    expect(setStaticFilterNodes.mock.calls).toHaveLength(0);
     expect(setLocationRadius.mock.calls).toHaveLength(0);
     expect(clearLocationRadius.mock.calls).toHaveLength(0);
     component.apply();
-    expect(setFilter.mock.calls).toHaveLength(0);
+    expect(setStaticFilterNodes.mock.calls).toHaveLength(0);
     expect(setLocationRadius.mock.calls).toHaveLength(1);
     expect(setLocationRadius.mock.calls[0][0]).toEqual(12345);
     expect(clearLocationRadius.mock.calls).toHaveLength(0);
+  });
+
+  it('clears locationRadius when radius = 0', () => {
+    const config = {
+      ...defaultConfig,
+      control: 'singleoption',
+      optionType: 'RADIUS_FILTER',
+      options: [
+        {
+          label: 'le 0 metres',
+          value: 0,
+          selected: true
+        }
+      ]
+    };
+
+    const component = COMPONENT_MANAGER.create('FilterOptions', config);
+    expect(setStaticFilterNodes.mock.calls).toHaveLength(0);
+    expect(setLocationRadius.mock.calls).toHaveLength(0);
+    expect(clearLocationRadius.mock.calls).toHaveLength(0);
+    component.apply();
+    expect(setStaticFilterNodes.mock.calls).toHaveLength(0);
+    expect(setLocationRadius.mock.calls).toHaveLength(0);
+    expect(clearLocationRadius.mock.calls).toHaveLength(1);
   });
 
   it('throws error when trying to use multioption with RADIUS_FILTER', () => {

--- a/tests/ui/components/filters/filteroptionscomponent.js
+++ b/tests/ui/components/filters/filteroptionscomponent.js
@@ -450,7 +450,7 @@ describe('filter options works with different optionTypes', () => {
         fieldName: 'filterOptionsLabel',
         displayValue: '12345 meters'
       }),
-      filter: Filter.locationRadius(12345)
+      filter: new Filter({ value: 12345 })
     });
     expect(setLocationRadiusFilterNode.mock.calls[0][0]).toEqual(filterNode);
   });

--- a/tests/ui/components/filters/filteroptionscomponent.js
+++ b/tests/ui/components/filters/filteroptionscomponent.js
@@ -233,3 +233,243 @@ describe('filter options component', () => {
     expect(setStaticFilterNodes.mock.calls).toHaveLength(6);
   });
 });
+
+describe('filter options component selected options', () => {
+  let COMPONENT_MANAGER, defaultConfig;
+
+  beforeEach(() => {
+    const bodyEl = DOM.query('body');
+    DOM.empty(bodyEl);
+    DOM.append(bodyEl, DOM.createEl('div', { id: 'test-component' }));
+
+    COMPONENT_MANAGER = mockManager(
+      {
+        globalStorage: {
+          getState: key => {
+            if (key === 'test-previous-options') {
+              return ['label1', 'label2'];
+            }
+          },
+          delete: () => {}
+        }
+      },
+      FilterOptionsComponent.defaultTemplateName()
+    );
+
+    defaultConfig = {
+      container: '#test-component',
+      options: [
+        {
+          label: 'label1',
+          field: 'field',
+          value: 'val1'
+        },
+        {
+          label: 'label2',
+          field: 'field',
+          value: 'val2',
+          selected: false
+        },
+        {
+          label: 'label3',
+          field: 'field',
+          value: 'val3',
+          selected: true
+        },
+        {
+          label: 'label4',
+          field: 'field',
+          value: 'val4',
+          selected: true
+        }
+      ]
+    };
+  });
+
+  it('has no selected options by default', () => {
+    const config = {
+      ...defaultConfig,
+      control: 'singleoption',
+      options: [
+        {
+          label: 'label1',
+          field: 'field',
+          value: 'val1'
+        },
+        {
+          label: 'label2',
+          field: 'field',
+          value: 'val2'
+        },
+        {
+          label: 'label3',
+          field: 'field',
+          value: 'val3'
+        }
+      ]
+    };
+
+    const component = COMPONENT_MANAGER.create('FilterOptions', config);
+    const options = component.config.options;
+    expect(options).toHaveLength(3);
+    expect(options.filter(o => o.selected)).toHaveLength(0);
+  });
+
+  it('can choose selected options for multioption', () => {
+    const config = {
+      ...defaultConfig,
+      control: 'multioption'
+    };
+
+    const component = COMPONENT_MANAGER.create('FilterOptions', config);
+    const options = component.config.options;
+    expect(options).toHaveLength(4);
+    const selectedOptions = options.filter(o => o.selected);
+    expect(selectedOptions).toHaveLength(2);
+    expect(selectedOptions[0].label).toEqual('label3');
+    expect(selectedOptions[1].label).toEqual('label4');
+  });
+
+  it('prioritizes previous options over selected config for multioption', () => {
+    const config = {
+      ...defaultConfig,
+      name: 'test-previous-options',
+      control: 'multioption'
+    };
+
+    const component = COMPONENT_MANAGER.create('FilterOptions', config);
+    const options = component.config.options;
+    expect(options).toHaveLength(4);
+    const selectedOptions = options.filter(o => o.selected);
+    expect(selectedOptions).toHaveLength(2);
+    expect(selectedOptions[0].label).toEqual('label1');
+    expect(selectedOptions[1].label).toEqual('label2');
+  });
+
+  it('can choose selected option for singleoption', () => {
+    const config = {
+      ...defaultConfig,
+      control: 'singleoption'
+    };
+
+    const component = COMPONENT_MANAGER.create('FilterOptions', config);
+    const options = component.config.options;
+    expect(options).toHaveLength(4);
+    const selectedOptions = options.filter(o => o.selected);
+    expect(selectedOptions).toHaveLength(1);
+    expect(selectedOptions[0].label).toEqual('label3');
+  });
+
+  it('prioritizes previous options over selected config for singleoption', () => {
+    const config = {
+      ...defaultConfig,
+      name: 'test-previous-options',
+      control: 'singleoption'
+    };
+
+    const component = COMPONENT_MANAGER.create('FilterOptions', config);
+    const options = component.config.options;
+    expect(options).toHaveLength(4);
+    const selectedOptions = options.filter(o => o.selected);
+    expect(selectedOptions).toHaveLength(1);
+    expect(selectedOptions[0].label).toEqual('label1');
+  });
+});
+
+describe('filter options component - works with different optionTypes', () => {
+  let COMPONENT_MANAGER, defaultConfig, setLocationRadius, clearLocationRadius, setFilter;
+
+  beforeEach(() => {
+    const bodyEl = DOM.query('body');
+    DOM.empty(bodyEl);
+    DOM.append(bodyEl, DOM.createEl('div', { id: 'test-component' }));
+    setLocationRadius = jest.fn();
+    clearLocationRadius = jest.fn();
+    setFilter = jest.fn();
+
+    COMPONENT_MANAGER = mockManager(
+      {
+        globalStorage: {
+          getState: () => {},
+          delete: () => {}
+        },
+        persistentStorage: {
+          set: () => {}
+        },
+        setLocationRadius,
+        clearLocationRadius,
+        setFilter
+      },
+      FilterOptionsComponent.defaultTemplateName()
+    );
+
+    defaultConfig = {
+      container: '#test-component'
+    };
+  });
+
+  it('defaults to STATIC_FILTER', () => {
+    const config = {
+      ...defaultConfig,
+      control: 'singleoption',
+      options: [
+        {
+          label: 'label1',
+          field: 'field',
+          value: 'val1'
+        }
+      ]
+    };
+
+    const component = COMPONENT_MANAGER.create('FilterOptions', config);
+    expect(setFilter.mock.calls).toHaveLength(0);
+    expect(setLocationRadius.mock.calls).toHaveLength(0);
+    expect(clearLocationRadius.mock.calls).toHaveLength(0);
+    component.apply();
+    expect(setFilter.mock.calls).toHaveLength(1);
+    expect(setLocationRadius.mock.calls).toHaveLength(0);
+    expect(clearLocationRadius.mock.calls).toHaveLength(0);
+  });
+
+  it('works with RADIUS_FILTER', () => {
+    const config = {
+      ...defaultConfig,
+      control: 'singleoption',
+      optionType: 'RADIUS_FILTER',
+      options: [
+        {
+          label: '12345 meters',
+          value: 12345,
+          selected: true
+        }
+      ]
+    };
+
+    const component = COMPONENT_MANAGER.create('FilterOptions', config);
+    expect(setFilter.mock.calls).toHaveLength(0);
+    expect(setLocationRadius.mock.calls).toHaveLength(0);
+    expect(clearLocationRadius.mock.calls).toHaveLength(0);
+    component.apply();
+    expect(setFilter.mock.calls).toHaveLength(0);
+    expect(setLocationRadius.mock.calls).toHaveLength(1);
+    expect(setLocationRadius.mock.calls[0][0]).toEqual(12345);
+    expect(clearLocationRadius.mock.calls).toHaveLength(0);
+  });
+
+  it('throws error when trying to use multioption with RADIUS_FILTER', () => {
+    const config = {
+      ...defaultConfig,
+      control: 'multioption',
+      optionType: 'RADIUS_FILTER',
+      options: [
+        {
+          label: '12345 meters',
+          value: 12345,
+          selected: true
+        }
+      ]
+    };
+
+    expect(() => COMPONENT_MANAGER.create('FilterOptions', config)).toThrow();
+  });
+});

--- a/tests/ui/components/filters/filteroptionscomponent.js
+++ b/tests/ui/components/filters/filteroptionscomponent.js
@@ -4,6 +4,7 @@ import mockManager from '../../../setup/managermocker';
 import FilterOptionsComponent from 'src/ui/components/filters/filteroptionscomponent';
 import FilterNodeFactory from 'src/core/filters/filternodefactory';
 import Filter from 'src/core/models/filter';
+import FilterMetadata from 'src/core/filters/filtermetadata';
 
 describe('filter options component', () => {
   DOM.setup(document, new DOMParser());
@@ -373,14 +374,13 @@ describe('filter options when setting selected options in config', () => {
 });
 
 describe('filter options works with different optionTypes', () => {
-  let COMPONENT_MANAGER, defaultConfig, setLocationRadius, clearLocationRadius, setStaticFilterNodes;
+  let COMPONENT_MANAGER, defaultConfig, setLocationRadiusFilterNode, setStaticFilterNodes;
 
   beforeEach(() => {
     const bodyEl = DOM.query('body');
     DOM.empty(bodyEl);
     DOM.append(bodyEl, DOM.createEl('div', { id: 'test-component' }));
-    setLocationRadius = jest.fn();
-    clearLocationRadius = jest.fn();
+    setLocationRadiusFilterNode = jest.fn();
     setStaticFilterNodes = jest.fn();
 
     COMPONENT_MANAGER = mockManager(
@@ -392,15 +392,15 @@ describe('filter options works with different optionTypes', () => {
         persistentStorage: {
           set: () => {}
         },
-        setLocationRadius,
-        clearLocationRadius,
+        setLocationRadiusFilterNode,
         setStaticFilterNodes
       },
       FilterOptionsComponent.defaultTemplateName()
     );
 
     defaultConfig = {
-      container: '#test-component'
+      container: '#test-component',
+      label: 'filterOptionsLabel'
     };
   });
 
@@ -419,12 +419,10 @@ describe('filter options works with different optionTypes', () => {
 
     const component = COMPONENT_MANAGER.create('FilterOptions', config);
     expect(setStaticFilterNodes.mock.calls).toHaveLength(0);
-    expect(setLocationRadius.mock.calls).toHaveLength(0);
-    expect(clearLocationRadius.mock.calls).toHaveLength(0);
+    expect(setLocationRadiusFilterNode.mock.calls).toHaveLength(0);
     component.apply();
     expect(setStaticFilterNodes.mock.calls).toHaveLength(1);
-    expect(setLocationRadius.mock.calls).toHaveLength(0);
-    expect(clearLocationRadius.mock.calls).toHaveLength(0);
+    expect(setLocationRadiusFilterNode.mock.calls).toHaveLength(0);
   });
 
   it('works with RADIUS_FILTER', () => {
@@ -443,13 +441,18 @@ describe('filter options works with different optionTypes', () => {
 
     const component = COMPONENT_MANAGER.create('FilterOptions', config);
     expect(setStaticFilterNodes.mock.calls).toHaveLength(0);
-    expect(setLocationRadius.mock.calls).toHaveLength(0);
-    expect(clearLocationRadius.mock.calls).toHaveLength(0);
+    expect(setLocationRadiusFilterNode.mock.calls).toHaveLength(0);
     component.apply();
     expect(setStaticFilterNodes.mock.calls).toHaveLength(0);
-    expect(setLocationRadius.mock.calls).toHaveLength(1);
-    expect(setLocationRadius.mock.calls[0][0]).toEqual(12345);
-    expect(clearLocationRadius.mock.calls).toHaveLength(0);
+    expect(setLocationRadiusFilterNode.mock.calls).toHaveLength(1);
+    const filterNode = FilterNodeFactory.from({
+      metadata: new FilterMetadata({
+        fieldName: 'filterOptionsLabel',
+        displayValue: '12345 meters'
+      }),
+      filter: Filter.locationRadius(12345)
+    });
+    expect(setLocationRadiusFilterNode.mock.calls[0][0]).toEqual(filterNode);
   });
 
   it('clears locationRadius when radius = 0', () => {
@@ -468,12 +471,18 @@ describe('filter options works with different optionTypes', () => {
 
     const component = COMPONENT_MANAGER.create('FilterOptions', config);
     expect(setStaticFilterNodes.mock.calls).toHaveLength(0);
-    expect(setLocationRadius.mock.calls).toHaveLength(0);
-    expect(clearLocationRadius.mock.calls).toHaveLength(0);
+    expect(setLocationRadiusFilterNode.mock.calls).toHaveLength(0);
     component.apply();
     expect(setStaticFilterNodes.mock.calls).toHaveLength(0);
-    expect(setLocationRadius.mock.calls).toHaveLength(0);
-    expect(clearLocationRadius.mock.calls).toHaveLength(1);
+    expect(setLocationRadiusFilterNode.mock.calls).toHaveLength(1);
+    const filterNode = FilterNodeFactory.from({
+      metadata: new FilterMetadata({
+        fieldName: 'filterOptionsLabel',
+        displayValue: 'le 0 metres'
+      }),
+      filter: Filter.empty()
+    });
+    expect(setLocationRadiusFilterNode.mock.calls[0][0]).toEqual(filterNode);
   });
 
   it('throws error when trying to use multioption with RADIUS_FILTER', () => {


### PR DESCRIPTION
This commit adds a new config option for FilterOptions called optionType, which
can be either RADIUS_FILTER or STATIC_FILTER, defaulting to STATIC_FILTER which
is the original behavior. Filtering by radius is done by appending a new
locationRadius param to a query.

TEST=manual
Test Facets, FilterBox, FilterOptions
Facets: smoke test
FilterBox:
- check that regular STATIC_FILTER FilterBox still works, and can filter by distance
- check that reseting FilterBox then applying also clears the locationRadius
- check that works with searchOnChange (after fixing reset button init bug with #768 )

FilterOptions:
- check that defaults to STATIC_FILTER, throws helpful errors
when trying to use unrecognized optionType or trying to use multioption
with RADIUS_FILTER
- check that setting a value of 0 for RADIUS_FILTER clears locationRadius
- check that selected filter persists over page refresh
- check that can filter by locationRadius by searching "new york" under vertical key "people"
  locationRadius = 1 gives no results, locationRadius = 8046.72 = 1 result
- check that clicking the reset button in FilterOptions then searching again clears the 
  locationRadius