### PR TITLE
change circleci resource class to large for unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,7 @@ jobs:
   unit_test:
     docker:
       - image: circleci/node:7.10
+    resource_class: large
     working_directory: ~/answers
     steps:
       - setup-workspace


### PR DESCRIPTION
This is necessary for unit tests to run correctly for pull requests.
Otherwise we get errors

    Call retries were exceeded
      at ChildProcessWorker.initialize (node_modules/jest-worker/build/workers/ChildProcessWorker.js:193:21)

J=None
TEST=manual

Copying this from the branch where it is working, v1.4.0