### PR TITLE
FilterBox: fix resetFilters and resetFiltersLabel config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -908,9 +908,9 @@ ANSWERS.addComponent('FilterBox', {
   resetFilter: false,
   // Optional, the label to use for the reset button above, this will only display if searchOnChange is false
   resetFilterLabel: 'reset',
-  // Optional, show a reset-all button for the filter control, this will only display if searchOnChange is false
+  // Optional, show a reset-all button for the filter control. Defaults to displaying a reset button if searchOnChange is false.
   resetFilters: true,
-  // Optional, the label to use for the reset-all button above, this will only display if searchOnChange is false
+  // Optional, the label to use for the reset-all button above, this will only display if resetFilters is true.
   resetFiltersLabel: 'reset-all',
   // Optional, allow collapsing excess filter options after a limit
   showMore: true,

--- a/src/ui/components/filters/filterboxcomponent.js
+++ b/src/ui/components/filters/filterboxcomponent.js
@@ -40,13 +40,13 @@ class FilterBoxConfig {
      * If true, show a "reset all" button to reset all facets
      * @type {boolean}
      */
-    this.resetFilters = config.resetFacets === undefined ? true : config.resetFacets;
+    this.resetFilters = config.resetFilters === undefined ? !config.searchOnChange : config.resetFilters;
 
     /**
      * The label to show for the "reset all" button
      * @type {string}
      */
-    this.resetFiltersLabel = config.resetFacetsLabel || 'reset all';
+    this.resetFiltersLabel = config.resetFiltersLabel || 'reset all';
 
     /**
      * The max number of facets to show before displaying "show more"/"show less"

--- a/src/ui/sass/modules/_FilterBox.scss
+++ b/src/ui/sass/modules/_FilterBox.scss
@@ -60,5 +60,9 @@
 
     margin-left: 10px;
     letter-spacing: 0.5px;
+
+    &--noApplyButton {
+      margin-left: 0;
+    }
   }
 }

--- a/src/ui/templates/filters/filterbox.hbs
+++ b/src/ui/templates/filters/filterbox.hbs
@@ -12,14 +12,16 @@
     <div class="js-yext-filterbox-filter{{@index}} yxt-FilterBox-filter">
     </div>
   {{/each}}
-  {{#if showApplyButton}}
+  {{#if (or showApplyButton showReset)}}
     <div class="yxt-FilterBox-controls">
-      <button type="button"
-              class="js-yext-filterbox-apply yxt-FilterBox-apply">
-        {{applyLabel}}
-      </button>
+      {{#if showApplyButton}}
+        <button type="button"
+                class="js-yext-filterbox-apply yxt-FilterBox-apply">
+          {{applyLabel}}
+        </button>
+      {{/if}}
       {{~#if showReset ~}}
-        <button type="button" class="js-yxt-FilterBox-reset yxt-FilterBox-reset">
+        <button type="button" class="js-yxt-FilterBox-reset yxt-FilterBox-reset{{#unless showApplyButton}} yxt-FilterBox-reset--noApplyButton{{/unless}}">
           {{resetLabel}}
         </button>
       {{/if}}

--- a/tests/ui/components/filters/filterboxcomponent.js
+++ b/tests/ui/components/filters/filterboxcomponent.js
@@ -434,3 +434,82 @@ describe('dynamic filterbox component', () => {
     expect(expectedFacetFilterNodes[1].children[1].getMetadata()).toEqual(node4.getMetadata());
   });
 });
+
+describe('FilterBox reset button', () => {
+  DOM.setup(document, new DOMParser());
+  let COMPONENT_MANAGER, defaultConfig;
+
+  beforeEach(() => {
+    const bodyEl = DOM.query('body');
+    DOM.empty(bodyEl);
+    DOM.append(bodyEl, DOM.createEl('div', { id: 'test-component' }));
+
+    COMPONENT_MANAGER = mockManager(
+      {},
+      FilterBoxComponent.defaultTemplateName(),
+      FilterOptionsComponent.defaultTemplateName()
+    );
+
+    defaultConfig = {
+      container: '#test-component',
+      filters: [{ type: 'FilterOptions', options: [] }, { type: 'FilterOptions', options: [] }]
+    };
+  });
+
+  it('does not render by default if searchOnChange', () => {
+    const component = COMPONENT_MANAGER.create('FilterBox', {
+      ...defaultConfig,
+      searchOnChange: true
+    });
+    const wrapper = mount(component);
+    expect(wrapper.find('.js-yxt-FilterBox-reset')).toHaveLength(0);
+  });
+
+  it('renders by default if not searchOnChange', () => {
+    const component = COMPONENT_MANAGER.create('FilterBox', {
+      ...defaultConfig,
+      searchOnChange: false
+    });
+    const wrapper = mount(component);
+    expect(wrapper.find('.js-yxt-FilterBox-reset')).toHaveLength(1);
+  });
+
+  it('does not render if false', () => {
+    const component = COMPONENT_MANAGER.create('FilterBox', {
+      ...defaultConfig,
+      resetFilters: false,
+      searchOnChange: false
+    });
+    const wrapper = mount(component);
+    expect(wrapper.find('.js-yxt-FilterBox-reset')).toHaveLength(0);
+  });
+
+  it('renders if true', () => {
+    const component = COMPONENT_MANAGER.create('FilterBox', {
+      ...defaultConfig,
+      resetFilters: true,
+      searchOnChange: true
+    });
+    const wrapper = mount(component);
+    expect(wrapper.find('.js-yxt-FilterBox-reset')).toHaveLength(1);
+  });
+
+  it('renders with correct default text', () => {
+    const component = COMPONENT_MANAGER.create('FilterBox', {
+      ...defaultConfig,
+      resetFilters: true
+    });
+    const wrapper = mount(component);
+    expect(wrapper.find('.js-yxt-FilterBox-reset').at(0).text().trim()).toEqual('reset all');
+  });
+
+  it('renders with correct text', () => {
+    const component = COMPONENT_MANAGER.create('FilterBox', {
+      ...defaultConfig,
+      resetFilters: true,
+      resetFiltersLabel: 'WE THE BEST MUSIC'
+    });
+    const wrapper = mount(component);
+    expect(wrapper.find('.js-yxt-FilterBox-reset').at(0).text().trim()).toEqual('WE THE BEST MUSIC');
+  });
+});


### PR DESCRIPTION
These config options probably have not worked for a very long time.
Now, resetFilters will control whether or not FilterBox displays a reset all button.
If resetFilters is not specified, it will default to its previous behavior, which was
displaying a reset button if searchOnChange was false. The text on the button will
now correctly try to use config.resetFiltersLabel first before using the default text.

QA=v1.4.0 no. 7
TEST=manual, auto
Test that if resetFilters is not specified, will display a reset button and apply button if searchOnChange
is true, otherwise neither will be displayed
Test that if resetFilters IS false, whether searchOnChange is true or false no reset button appears
Test that if resetFilters is true, whether searchOnChange is true or false a reset button will appear
Test that facets still work properly
Sent codepen with dev branch to Rose to verify styling is ok