### PR TITLE
FilterOptions: Add clear button to searchable options

### DIFF
--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -342,30 +342,41 @@ export default class FilterOptionsComponent extends Component {
       const filterOptionEls = DOM.queryAll(this._container, '.js-yxt-FilterOptions-option');
       const filterContainerEl = DOM.query(this._container, '.js-yxt-FilterOptions-container');
 
-      // On clearSearchEl click, clear search
+      // On clearSearchEl click, clear search input
       if (clearSearchEl && searchInputEl) {
         DOM.on(clearSearchEl, 'click', event => {
           searchInputEl.value = '';
+          searchInputEl.dispatchEvent(new Event('input', {
+            'bubbles': true,
+            'cancelable': true
+          }));
           searchInputEl.focus();
-          this._clearFilterStyling(filterOptionEls, filterContainerEl, clearSearchEl);
         });
       }
 
       DOM.on(
         searchInputEl,
-        'keyup',
+        'input',
         event => {
           const filter = event.target.value;
 
           if (!filter) {
-            this._clearFilterStyling(filterOptionEls, filterContainerEl, clearSearchEl);
+            filterContainerEl.classList.remove('yxt-FilterOptions-container--searching');
+            clearSearchEl.classList.add('js-hidden');
           } else {
             filterContainerEl.classList.add('yxt-FilterOptions-container--searching');
             clearSearchEl.classList.remove('js-hidden');
-            // Filter/unfilter options
-            for (let filterOption of filterOptionEls) {
-              const labelEl = DOM.query(filterOption, '.js-yxt-FilterOptions-optionLabel--name');
-              const labelText = this._getOptionLabelText(labelEl);
+          }
+
+          for (let filterOption of filterOptionEls) {
+            const labelEl = DOM.query(filterOption, '.js-yxt-FilterOptions-optionLabel--name');
+            let labelText = labelEl.textContent || labelEl.innerText || '';
+            labelText = labelText.trim();
+            if (!filter) {
+              filterOption.classList.remove('hiddenSearch');
+              filterOption.classList.remove('displaySearch');
+              labelEl.innerHTML = labelText;
+            } else {
               let matchedSubstring = this._getMatchedSubstring(labelText.toLowerCase(), filter.toLowerCase());
               if (matchedSubstring) {
                 filterOption.classList.add('displaySearch');
@@ -409,33 +420,6 @@ export default class FilterOptionsComponent extends Component {
           }
         });
     }
-  }
-
-  /**
-   * Returns label of a given filter option
-   * @returns {string}
-   * @private
-   */
-  _clearFilterStyling (filterOptionEls, filterContainerEl, clearSearchEl) {
-    filterContainerEl.classList.remove('yxt-FilterOptions-container--searching');
-
-    for (let option of filterOptionEls) {
-      const labelEl = DOM.query(option, '.js-yxt-FilterOptions-optionLabel--name');
-      clearSearchEl.classList.add('js-hidden');
-      option.classList.remove('hiddenSearch');
-      option.classList.remove('displaySearch');
-      labelEl.innerHTML = this._getOptionLabelText(labelEl);
-    }
-  }
-
-  /**
-   * Returns label of a given filter option
-   * @returns {string}
-   * @private
-   */
-  _getOptionLabelText (labelEl) {
-    let labelText = labelEl.textContent || labelEl.innerText || '';
-    return labelText.trim();
   }
 
   /**

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -426,7 +426,7 @@ export default class FilterOptionsComponent extends Component {
       option.classList.remove('displaySearch');
       labelEl.innerHTML = this._getOptionLabelText(labelEl);
     }
-  };
+  }
 
   /**
    * Returns label of a given filter option
@@ -436,7 +436,7 @@ export default class FilterOptionsComponent extends Component {
   _getOptionLabelText (labelEl) {
     let labelText = labelEl.textContent || labelEl.innerText || '';
     return labelText.trim();
-  };
+  }
 
   /**
    * Returns the count of currently selected options

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -1,5 +1,7 @@
 /** @module FilterOptionsComponent */
 
+/* global Event */
+
 import Component from '../component';
 import { AnswersComponentError } from '../../../core/errors/errors';
 import Filter from '../../../core/models/filter';

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -337,25 +337,35 @@ export default class FilterOptionsComponent extends Component {
 
     // searchable option list
     if (this.config.searchable) {
+      const clearSearchEl = DOM.query(this._container, '.js-yxt-FilterOptions-clearSearch');
+      const searchInputEl = DOM.query(this._container, '.js-yxt-FilterOptions-filter');
       const filterOptionEls = DOM.queryAll(this._container, '.js-yxt-FilterOptions-option');
       const filterContainerEl = DOM.query(this._container, '.js-yxt-FilterOptions-container');
+
+      // On clearSearchEl click, clear search
+      if (clearSearchEl && searchInputEl) {
+        DOM.on(clearSearchEl, 'click', event => {
+          searchInputEl.value = '';
+          searchInputEl.focus();
+          this._clearFilterStyling(filterOptionEls, filterContainerEl, clearSearchEl);
+        });
+      }
+
       DOM.on(
-        DOM.query(this._container, '.js-yxt-FilterOptions-filter'),
+        searchInputEl,
         'keyup',
         event => {
           const filter = event.target.value;
-          filterContainerEl.classList.add('yxt-FilterOptions-container--searching');
 
-          for (let filterOption of filterOptionEls) {
-            const labelEl = DOM.query(filterOption, '.js-yxt-FilterOptions-optionLabel--name');
-            let labelText = labelEl.textContent || labelEl.innerText || '';
-            labelText = labelText.trim();
-            if (!filter) {
-              filterContainerEl.classList.remove('yxt-FilterOptions-container--searching');
-              filterOption.classList.remove('hiddenSearch');
-              filterOption.classList.remove('displaySearch');
-              labelEl.innerHTML = labelText;
-            } else {
+          if (!filter) {
+            this._clearFilterStyling(filterOptionEls, filterContainerEl, clearSearchEl);
+          } else {
+            filterContainerEl.classList.add('yxt-FilterOptions-container--searching');
+            clearSearchEl.classList.remove('js-hidden');
+            // Filter/unfilter options
+            for (let filterOption of filterOptionEls) {
+              const labelEl = DOM.query(filterOption, '.js-yxt-FilterOptions-optionLabel--name');
+              const labelText = this._getOptionLabelText(labelEl);
               let matchedSubstring = this._getMatchedSubstring(labelText.toLowerCase(), filter.toLowerCase());
               if (matchedSubstring) {
                 filterOption.classList.add('displaySearch');
@@ -400,6 +410,33 @@ export default class FilterOptionsComponent extends Component {
         });
     }
   }
+
+  /**
+   * Returns label of a given filter option
+   * @returns {string}
+   * @private
+   */
+  _clearFilterStyling (filterOptionEls, filterContainerEl, clearSearchEl) {
+    filterContainerEl.classList.remove('yxt-FilterOptions-container--searching');
+
+    for (let option of filterOptionEls) {
+      const labelEl = DOM.query(option, '.js-yxt-FilterOptions-optionLabel--name');
+      clearSearchEl.classList.add('js-hidden');
+      option.classList.remove('hiddenSearch');
+      option.classList.remove('displaySearch');
+      labelEl.innerHTML = this._getOptionLabelText(labelEl);
+    }
+  };
+
+  /**
+   * Returns label of a given filter option
+   * @returns {string}
+   * @private
+   */
+  _getOptionLabelText (labelEl) {
+    let labelText = labelEl.textContent || labelEl.innerText || '';
+    return labelText.trim();
+  };
 
   /**
    * Returns the count of currently selected options

--- a/src/ui/sass/modules/_FilterOptions.scss
+++ b/src/ui/sass/modules/_FilterOptions.scss
@@ -35,7 +35,7 @@
       border: $border-default;
       border-radius: 4px;
       padding: 4px 8px;
-      margin-top: 10px;
+      width: 100%;
 
       &:hover {
         border: var(--yxt-border-hover);
@@ -89,6 +89,28 @@
       margin: 12px 0;
       padding-left: 0;
     }
+
+  &-search {
+    position: relative;
+    margin-top: 10px;
+  }
+
+  &-clearSearch {
+    position: absolute;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    border: none;
+    background: none;
+    padding: 0;
+    font-size: 24px;
+    cursor: pointer;
+    color: var(--yxt-color-text-secondary);
+
+    &.js-hidden {
+      display: none;
+    }
+  }
 
   &-optionLabel {
     position: relative;

--- a/src/ui/templates/controls/filteroptions.hbs
+++ b/src/ui/templates/controls/filteroptions.hbs
@@ -42,7 +42,13 @@
       {{/if}}
 
     {{#if searchable}}
-      <input type="text" class="yxt-FilterOptions-filter js-yxt-FilterOptions-filter" placeholder="{{placeholderText}}">
+      <div class="yxt-FilterOptions-search js-yxt-FilterOptions-search">
+        <input type="text" class="yxt-FilterOptions-filter js-yxt-FilterOptions-filter" placeholder="{{placeholderText}}">
+        <button class="yxt-FilterOptions-clearSearch js-yxt-FilterOptions-clearSearch js-hidden"
+          data-component="IconComponent"
+          data-opts='{ "iconName": "close" }'
+          data-prop="icon"></button>
+      </div>
     {{/if}}
     </div>
     <div class='yxt-FilterOptions-options'>


### PR DESCRIPTION
Add a clear button that clears the search input and otherwise has the same affect as an empty search filter: removes the search styling.

TEST=manual

Test that clear button is not there on page load. Start typing in the search input and see clear button appear. Click button and see (1) search input clear,  (2) clear button disappear, and (3) search styling removed.