### PR TITLE
VerticalResults: fix appliedFilters.hiddenFields default

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,7 +574,7 @@ ANSWERS.addComponent('VerticalResults', {
     showFieldNames: false,
     // If appliedFilters.show is true, this is list of filters that should not be displayed.
     // By default, builtin.entityType will be hidden
-    hiddenFields: ['builtin.location'],
+    hiddenFields: ['builtin.entityType'],
     // The character that separates the count of results (e.g. “1-6”) from the applied filter bar. Defaults to '|'
     resultsCountSeparator: '|',
     // If the filters are shown, whether or not they should be removable from within the applied filter bar. Defaults to false.

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -92,7 +92,7 @@ class VerticalResultsConfig {
        * Any fieldIds in hiddenFields will be hidden from the list of appied filters.
        * @type {Array<string>}
        */
-      hiddenFields: defaultConfigOption(config, ['appliedFilters.hiddenFields', 'hiddenFields'], ['builtin.location']),
+      hiddenFields: defaultConfigOption(config, ['appliedFilters.hiddenFields', 'hiddenFields'], ['builtin.entityType']),
 
       /**
        * The character that should separate each field (and its associated filters) within the applied filter bar


### PR DESCRIPTION
Spec was incorrect, should be ['builtin.entityType'] just like it is
on universal

https://yext.slack.com/archives/GREFVUD7V/p1591284206004800