### PR TITLE
FilterOptions, Facets: Add searchLabelText as an aria label for form input

### DIFF
--- a/README.md
+++ b/README.md
@@ -977,6 +977,8 @@ ANSWERS.addComponent('Facets', {
   placeholderText: 'Search here...',
   // Optional, if true, display the filter option search input
   searchable: false,
+  // Optional, the form label text for the search input, defaults to 'Search for a filter option'
+  searchLabelText: 'Search for a filter option',
   // Optional, field-specific overrides for a filter
   fields: {
     'c_customFieldName':  { // Field id to override e.g. c_customFieldName, buildin.location
@@ -1112,6 +1114,8 @@ ANSWERS.addComponent('FilterOptions', {
   placeholderText: 'Search here...',
   // Optional, if true, display the filter option search input
   searchable: false,
+  // Optional, the form label text for the search input, defaults to 'Search for a filter option'
+  searchLabelText: 'Search for a filter option',
 });
 ```
 

--- a/src/ui/components/filters/facetscomponent.js
+++ b/src/ui/components/filters/facetscomponent.js
@@ -113,6 +113,12 @@ class FacetsConfig {
     this.searchable = config.searchable || false;
 
     /**
+     * The form label text for the search input
+     * @type {boolean}
+     */
+    this.searchLabelText = config.searchLabelText || 'Search for a filter option';
+
+    /**
      * An object that maps field API names to their filter options overrides,
      * which have the same keys as the config options in FilterOptions component.
      * @type {Object}
@@ -217,6 +223,7 @@ export default class FacetsComponent extends Component {
         type: 'FilterOptions',
         control: this.config.fieldControls[f.fieldId] || 'multioption',
         searchable: this.config.searchable,
+        searchLabelText: this.config.searchLabelText,
         placeholderText: this.config.placeholderText,
         ...fieldOverrides
       });

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -141,6 +141,12 @@ class FilterOptionsConfig {
      */
     this.searchable = config.searchable || false;
 
+    /**
+     * The form label text for the search input
+     * @type {boolean}
+     */
+    this.searchLabelText = config.searchLabelText || 'Search for a filter option';
+
     this.validate();
 
     if (typeof config.previousOptions === 'string') {

--- a/src/ui/templates/controls/filteroptions.hbs
+++ b/src/ui/templates/controls/filteroptions.hbs
@@ -42,7 +42,7 @@
       {{/if}}
 
     {{#if searchable}}
-      <input type="text" class="yxt-FilterOptions-filter js-yxt-FilterOptions-filter" placeholder="{{placeholderText}}">
+      <input type="text" class="yxt-FilterOptions-filter js-yxt-FilterOptions-filter" aria-label="{{searchLabelText}}" placeholder="{{placeholderText}}">
     {{/if}}
     </div>
     <div class='yxt-FilterOptions-options'>


### PR DESCRIPTION
TEST=manual

On local test site, configure searchable facets before change. Run the Wave chrome plugin, see error. Test after change with no searchLabelText. Run the Wave chrome plugin, see error resolved. Add searchLabelText to config. In browser, inspect DOM and see updated aria-label.