### PR TITLE
UniversalResults: add appliedFilters.showChangeFilters config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,9 +486,9 @@ ANSWERS.addComponent('UniversalResults', {
       appliedFilters: {
         // If true, show any applied filters that were applied to the universal search. Defaults to false
         show: true,
-        // If showAppliedFilters is true, whether to display the field name of an applied filter, e.g. "Location: Virginia" vs just "Virginia". Defaults to false.
+        // If appliedFilters.show is true, whether to display the field name of an applied filter, e.g. "Location: Virginia" vs just "Virginia". Defaults to false.
         showFieldNames: false,
-        // If showAppliedFilters is true, this is list of filters that should not be displayed.
+        // If appliedFilters.show is true, this is list of filters that should not be displayed.
         // By default, builtin.entityType will be hidden
         hiddenFields: ['builtin.entityType'],
         // The character that separates the count of results (e.g. “1-6”) from the applied filter bar. Defaults to '|'

--- a/README.md
+++ b/README.md
@@ -482,18 +482,23 @@ ANSWERS.addComponent('UniversalResults', {
       viewMore: true,
       // The text for the view more link, if viewMore is true. Defaults to 'View More'
       viewMoreLabel: 'View More!',
-      // Whether or not to display the change-filters link, which links to the url config option
-      changeFilters: true,
-      // If true, show any applied back-end filters that were applied to the universal search. Defaults to false
-      showAppliedFilters: true,
-      // If showAppliedFilters is true, whether to display the field name of an applied filter, e.g.
-      // if a filter on 'Location' by the value 'Virginia', display 'Location: Virginia' if true,
-      // otherwise display just 'Virginia'. Defaults to false.
-      showFieldNames: false,
-      // If showAppliedFilters is true, this is list of filters that should not be displayed.
-      // By default, builtin.entityType will be hidden
-      hiddenFields: ['builtin.entityType'],
-      // If true, adds a map to the vertical using the provided mapConfig. Defaults to false
+      // Config for the applied filters bar in the results header.
+      appliedFilters: {
+        // If true, show any applied filters that were applied to the universal search. Defaults to false
+        show: true,
+        // If showAppliedFilters is true, whether to display the field name of an applied filter, e.g. "Location: Virginia" vs just "Virginia". Defaults to false.
+        showFieldNames: false,
+        // If showAppliedFilters is true, this is list of filters that should not be displayed.
+        // By default, builtin.entityType will be hidden
+        hiddenFields: ['builtin.entityType'],
+        // The character that separates the count of results (e.g. “1-6”) from the applied filter bar. Defaults to '|'
+        resultsCountSeparator: '|',
+        // Whether to display the change filters link in universal results. Defaults to true.
+        showChangeFilters: true,
+        // The character that separates each field (and its associated filters) within the applied filter bar. Defaults to '|'
+        delimiter: '|'
+      },
+      // If true, display the count of results at the very top of the results. Defaults to false.
       showResultCount: true,
       // If true, display the total number of results. Defaults to true
       // Optional, whether to use the AccordionResults component instead of VerticalResults for this vertical

--- a/README.md
+++ b/README.md
@@ -493,8 +493,8 @@ ANSWERS.addComponent('UniversalResults', {
         hiddenFields: ['builtin.entityType'],
         // The character that separates the count of results (e.g. “1-6”) from the applied filter bar. Defaults to '|'
         resultsCountSeparator: '|',
-        // Whether to display the change filters link in universal results. Defaults to true.
-        showChangeFilters: true,
+        // Whether to display the change filters link in universal results. Defaults to false.
+        showChangeFilters: false,
         // The character that separates each field (and its associated filters) within the applied filter bar. Defaults to '|'
         delimiter: '|'
       },

--- a/src/ui/components/results/universalresultscomponent.js
+++ b/src/ui/components/results/universalresultscomponent.js
@@ -5,6 +5,7 @@ import Component from '../component';
 import StorageKeys from '../../../core/storage/storagekeys';
 import SearchStates from '../../../core/storage/searchstates';
 import AccordionResultsComponent from './accordionresultscomponent.js';
+import { defaultConfigOption } from '../../../core/utils/configutils';
 
 export default class UniversalResultsComponent extends Component {
   constructor (config = {}, systemConfig = {}) {
@@ -67,22 +68,26 @@ export default class UniversalResultsComponent extends Component {
       viewMore: true,
       // By default, the view more link has a label of 'View More'.
       viewMoreLabel: config.viewAllText || 'View More',
-      // By default, do not show a change filters button next to the applied filters.
-      // Also links to verticalURL
-      changeFilters: false,
-      // Whether to show the applied filters.
-      showAppliedFilters: true,
-      // Whether to show field names in the applied filters, e.g. 'Location: Virginia' vs just 'Virginia'.
-      showFieldNames: false,
-      // Field ids to hide in the applied filters.
-      hiddenFields: ['builtin.entityType'],
       // Whether to show a result count.
       showResultCount: false,
-      // Whether to show the change filters link.
-      showChangeFilters: true,
       // Whether to use AccordionResults (DEPRECATED)
       useAccordion: false,
-      ...config
+      ...config,
+      // Config for the applied filters bar. Must be placed after ...config to not override defaults.
+      appliedFilters: {
+        // Whether to display applied filters.
+        show: defaultConfigOption(config, ['appliedFilters.show', 'showAppliedFilters'], true),
+        // Whether to show field names, e.g. Location in Location: Virginia.
+        showFieldNames: defaultConfigOption(config, ['appliedFilters.showFieldNames', 'showFieldNames'], false),
+        // Hide filters with these field ids.
+        hiddenFields: defaultConfigOption(config, ['appliedFilters.hiddenFields', 'hiddenFields'], ['builtin.entityType']),
+        // Symbol placed between the result count and the applied filters.
+        resultsCountSeparator: defaultConfigOption(config, ['appliedFilters.resultsCountSeparator', 'resultsCountSeparator'], '|'),
+        // Whether to show a 'change filters' link, linking back to verticalURL.
+        showChangeFilters: defaultConfigOption(config, ['appliedFilters.showChangeFilters', 'showChangeFilters'], true),
+        // The symbol placed between different filters with the same fieldName. e.g. Location: Virginia | New York | Miami.
+        delimiter: defaultConfigOption(config, ['appliedFilters.delimiter'], '|')
+      }
     };
   }
 }

--- a/src/ui/components/results/universalresultscomponent.js
+++ b/src/ui/components/results/universalresultscomponent.js
@@ -84,7 +84,7 @@ export default class UniversalResultsComponent extends Component {
         // Symbol placed between the result count and the applied filters.
         resultsCountSeparator: defaultConfigOption(config, ['appliedFilters.resultsCountSeparator', 'resultsCountSeparator'], '|'),
         // Whether to show a 'change filters' link, linking back to verticalURL.
-        showChangeFilters: defaultConfigOption(config, ['appliedFilters.showChangeFilters', 'showChangeFilters'], true),
+        showChangeFilters: defaultConfigOption(config, ['appliedFilters.showChangeFilters', 'showChangeFilters'], false),
         // The symbol placed between different filters with the same fieldName. e.g. Location: Virginia | New York | Miami.
         delimiter: defaultConfigOption(config, ['appliedFilters.delimiter'], '|')
       }

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -104,7 +104,13 @@ class VerticalResultsConfig {
        * If the filters are shown, whether or not they should be removable from within the applied filter bar.
        * @type {boolean}
        */
-      removable: defaultConfigOption(config, ['appliedFilters.removable'], false)
+      removable: defaultConfigOption(config, ['appliedFilters.removable'], false),
+
+      /**
+       * Whether to show the change filters link on universal results.
+       * @type {boolean}
+       **/
+      showChangeFilters: defaultConfigOption(config, ['appliedFilters.showChangeFilters', 'showChangeFilters'], false)
     };
 
     /**
@@ -112,12 +118,6 @@ class VerticalResultsConfig {
      * @type {string}
      */
     this.viewMoreLabel = config.viewMoreLabel;
-
-    /**
-     * Whether to show the change filters link.
-     * @type {boolean}
-     **/
-    this.showChangeFilters = config.showChangeFilters;
   }
 }
 
@@ -181,7 +181,7 @@ export default class VerticalResultsComponent extends Component {
       showFieldNames: this._config.appliedFilters.showFieldNames,
       resultsCountSeparator: this._config.appliedFilters.resultsCountSeparator,
       showAppliedFilters: this._config.appliedFilters.show,
-      showChangeFilters: this._config.showChangeFilters,
+      showChangeFilters: this._config.appliedFilters.showChangeFilters,
       showResultCount: this._config.showResultCount,
       removable: this._config.appliedFilters.removable, // TODO implement
       delimiter: this._config.appliedFilters.delimiter


### PR DESCRIPTION
This commit moves the showChangeFilters config option under the appliedFilters
object. This config option is only used on universal results, and displays
a link to the verticalURL for a specific vertical. Also updates the readme
for universal results to use the recently added appliedFilters config object.

QA=v1.4.0 no. 13
TEST=manual
test that on universal, can specify showChangeFilters in either the
root component config or in the appliedFilters config object, and that
the appliedFilters config takes precedence.
test that changeFilters do not show up on vertical results no matter
what