### PR TITLE
AnalyticsReporter: only send SCROLL_TO_BOTTOM_OF_PAGE when queryId ex…

### DIFF
--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -487,7 +487,9 @@ function initScrollListener (reporter) {
   const sendEvent = () => {
     if ((window.innerHeight + window.pageYOffset) >= document.body.scrollHeight) {
       const event = new AnalyticsEvent('SCROLL_TO_BOTTOM_OF_PAGE');
-      reporter.report(event);
+      if (reporter.getQueryId()) {
+        reporter.report(event);
+      }
     }
   };
 

--- a/src/core/analytics/analyticsreporter.js
+++ b/src/core/analytics/analyticsreporter.js
@@ -59,6 +59,10 @@ export default class AnalyticsReporter {
     }
   }
 
+  getQueryId () {
+    return this._globalOptions.queryId;
+  }
+
   setQueryId (queryId) {
     this._globalOptions.queryId = queryId;
   }


### PR DESCRIPTION
…ists

If queryId does not exist in the global event options,
SCROLL_TO_BOTTOM_OF_PAGE will 500.

T=320737
J=SPR-2193
TEST=manual

- w/ show allowEmptySearch: false for searchBar
  tested that on page with no results, which causes there to be no
  queryId (checked this too), before would fire the event and 500 but
  no longer does this

- after adding a query, check that event still fires without 500ing