### PR TITLE
Pagination: add missing --yxt-pagination-color-hover variable

### DIFF
--- a/src/ui/sass/modules/_Pagination.scss
+++ b/src/ui/sass/modules/_Pagination.scss
@@ -15,6 +15,7 @@ $pagination-color-hover: var(--yxt-color-text-secondary) !default;
   --yxt-pagination-text-line-height: #{$pagination-text-line-height};
   --yxt-pagination-text-font-weight: #{$pagination-text-font-weight};
   --yxt-pagination-color-active-page: #{$pagination-color-active-page};
+  --yxt-pagination-color-hover: #{$pagination-color-hover};
 }
 
 .yxt-Pagination


### PR DESCRIPTION
This css var was being referenced but not initialized. This was probably
missed during a rebase. Now there are 7 sass variables and 7 matching scss variables.

TEST=manual
test that background color for pagination on hover is not white anymore