### PR TITLE
ResultsHeader: make removable filters a tabbable button

### DIFF
--- a/src/ui/sass/modules/_ResultsHeader.scss
+++ b/src/ui/sass/modules/_ResultsHeader.scss
@@ -128,6 +128,7 @@ $results-header-filters-line-height: var(--yxt-line-height-md) !default;
   {
     background-color: var(--yxt-color-borders);
     border-radius: 2px;
+    border-width: 0;
     margin-bottom: 4px;
     padding-left: 5px;
     padding-right: 4px;
@@ -138,14 +139,14 @@ $results-header-filters-line-height: var(--yxt-line-height-md) !default;
       $line-height: 20px,
       $style: italic,
     );
-  }
 
-
-  &-removableFilterTag:hover
-  {
-    color: var(--yxt-color-brand-white);
-    background-color: var(--yxt-color-text-secondary);
-    cursor: pointer;
+    &:hover,
+    &:focus
+    {
+      color: var(--yxt-color-brand-white);
+      background-color: var(--yxt-color-text-secondary);
+      cursor: pointer;
+    }
   }
 
   &-removableFilterX

--- a/src/ui/templates/results/resultsheader.hbs
+++ b/src/ui/templates/results/resultsheader.hbs
@@ -32,11 +32,11 @@
         {{/if}}
         {{#each filterDataArray}}
           {{#if removable}}
-            <div class="yxt-ResultsHeader-removableFilterTag js-yxt-ResultsHeader-removableFilterTag"
-              data-filter-id={{dataFilterId}}>
+            <button class="yxt-ResultsHeader-removableFilterTag js-yxt-ResultsHeader-removableFilterTag"
+              data-filter-id={{dataFilterId}} tabindex="0">
               <span class="yxt-ResultsHeader-removableFilterValue">{{displayValue}}</span>
               <span class="yxt-ResultsHeader-removableFilterX">&times;</span>
-            </div>
+            </button>
           {{else}}
             <div class="yxt-ResultsHeader-filterValue">
               <span class="yxt-ResultsHeader-filterValueText">{{displayValue}}</span>


### PR DESCRIPTION
This commit updates the removable filter tags to be a tabbable button

v1.4.0 QA: 15, 16
TEST=manual
Test I can tab onto the filter tag
when it is tabbed onto the styling will update to the hover/focus styling
tabbing to it doesn't change my cursor to a pointer, but it does change if I hover over it
can press enter to remove the filter