### PR TITLE
add pin hover event functions for map component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1428,7 +1428,9 @@ ANSWERS.addComponent('Map', {
   // Optional, callback to invoke when a pin is clicked. The clicked item(s) are passed to the callback
   onPinClick: null,
   // Optional, callback to invoke when a pin is hovered. The clicked item(s) are passed to the callback
-  onPinHover: null,
+  onPinMouseOver: null,
+  // Optional, callback to invoke when a pin is no longer hovered after being hovered. The clicked item(s) are passed to the callback
+  onPinMouseOut: null,
   // Optional, callback to invoke once the Javascript is loaded
   onLoaded: function () {},
   // Optional, configuration for the map's behavior when a query returns no results

--- a/README.md
+++ b/README.md
@@ -1427,6 +1427,8 @@ ANSWERS.addComponent('Map', {
   showEmptyMap: false,
   // Optional, callback to invoke when a pin is clicked. The clicked item(s) are passed to the callback
   onPinClick: null,
+  // Optional, callback to invoke when a pin is hovered. The clicked item(s) are passed to the callback
+  onPinHover: null,
   // Optional, callback to invoke once the Javascript is loaded
   onLoaded: function () {},
   // Optional, configuration for the map's behavior when a query returns no results

--- a/src/ui/components/map/providers/googlemapprovider.js
+++ b/src/ui/components/map/providers/googlemapprovider.js
@@ -105,8 +105,11 @@ export default class GoogleMapProvider extends MapProvider {
           if (this._onPinClick) {
             marker.addListener('click', () => this._onPinClick(collapsedMarkers[i].item));
           }
-          if (this._onPinHover) {
-            marker.addListener('mouseover', () => this._onPinHover(collapsedMarkers[i].item));
+          if (this._onPinMouseOver) {
+            marker.addListener('mouseover', () => this._onPinMouseOver(collapsedMarkers[i].item));
+          }
+          if (this._onPinMouseOut) {
+            marker.addListener('mouseout', () => this._onPinMouseOut(collapsedMarkers[i].item));
           }
           bounds.extend(marker.position);
         }

--- a/src/ui/components/map/providers/googlemapprovider.js
+++ b/src/ui/components/map/providers/googlemapprovider.js
@@ -105,6 +105,9 @@ export default class GoogleMapProvider extends MapProvider {
           if (this._onPinClick) {
             marker.addListener('click', () => this._onPinClick(collapsedMarkers[i].item));
           }
+          if (this._onPinHover) {
+            marker.addListener('mouseover', () => this._onPinHover(collapsedMarkers[i].item));
+          }
           bounds.extend(marker.position);
         }
 

--- a/src/ui/components/map/providers/mapboxmapprovider.js
+++ b/src/ui/components/map/providers/mapboxmapprovider.js
@@ -79,6 +79,9 @@ export default class MapBoxMapProvider extends MapProvider {
         if (this._onPinClick) {
           marker.getElement().addEventListener('click', () => this._onPinClick(collapsedMarkers[i].item));
         }
+        if (this._onPinHover) {
+          marker.getElement().addEventListener('mouseover', () => this._onPinHover(collapsedMarkers[i].item));
+        }
       }
       if (mapboxMapMarkerConfigs.length >= 2) {
         this._map.fitBounds(bounds, { padding: 50 });

--- a/src/ui/components/map/providers/mapboxmapprovider.js
+++ b/src/ui/components/map/providers/mapboxmapprovider.js
@@ -79,8 +79,13 @@ export default class MapBoxMapProvider extends MapProvider {
         if (this._onPinClick) {
           marker.getElement().addEventListener('click', () => this._onPinClick(collapsedMarkers[i].item));
         }
-        if (this._onPinHover) {
-          marker.getElement().addEventListener('mouseover', () => this._onPinHover(collapsedMarkers[i].item));
+        if (this._onPinMouseOver) {
+          marker.getElement().addEventListener('mouseover', () =>
+            this._onPinMouseOver(collapsedMarkers[i].item));
+        }
+        if (this._onPinMouseOut) {
+          marker.getElement().addEventListener('mouseout', () =>
+            this._onPinMouseOut(collapsedMarkers[i].item));
         }
       }
       if (mapboxMapMarkerConfigs.length >= 2) {

--- a/src/ui/components/map/providers/mapprovider.js
+++ b/src/ui/components/map/providers/mapprovider.js
@@ -64,7 +64,14 @@ export default class MapProvider {
      * Callback to invoke when a pin is hovered. The hovered item is passed to the callback
      * @type {function}
      */
-    this._onPinHover= config.onPinHover || null;
+    this._onPinMouseOver = config.onPinMouseOver || null;
+
+    /**
+     * Callback to invoke when a pin is no longer hovered after being hovered.
+     * The hovered item is passed to the callback
+     * @type {function}
+     */
+    this._onPinMouseOut = config.onPinMouseOut || null;
 
     /**
      * Callback to invoke once the Javascript is loaded

--- a/src/ui/components/map/providers/mapprovider.js
+++ b/src/ui/components/map/providers/mapprovider.js
@@ -61,6 +61,12 @@ export default class MapProvider {
     this._onPinClick = config.onPinClick || null;
 
     /**
+     * Callback to invoke when a pin is hovered. The hovered item is passed to the callback
+     * @type {function}
+     */
+    this._onPinHover= config.onPinHover || null;
+
+    /**
      * Callback to invoke once the Javascript is loaded
      * @type {function}
      */


### PR DESCRIPTION
* add pin hover event functions for map component

Add a pin hover function option for the map component that will be
called on a mouseon event.  This function will be called with the
selected marker as a parameter (including the item's result data).

* rename function for pin mouse over and add mouse out for map component

Commonly, if a user wants to use hover events, they also want offhover
events (for example, to show and hide a modal). This allows the user to
provide mouse over and mouse out event handlers for pins on Google and
Mapbox for the Map component on verticals

J=SPR-2229
TEST=manual

Tested on a Jambo site sourcing a locally built SDK dist
Tested on a vertical-map vertical using Map component on
        - Google provider
        - Mapbox provider
Made sure hovered item was available to the on pin hover function.
Tested on Chrome,IE11