### PR TITLE
Align clear button vertical for Chrome v83

### DIFF
--- a/src/ui/sass/modules/_SearchBar.scss
+++ b/src/ui/sass/modules/_SearchBar.scss
@@ -121,6 +121,7 @@ $searchbar-button-text-color-active: var(--yxt-searchbar-button-text-color-base)
   &-clear
   {
     display: flex;
+    align-items: center;
     font: inherit;
     padding-top: calc(var(--yxt-base-spacing) / 2);
     padding-bottom: calc(var(--yxt-base-spacing) / 2);


### PR DESCRIPTION
Fix visual bug where on Google Chrome v83 (latest Chrome) the clear
button on the search bar is top-aligned instead of center-aligned
within the search bar.

T=328286
TEST=manual

Local index.html file calling the SDK directly. Checked on
mobile/desktop on Chrome v83 to make sure everything was center aligned.

Checked latest Firefox, Safari, iOS, Android
Checked IE11 with manual fix on who site

Tested with magnifying glass and animated yext search icon.