### PR TITLE
ResultsHeader: add aria-label config options for applied filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,7 +496,9 @@ ANSWERS.addComponent('UniversalResults', {
         // Whether to display the change filters link in universal results. Defaults to false.
         showChangeFilters: false,
         // The character that separates each field (and its associated filters) within the applied filter bar. Defaults to '|'
-        delimiter: '|'
+        delimiter: '|',
+        // The aria-label given to the applied filters bar. Defaults to 'Filters applied to this search:'.
+        labelText: 'Filters applied to this search:',
       },
       // If true, display the count of results at the very top of the results. Defaults to false.
       showResultCount: true,
@@ -577,10 +579,14 @@ ANSWERS.addComponent('VerticalResults', {
     hiddenFields: ['builtin.entityType'],
     // The character that separates the count of results (e.g. “1-6”) from the applied filter bar. Defaults to '|'
     resultsCountSeparator: '|',
-    // If the filters are shown, whether or not they should be removable from within the applied filter bar. Defaults to false.
+    // If the filters are shown, whether or not they should be removable buttons. Defaults to false.
     removable: false,
     // The character that separates each field (and its associated filters) within the applied filter bar. Defaults to '|'
-    delimiter: '|'
+    delimiter: '|',
+    // The aria-label given to the applied filters bar. Defaults to 'Filters applied to this search:'.
+    labelText: 'Filters applied to this search:',
+    // The aria-label given to the removable filter buttons.
+    removableLabelText: 'Remove'
   }
 })
 ```

--- a/src/ui/components/results/resultsheadercomponent.js
+++ b/src/ui/components/results/resultsheadercomponent.js
@@ -14,7 +14,9 @@ const DEFAULT_CONFIG = {
   showChangeFilters: false,
   removable: false,
   delimiter: '|',
-  isUniversal: false
+  isUniversal: false,
+  labelText: 'Filters applied to this search:',
+  removableLabelText: 'Remove'
 };
 
 export default class ResultsHeaderComponent extends Component {

--- a/src/ui/components/results/universalresultscomponent.js
+++ b/src/ui/components/results/universalresultscomponent.js
@@ -86,7 +86,9 @@ export default class UniversalResultsComponent extends Component {
         // Whether to show a 'change filters' link, linking back to verticalURL.
         showChangeFilters: defaultConfigOption(config, ['appliedFilters.showChangeFilters', 'showChangeFilters'], false),
         // The symbol placed between different filters with the same fieldName. e.g. Location: Virginia | New York | Miami.
-        delimiter: defaultConfigOption(config, ['appliedFilters.delimiter'], '|')
+        delimiter: defaultConfigOption(config, ['appliedFilters.delimiter'], '|'),
+        // The aria-label given to the applied filters bar.
+        labelText: defaultConfigOption(config, ['appliedFilters.labelText'], 'Filters applied to this search:')
       }
     };
   }

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -110,7 +110,19 @@ class VerticalResultsConfig {
        * Whether to show the change filters link on universal results.
        * @type {boolean}
        **/
-      showChangeFilters: defaultConfigOption(config, ['appliedFilters.showChangeFilters', 'showChangeFilters'], false)
+      showChangeFilters: defaultConfigOption(config, ['appliedFilters.showChangeFilters', 'showChangeFilters'], false),
+
+      /**
+       * The aria-label given to the applied filters bar. Defaults to 'Filters applied to this search:'.
+       * @type {string}
+       **/
+      labelText: defaultConfigOption(config, ['appliedFilters.labelText'], 'Filters applied to this search:'),
+
+      /**
+       * The aria-label given to the removable filter buttons.
+       * @type {string}
+       */
+      removableLabelText: defaultConfigOption(config, ['appliedFilters.removableLabelText'], 'Remove')
     };
 
     /**
@@ -183,8 +195,10 @@ export default class VerticalResultsComponent extends Component {
       showAppliedFilters: this._config.appliedFilters.show,
       showChangeFilters: this._config.appliedFilters.showChangeFilters,
       showResultCount: this._config.showResultCount,
-      removable: this._config.appliedFilters.removable, // TODO implement
-      delimiter: this._config.appliedFilters.delimiter
+      removable: this._config.appliedFilters.removable,
+      delimiter: this._config.appliedFilters.delimiter,
+      labelText: this._config.appliedFilters.labelText,
+      removableLabelText: this._config.appliedFilters.removableLabelText
     };
   }
 

--- a/src/ui/templates/results/resultsheader.hbs
+++ b/src/ui/templates/results/resultsheader.hbs
@@ -22,7 +22,7 @@
 
 {{#*inline "filters"}}
   {{#if shouldShowFilters}}
-    <div class="yxt-ResultsHeader-appliedFilters">
+    <div class="yxt-ResultsHeader-appliedFilters" aria-label="{{_config.labelText}}">
       {{#each appliedFiltersArray}}
         {{#if ../_config.showFieldNames}}
           <div class="yxt-ResultsHeader-filterLabel">
@@ -33,7 +33,7 @@
         {{#each filterDataArray}}
           {{#if removable}}
             <button class="yxt-ResultsHeader-removableFilterTag js-yxt-ResultsHeader-removableFilterTag"
-              data-filter-id={{dataFilterId}} tabindex="0">
+              data-filter-id={{dataFilterId}} tabindex="0" aria-label="{{../../_config.removableLabelText}}">
               <span class="yxt-ResultsHeader-removableFilterValue">{{displayValue}}</span>
               <span class="yxt-ResultsHeader-removableFilterX">&times;</span>
             </button>


### PR DESCRIPTION
This commit adds aria-labels to the applied filters bar and removable filter tags,
as well as config options to customize these values.

TEST=manual
test that in both universal and vertical results, labelText will default correctly,
  and can also be custom set
test that in vertical results removableLabelText will default, and can also be customized