### PR TITLE
FilterOptions: fix showMoreLimit for single-option

### DIFF
--- a/src/ui/components/filters/filterboxcomponent.js
+++ b/src/ui/components/filters/filterboxcomponent.js
@@ -187,6 +187,8 @@ export default class FilterBoxComponent extends Component {
     }
 
     // Initialize filters from configs
+    // TODO: the FilterOptions config, which is more specific, should probably
+    // take priority over the FilterBox config. This is not the case below.
     for (let i = 0; i < this.config.filterConfigs.length; i++) {
       const config = this.config.filterConfigs[i];
       const component = this.componentManager.create(config.type, Object.assign({},

--- a/src/ui/templates/controls/filteroptions.hbs
+++ b/src/ui/templates/controls/filteroptions.hbs
@@ -48,7 +48,7 @@
     <div class='yxt-FilterOptions-options'>
       {{#each options}}
         {{#if ../isSingleOption}}
-          <div class="singleoption-option yxt-FilterOptions-option">
+          <div class="singleoption-option yxt-FilterOptions-option js-yxt-FilterOptions-option{{#if (and ../showMore (gte @index ../showMoreLimit))}} js-yxt-FilterOptions-aboveShowMoreLimit hidden{{/if}}">
             <input
               type="radio"
               class="js-yext-filter-option yxt-FilterOptions-input"
@@ -57,7 +57,7 @@
               value="{{value}}"
               data-index="{{@index}}"
               {{#if selected}}checked{{/if}}>
-            <label class="singleoption-label" for="js-yext-radio-{{../name}}-{{@index}}">
+            <label class="singleoption-label" for="js-yext-radio-{{../name}}-{{@index}} js-yxt-FilterOptions-optionLabel">
               <span class="yxt-FilterOptions-optionLabel--name js-yxt-FilterOptions-optionLabel--name">
                 {{label}}
               </span>
@@ -67,7 +67,7 @@
             </label>
           </div>
         {{else}}
-          <div class="multioption-option yxt-FilterOptions-option js-yxt-FilterOptions-option{{#if (gte @index ../showMoreLimit)}} js-yxt-FilterOptions-aboveShowMoreLimit hidden{{/if}}">
+          <div class="multioption-option yxt-FilterOptions-option js-yxt-FilterOptions-option{{#if (and ../showMore (gte @index ../showMoreLimit))}} js-yxt-FilterOptions-aboveShowMoreLimit hidden{{/if}}">
             <input
               type="checkbox"
               class="js-yext-filter-option yxt-FilterOptions-input yxt-FilterOptions-checkboxInput js-yxt-FilterOptions-checkboxInput"

--- a/tests/ui/components/filters/filteroptionscomponent.js
+++ b/tests/ui/components/filters/filteroptionscomponent.js
@@ -140,6 +140,66 @@ describe('filter options component', () => {
     }
   });
 
+  describe('hides options if the number of options exceeds the show more limit', () => {
+    it('works for singleoption', () => {
+      const config = {
+        ...defaultConfig,
+        control: 'singleoption',
+        showMoreLimit: 2
+      };
+      const component = COMPONENT_MANAGER.create('FilterOptions', config);
+      const wrapper = mount(component);
+      const displayedOptions = wrapper.find('.singleoption-option:not(.hidden)');
+      const hiddenOptions = wrapper.find('.singleoption-option.hidden');
+      expect(displayedOptions).toHaveLength(2);
+      expect(hiddenOptions).toHaveLength(4);
+    });
+
+    it('works for multioption', () => {
+      const config = {
+        ...defaultConfig,
+        control: 'multioption',
+        showMoreLimit: 2
+      };
+      const component = COMPONENT_MANAGER.create('FilterOptions', config);
+      const wrapper = mount(component);
+      const displayedOptions = wrapper.find('.multioption-option:not(.hidden)');
+      const hiddenOptions = wrapper.find('.multioption-option.hidden');
+      expect(displayedOptions).toHaveLength(2);
+      expect(hiddenOptions).toHaveLength(4);
+    });
+
+    it('ignores showMoreLimit if showMore is false (singleoption)', () => {
+      const config = {
+        ...defaultConfig,
+        control: 'singleoption',
+        showMore: false,
+        showMoreLimit: 2
+      };
+      const component = COMPONENT_MANAGER.create('FilterOptions', config);
+      const wrapper = mount(component);
+      const displayedOptions = wrapper.find('.singleoption-option:not(.hidden)');
+      const hiddenOptions = wrapper.find('.singleoption-option.hidden');
+      expect(displayedOptions).toHaveLength(6);
+      expect(hiddenOptions).toHaveLength(0);
+    });
+
+    it('ignores showMoreLimit if showMore is false (singleoption)', () => {
+      const config = {
+        ...defaultConfig,
+        control: 'multioption',
+        showMore: false,
+        showMoreLimit: 2
+      };
+      const component = COMPONENT_MANAGER.create('FilterOptions', config);
+      const wrapper = mount(component);
+      const displayedOptions = wrapper.find('.multioption-option:not(.hidden)');
+      const hiddenOptions = wrapper.find('.multioption-option.hidden');
+      expect(displayedOptions).toHaveLength(6);
+      expect(hiddenOptions).toHaveLength(0);
+    });
+  });
+
   describe('can create filter nodes', () => {
     let config;
 


### PR DESCRIPTION
The template was not giving single-options the hidden
css class if they were over the showMoreLimit. It was
also giving the hidden class even if config.showMore was
false. Also added 2 js classes when the control is singleoption
to match multioption.

QA=v1.4.0 no. 5
TEST=manual,auto
Test that showMoreLimit works for both multioption and singleoption
inside a FilterBox
Test that works when showMore is true, false, and unset