### PR TITLE
FilterOptions: pass additional needed state to the template

### DIFF
--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -263,10 +263,12 @@ export default class FilterOptionsComponent extends Component {
     this.expanded = this.config.showExpand ? selectedCount > 0 : true;
 
     /**
-     * True if all options are shown, false if some are hidden based on config
+     * Whether the current is currently showing more or less. If true, is currently "show more".
+     * Only used if config.showMore is true.
      * @type {boolean}
      */
-    this.allShown = false;
+    this.showMoreState = this.config.showMore;
+
     if (this.config.storeOnChange) {
       this.apply();
     }
@@ -286,10 +288,11 @@ export default class FilterOptionsComponent extends Component {
   }
 
   setState (data) {
-    const selectedCount = this.config.getInitialSelectedCount();
+    const selectedCount = this._getSelectedCount();
     super.setState(Object.assign({}, data, {
       name: this.name.toLowerCase(),
       ...this.config,
+      showMoreState: this.showMoreState,
       displayReset: this.config.showReset && selectedCount > 0,
       expanded: this.expanded,
       selectedCount,
@@ -325,6 +328,7 @@ export default class FilterOptionsComponent extends Component {
         showLessEl,
         'click',
         () => {
+          this.showMoreState = true;
           showLessEl.classList.add('hidden');
           showMoreEl.classList.remove('hidden');
           for (let optionEl of optionsOverLimitEls) {
@@ -335,6 +339,7 @@ export default class FilterOptionsComponent extends Component {
         showMoreEl,
         'click',
         () => {
+          this.showMoreState = false;
           showLessEl.classList.remove('hidden');
           showMoreEl.classList.add('hidden');
           for (let optionEl of optionsOverLimitEls) {
@@ -436,8 +441,7 @@ export default class FilterOptionsComponent extends Component {
    * @private
    */
   _getSelectedCount () {
-    const selectedEls = DOM.queryAll(this._container, '.js-yxt-FilterOptions-checkboxInput:checked');
-    return selectedEls && selectedEls.length;
+    return this.config.options.filter(o => o.selected).length;
   }
 
   /**
@@ -570,9 +574,7 @@ export default class FilterOptionsComponent extends Component {
     this.config.options[index] = Object.assign({}, this.config.options[index], { selected });
     this.updateListeners();
 
-    if (this.config.storeOnChange) {
-      this.setState();
-    }
+    this.setState();
   }
 
   apply () {
@@ -590,18 +592,6 @@ export default class FilterOptionsComponent extends Component {
 
   floatSelected () {
     this.config.options = this.config.options.sort((a, b) => b.selected - a.selected);
-  }
-
-  /**
-   * Clear all options
-   * TODO(oshi): Investigate removing this, this is not referenced anywhere,
-   * even if you go back to the original commit (#42).
-   * Same thing with this._applyFilter().
-   */
-  clear () {
-    const elements = DOM.queryAll(this._container, this.config.optionSelector);
-    elements.forEach(e => e.setAttribute('checked', 'false'));
-    this._applyFilter();
   }
 
   _buildFilter (option) {

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -563,18 +563,16 @@ export default class FilterOptionsComponent extends Component {
   }
 
   _updateOption (index, selected) {
-    if (this.config.showReset) {
-      this._toggleReset();
-    }
-
     if (this.config.control === 'singleoption') {
       this.config.options = this.config.options.map(o => Object.assign({}, o, { selected: false }));
     }
 
     this.config.options[index] = Object.assign({}, this.config.options[index], { selected });
+  
+    if (this.config.showReset) {
+      this._toggleReset();
+    }
     this.updateListeners();
-
-    this.setState();
   }
 
   apply () {

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -568,7 +568,7 @@ export default class FilterOptionsComponent extends Component {
     }
 
     this.config.options[index] = Object.assign({}, this.config.options[index], { selected });
-  
+
     if (this.config.showReset) {
       this._toggleReset();
     }

--- a/src/ui/templates/controls/filteroptions.hbs
+++ b/src/ui/templates/controls/filteroptions.hbs
@@ -27,7 +27,9 @@
           <span class="yxt-FilterOptions-label">{{label}}</span>
       {{/if}}
       {{#unless showExpand}}
-        <button class="yxt-FilterOptions-reset js-yxt-FilterOptions-reset yxt-FilterOptions-reset--right{{#unless displayReset}} js-hidden{{/unless}}">{{resetLabel}}</button>
+        <button class="yxt-FilterOptions-reset js-yxt-FilterOptions-reset yxt-FilterOptions-reset--right{{#unless displayReset}} js-hidden{{/unless}}">
+          {{resetLabel}}
+        </button>
       {{/unless}}
     </div>
   </legend>
@@ -37,7 +39,9 @@
     <div class="yxt-FilterOptions-controls">
       {{#if showExpand}}
         <span class="yxt-FilterOptions-buttonWrapper">
-          <button class="yxt-FilterOptions-reset js-yxt-FilterOptions-reset{{#unless displayReset}} js-hidden{{/unless}}">{{resetLabel}}</button>
+          <button class="yxt-FilterOptions-reset js-yxt-FilterOptions-reset{{#unless displayReset}} js-hidden{{/unless}}">
+            {{resetLabel}}
+          </button>
         </span>
       {{/if}}
 
@@ -54,7 +58,11 @@
     <div class='yxt-FilterOptions-options'>
       {{#each options}}
         {{#if ../isSingleOption}}
-          <div class="singleoption-option yxt-FilterOptions-option js-yxt-FilterOptions-option{{#if (and ../showMore (gte @index ../showMoreLimit))}} js-yxt-FilterOptions-aboveShowMoreLimit hidden{{/if}}">
+          <div class="singleoption-option yxt-FilterOptions-option js-yxt-FilterOptions-option
+            {{#if (and ../showMore (gte @index ../showMoreLimit))}}
+              js-yxt-FilterOptions-aboveShowMoreLimit
+              {{#if ../showMoreState}} hidden{{/if}}
+            {{/if}}">
             <input
               type="radio"
               class="js-yext-filter-option yxt-FilterOptions-input"
@@ -73,7 +81,11 @@
             </label>
           </div>
         {{else}}
-          <div class="multioption-option yxt-FilterOptions-option js-yxt-FilterOptions-option{{#if (and ../showMore (gte @index ../showMoreLimit))}} js-yxt-FilterOptions-aboveShowMoreLimit hidden{{/if}}">
+          <div class="multioption-option yxt-FilterOptions-option js-yxt-FilterOptions-option
+            {{#if (and ../showMore (gte @index ../showMoreLimit))}}
+              js-yxt-FilterOptions-aboveShowMoreLimit
+              {{#if ../showMoreState}} hidden{{/if}}
+            {{/if}}">
             <input
               type="checkbox"
               class="js-yext-filter-option yxt-FilterOptions-input yxt-FilterOptions-checkboxInput js-yxt-FilterOptions-checkboxInput"
@@ -95,7 +107,7 @@
     </div>
 
     {{#if showMore}}
-      <button class="yxt-FilterOptions-showToggle js-yxt-FilterOptions-showToggle js-yxt-FilterOptions-showLess hidden">
+      <button class="yxt-FilterOptions-showToggle js-yxt-FilterOptions-showToggle js-yxt-FilterOptions-showLess{{#if showMoreState}} hidden{{/if}}">
         <span class="yxt-FilterOptions-showToggleLabel">
           {{showLessLabel}}
         </span>
@@ -103,7 +115,7 @@
           data-component="IconComponent"
           data-opts='{ "iconName": "chevron" }'></span>
       </button>
-      <button class="yxt-FilterOptions-showToggle js-yxt-FilterOptions-showToggle js-yxt-FilterOptions-showMore">
+      <button class="yxt-FilterOptions-showToggle js-yxt-FilterOptions-showToggle js-yxt-FilterOptions-showMore{{#unless showMoreState}} hidden{{/unless}}">
         <span class="yxt-FilterOptions-showToggleLabel">
           {{showMoreLabel}}
         </span>

--- a/tests/ui/components/filters/filteroptionscomponent.js
+++ b/tests/ui/components/filters/filteroptionscomponent.js
@@ -102,10 +102,22 @@ describe('filter options component', () => {
     expect(wrapper.find('.yxt-FilterOptions-fieldSet')).toHaveLength(1);
   });
 
-  it('renders correct number of options + show more with default showMoreLimit of 5', () => {
+  it('renders correct number of options + show more with default showMoreLimit of 5 (multioption)', () => {
     const config = {
       ...defaultConfig,
       control: 'multioption'
+    };
+    const component = COMPONENT_MANAGER.create('FilterOptions', config);
+    const wrapper = mount(component);
+    expect(options).toHaveLength(6);
+    expect(wrapper.find('.js-yxt-FilterOptions-option.hidden')).toHaveLength(1);
+    expect(wrapper.find('.js-yxt-FilterOptions-showMore')).toHaveLength(1);
+  });
+
+  it('renders correct number of options + show more with default showMoreLimit of 5 (singleoption)', () => {
+    const config = {
+      ...defaultConfig,
+      control: 'singleoption'
     };
     const component = COMPONENT_MANAGER.create('FilterOptions', config);
     const wrapper = mount(component);


### PR DESCRIPTION
The show more/less mechanism FilterOptions was using was changing
DOM element classes but not propagating these changes into setState,
meaning if the component calls setState sometimes unexpected show more/less
behavior would occur.

Also update this._getSelectedCount to use this.config.options instead of
doing a DOM query. This should improve performance slightly, especially
for facets with 100 options.

Also remove unused variable this.allShown and unused method this.clear().

TEST=manual, auto
Added a unit test to make sure showMore renders for single option.
Tested that with storeOnChange both true and false, and multioption
and singleoption, can use the reset button and show more toggle without weird behavior