### PR TITLE
Support click analytics for RTF links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1835,10 +1835,13 @@ The Answers SDK exposes a `formatRichText` function which translates CommonMark 
 ensure that a Rich Text Formatted value is shown properly on the page. To use this function, call it like so:
 
 ```js
-ANSWERS.formatRichText(rtfFieldValue)
+ANSWERS.formatRichText(rtfFieldValue, eventOptionsFieldName)
 ```
 
-For instance, this function can be used in the `dataMappings` of a Card to display an RTF attribute. When using this function, you must ensure that the relevant Handlebars template correctly unescapes the value's resultant HTML.
+For instance, this function can be used in the `dataMappings` of a Card to display an RTF attribute. 
+
+When clicking any link in the resultant HTML, an `AnalyticsEvent` will be fired. If the `eventOptionsFieldName` has been
+specified, the `eventOptions` will include a `fieldName` attribute with the given value. Note that when using this function, you must ensure that the relevant Handlebars template correctly unescapes the output HTML.
 
 # CSS Variable Styling
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1865,9 +1865,9 @@
       "dev": true
     },
     "@yext/rtf-converter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@yext/rtf-converter/-/rtf-converter-1.0.0.tgz",
-      "integrity": "sha512-3h6roCRuOze40GdIXtCtXxi+xuBrFj10OMhbTr5utvWtjEBzjj7t3hzA2d5a1MvNm1zvKt2xhjBJgh09DQQtTw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@yext/rtf-converter/-/rtf-converter-1.1.1.tgz",
+      "integrity": "sha512-iPbLYRITyvFGF7JxEtcNatWImG5nrL7HshGZh7eOyVmZgcn1FABNyQO6idfJpj2SFb57nirftXA7AA2wE4yMSg==",
       "requires": {
         "markdown-it": "^10.0.0",
         "markdown-it-plugin-underline": "0.0.1"
@@ -7376,8 +7376,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7398,14 +7397,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7420,20 +7417,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7550,8 +7544,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7563,7 +7556,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7578,7 +7570,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7586,14 +7577,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7612,7 +7601,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7693,8 +7681,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7706,7 +7693,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7792,8 +7778,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7829,7 +7814,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7849,7 +7833,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7893,14 +7876,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -11303,9 +11284,9 @@
       },
       "dependencies": {
         "entities": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
-          "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw=="
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.2.tgz",
+          "integrity": "sha512-dmD3AvJQBUjKpcNkoqr+x+IF0SdRtPz9Vk0uTy4yWqga9ibB6s4v++QFWNohjiUGoMlF552ZvNyXDxz5iW0qmw=="
         }
       }
     },
@@ -11314,6 +11295,11 @@
       "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.2.4.tgz",
       "integrity": "sha512-n8zCGjxA3T+Mx1pG8HEgbJbkB8JFUuRkeTZQuIM8iPY6oQ8sWOPRZJDFC9a/pNg2QkHEjjGkhBEl/RSyzaDZ3A==",
       "dev": true
+    },
+    "markdown-it-for-inline": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-for-inline/-/markdown-it-for-inline-0.1.1.tgz",
+      "integrity": "sha1-Q18jFvW15o4UUM+iJC8rjVmtx18="
     },
     "markdown-it-plugin-underline": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -4,12 +4,13 @@
   "description": "Javascript Answers Programming Interface",
   "main": "gulpfile.js",
   "dependencies": {
-    "@yext/rtf-converter": "^1.0.0",
+    "@yext/rtf-converter": "^1.1.1",
     "core-js": "^3.6.5",
     "css-vars-ponyfill": "^2.3.1",
     "handlebars": "^4.7.2",
     "js-levenshtein": "^1.1.6",
     "kind-of": "^6.0.3",
+    "markdown-it-for-inline": "^0.1.1",
     "regenerator-runtime": "^0.13.3",
     "template-helpers": "^1.0.1"
   },

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -1,7 +1,6 @@
 /** @module */
 
 import Core from './core/core';
-import RtfConverter from '@yext/rtf-converter';
 import cssVars from 'css-vars-ponyfill';
 
 import {
@@ -16,7 +15,7 @@ import ConsoleErrorReporter from './core/errors/consoleerrorreporter';
 import { AnalyticsReporter, NoopAnalyticsReporter } from './core';
 import PersistentStorage from './ui/storage/persistentstorage';
 import GlobalStorage from './core/storage/globalstorage';
-import { AnswersComponentError, AnswersCoreError } from './core/errors/errors';
+import { AnswersComponentError } from './core/errors/errors';
 import AnalyticsEvent from './core/analytics/analyticsevent';
 import StorageKeys from './core/storage/storagekeys';
 import SearchConfig from './core/models/searchconfig';
@@ -30,6 +29,7 @@ import ComponentManager from './ui/components/componentmanager';
 import VerticalPagesConfig from './core/models/verticalpagesconfig';
 import { SANDBOX, PRODUCTION } from './core/constants';
 import MasterSwitchApi from './core/utils/masterswitchapi';
+import RichTextFormatter from './core/utils/richtextformatter';
 
 /** @typedef {import('./core/services/searchservice').default} SearchService */
 /** @typedef {import('./core/services/autocompleteservice').default} AutoCompleteService */
@@ -81,14 +81,8 @@ class Answers {
      * A reference to the formatRichText function.
      * @type {Function}
      */
-    this.formatRichText = (markdown) => {
-      if (typeof markdown !== 'string') {
-        throw new AnswersCoreError(
-          `Rich text "${markdown}" needs to be a string. Currently is a ${typeof markdown}`
-        );
-      }
-      return RtfConverter.toHTML(markdown);
-    };
+    this.formatRichText = (markdown, eventOptionsFieldName) =>
+      RichTextFormatter.format(markdown, eventOptionsFieldName);
 
     /**
      * A local reference to the component manager

--- a/src/core/utils/richtextformatter.js
+++ b/src/core/utils/richtextformatter.js
@@ -1,0 +1,57 @@
+import iterator from 'markdown-it-for-inline';
+import RtfConverter from '@yext/rtf-converter';
+import { AnswersCoreError } from '../errors/errors';
+
+/**
+ * This class leverages the {@link RtfConverter} library to perform Rich Text to
+ * HTML conversions.
+ */
+class RichTextFormatterImpl {
+  constructor () {
+    RtfConverter.addPlugin(iterator, 'url_new_win', 'link_open', this._urlTransformer);
+  }
+
+  /**
+   * Generates an HTML representation of the provided Rich Text field value. Note that
+   * the HTML will contain a wrapper div. This is to support click analytics for Rich Text
+   * links.
+   *
+   * @param {string} fieldValue A Rich Text field value.
+   * @param {string} fieldName The name of the field, to be included in the payload of a click
+   *                           analytics event. This parameter is optional.
+   * @returns {string} The HTML representation of the field value, serialized as a string.
+   */
+  format (fieldValue, fieldName) {
+    if (typeof fieldValue !== 'string') {
+      throw new AnswersCoreError(
+        `Rich text "${fieldValue}" needs to be a string. Currently is a ${typeof fieldValue}`
+      );
+    }
+
+    fieldName = fieldName || '';
+    const html =
+      `<div class="js-yxt-rtfValue" data-field-name="${fieldName}">\n` +
+      `${RtfConverter.toHTML(fieldValue)}` +
+      '</div>';
+    return html;
+  }
+
+  /**
+   * An inline token parser for use with the {@link iterator} Markdown-it plugin.
+   * This token parser adds a cta-type data attribute to any link it encounters.
+   */
+  _urlTransformer (tokens, idx) {
+    const href = tokens[idx].attrGet('href');
+    let ctaType = 'VIEW_WEBSITE';
+    if (href.startsWith('mailto')) {
+      ctaType = 'EMAIL';
+    } else if (href.startsWith('tel')) {
+      ctaType = 'TAP_TO_CALL';
+    }
+    tokens[idx].attrPush(['data-cta-type', ctaType]);
+  }
+}
+
+const RichTextFormatter = new RichTextFormatterImpl();
+
+export default RichTextFormatter;

--- a/src/ui/components/cards/cardcomponent.js
+++ b/src/ui/components/cards/cardcomponent.js
@@ -1,7 +1,9 @@
 /** @module CardComponent */
 
 import Component from '../component';
+import DOM from '../../dom/dom';
 import { cardTypes } from './consts';
+import AnalyticsEvent from '../../../core/analytics/analyticsevent';
 
 class CardConfig {
   constructor (config = {}) {
@@ -64,11 +66,53 @@ export default class CardComponent extends Component {
     this.verticalKey = data.verticalKey;
   }
 
+  onMount () {
+    const rtfElement = DOM.query(this._container, '.js-yxt-rtfValue');
+    if (rtfElement) {
+      const fieldName = rtfElement.dataset.fieldName;
+      DOM.on(rtfElement, 'click', e => this._handleRtfClickAnalytics(e, fieldName));
+    }
+  }
+
+  /**
+   * A click handler for links in a Rich Text attriubte. When such a link is
+   * clicked, an {@link AnalyticsEvent} needs to be fired.
+   *
+   * @param {Event} event The click event.
+   * @param {string} fieldName The name of the Rich Text field used in the
+   *                           attriubte.
+   */
+  _handleRtfClickAnalytics (event, fieldName) {
+    if (!event.target.dataset.ctaType) {
+      return;
+    }
+    const ctaType = event.target.dataset.ctaType;
+
+    const analyticsOptions = {
+      directAnswer: false,
+      verticalKey: this._config.data.verticalKey,
+      searcher: this._config.isUniversal ? 'UNIVERSAL' : 'VERTICAL',
+      entityId: this._config.data.result.id
+    };
+    if (ctaType !== 'TAP_TO_CALL') {
+      analyticsOptions.url = event.target.href;
+    }
+    if (!fieldName) {
+      console.warn('Field name not provided for RTF click analytics');
+    } else {
+      analyticsOptions.fieldName = fieldName;
+    }
+
+    const analyticsEvent = new AnalyticsEvent(ctaType);
+    analyticsEvent.addOptions(analyticsOptions);
+    this.analyticsReporter.report(analyticsEvent);
+  }
+
   setState (data) {
     const cardType = this._config.cardType;
 
     // Use the cardType as component name if it is not a built-in type
-    let cardComponentName = cardTypes[cardType] || cardType;
+    const cardComponentName = cardTypes[cardType] || cardType;
     return super.setState({
       ...data,
       result: this.result,

--- a/src/ui/components/cards/cardcomponent.js
+++ b/src/ui/components/cards/cardcomponent.js
@@ -78,15 +78,15 @@ export default class CardComponent extends Component {
    * A click handler for links in a Rich Text attriubte. When such a link is
    * clicked, an {@link AnalyticsEvent} needs to be fired.
    *
-   * @param {Event} event The click event.
+   * @param {MouseEvent} event The click event.
    * @param {string} fieldName The name of the Rich Text field used in the
    *                           attriubte.
    */
   _handleRtfClickAnalytics (event, fieldName) {
-    if (!event.target.dataset.ctaType) {
+    const ctaType = event.target.dataset.ctaType;
+    if (!ctaType) {
       return;
     }
-    const ctaType = event.target.dataset.ctaType;
 
     const analyticsOptions = {
       directAnswer: false,

--- a/src/ui/components/results/directanswercomponent.js
+++ b/src/ui/components/results/directanswercomponent.js
@@ -115,7 +115,7 @@ export default class DirectAnswerComponent extends Component {
    * A click handler for links in a Rich Text Direct Answer. When such a link
    * is clicked, an {@link AnalyticsEvent} needs to be fired.
    *
-   * @param {Event} event The click event.
+   * @param {MouseEvent} event The click event.
    */
   _handleRtfClickAnalytics (event) {
     if (!event.target.dataset.ctaType) {

--- a/src/ui/components/results/directanswercomponent.js
+++ b/src/ui/components/results/directanswercomponent.js
@@ -93,8 +93,8 @@ export default class DirectAnswerComponent extends Component {
 
     // For WCAG compliance, the feedback should be a submittable form
     DOM.on(this._formEl, 'submit', (e) => {
-      let formEl = e.target;
-      let checkedValue = DOM.query(formEl, 'input:checked').value === 'true';
+      const formEl = e.target;
+      const checkedValue = DOM.query(formEl, 'input:checked').value === 'true';
 
       this.reportQuality(checkedValue);
       this.updateState({
@@ -106,6 +106,38 @@ export default class DirectAnswerComponent extends Component {
     // submit button is hidden.
     DOM.on(this._thumbsUpSelector, 'click', () => { DOM.trigger(this._formEl, 'submit'); });
     DOM.on(this._thumbsDownSelector, 'click', () => { DOM.trigger(this._formEl, 'submit'); });
+
+    const rtfElement = DOM.query(this._container, '.js-yxt-rtfValue');
+    rtfElement && DOM.on(rtfElement, 'click', e => this._handleRtfClickAnalytics(e));
+  }
+
+  /**
+   * A click handler for links in a Rich Text Direct Answer. When such a link
+   * is clicked, an {@link AnalyticsEvent} needs to be fired.
+   *
+   * @param {Event} event The click event.
+   */
+  _handleRtfClickAnalytics (event) {
+    if (!event.target.dataset.ctaType) {
+      return;
+    }
+    const ctaType = event.target.dataset.ctaType;
+
+    const relatedItem = this.getState('relatedItem');
+    const analyticsOptions = {
+      verticalKey: relatedItem.verticalConfigId,
+      directAnswer: true,
+      fieldName: this.getState('answer').fieldApiName,
+      searcher: 'UNIVERSAL',
+      entityId: relatedItem.data.id
+    };
+    if (ctaType !== 'TAP_TO_CALL') {
+      analyticsOptions.url = event.target.href;
+    }
+
+    const analyticsEvent = new AnalyticsEvent(ctaType);
+    analyticsEvent.addOptions(analyticsOptions);
+    this.analyticsReporter.report(analyticsEvent);
   }
 
   /**

--- a/tests/core/utils/richtextformatter.js
+++ b/tests/core/utils/richtextformatter.js
@@ -1,0 +1,29 @@
+import RichTextFormatter from '../../../src/core/utils/richtextformatter';
+
+describe('formats rich text to HTML', () => {
+  it('adds correct data attributes for links', () => {
+    const richText =
+        '**I AM BOLD** now I am not *I AM ITALICS* now I am not ++BRASAAAAAP++\n\n' +
+        '* ++I am underline list++\n\n' +
+        '1. ++I am number list++\n' +
+        '2. ++[I am link to site](http://olivershi.io)++\n\n' +
+        '++[url link](http://google.com)++\n\n' +
+        '++[phone link](tel:+17326183404)++\n\n' +
+        '++[email link](mailto:oshi@yext.com)++\n';
+    const expectedHTML =
+        '<div class="js-yxt-rtfValue" data-field-name="someField">\n' +
+        '<p><strong>I AM BOLD</strong> now I am not <em>I AM ITALICS</em> now I am not <u>BRASAAAAAP</u></p>\n' +
+        '<ul>\n' +
+        '<li><u>I am underline list</u></li>\n' +
+        '</ul>\n' +
+        '<ol>\n' +
+        '<li><u>I am number list</u></li>\n' +
+        '<li><u><a href="http://olivershi.io" data-cta-type="VIEW_WEBSITE">I am link to site</a></u></li>\n' +
+        '</ol>\n' +
+        '<p><u><a href="http://google.com" data-cta-type="VIEW_WEBSITE">url link</a></u></p>\n' +
+        '<p><u><a href="tel:+17326183404" data-cta-type="TAP_TO_CALL">phone link</a></u></p>\n' +
+        '<p><u><a href="mailto:oshi@yext.com" data-cta-type="EMAIL">email link</a></u></p>\n' +
+        '</div>';
+    expect(RichTextFormatter.format(richText, 'someField')).toEqual(expectedHTML);
+  });
+});


### PR DESCRIPTION
This PR adds click analytics for links in a formatted RTF value. Note that such
values occur only in Cards or the DirectAnswers component. Now, when the
formatRichText function is called, it places a wrapper div around the newly
formatted RTF value. A 'cta-type' data attribute is also added to all links
in the value. Click events from the links are bubbled up to this wrapper div
and handled in both the CardComponent and DirectAnswersComponent classes.

The adding of the 'cta-type' attribute is handled by the markdown-it-for-inline
plugin.

Right now, we only support one RTF formatted value per Card. The solution in
this PR can be easily extended to support multiple RTF values in the future.
Some room for future improvement would be to add classes to the links in
formatRichText. This would allow us to write click handlers for the links
directly, instead of having the container div around the entire formatted RTF
value. Unfortunately, it seems the markdown-it-for-inline plugin does not
support this functionality currently.

J=SPR-2232
TEST=auto, manual

Added unit tests for the new RichTextFormatter class. Manually tested the
following scenarios for DirectAnswers and Cards (Vertical and Universal):

- Clicking outside a link, in the formatted value, does nothing.
- Clicking a phone-type link in the formatted value works as expected and
  issues the correct AnalyticsEvent.
- Clicking an email-type link in the formatted value works as expected and
  issues the correct AnalyticsEvent.
- Clicking a normal link in the formatted value works as expected and issues
  the correct AnalyticsEvent.
- For cards, verified that if no eventOptionsFieldName is specified,
  clicking a link would produce an Analytics event without fieldName. A warning
  would also be displayed in the console.