### PR TITLE
Fix malformed calc in Card.scss

### DIFF
--- a/src/ui/sass/modules/_Card.scss
+++ b/src/ui/sass/modules/_Card.scss
@@ -1,4 +1,4 @@
-$cards-margin: calc(var(--yxt-base-spacing)) / 2 !default;
+$cards-margin: calc(var(--yxt-base-spacing) / 2) !default;
 
 :root {
   --yxt-cards-margin: #{$cards-margin};


### PR DESCRIPTION
Division of the css variables performed outside of the calc in Card.scss
for the margin. This caused the FAQ to not have spacing in between
cards.

J=None
TEST=manual

Tested on a new Jambo site referencing a local sdk dist (served through npm
serve package). Verified that the FAQ cards did not have spacing before
and have margin between them now.