### PR TITLE
FilterOptions: have cursor: pointer for singleoption radio button labels

### DIFF
--- a/src/ui/sass/modules/_FilterOptions.scss
+++ b/src/ui/sass/modules/_FilterOptions.scss
@@ -114,6 +114,10 @@
     }
   }
 
+  &-radioButtonLabel {
+    cursor: pointer;
+  }
+
   &-optionLabel {
     position: relative;
     font-size: $font-size-md;
@@ -215,6 +219,10 @@
 
   &-input {
     margin-left: 0;
+  }
+
+  &-radioButtonInput {
+    cursor: pointer;
   }
 
   &-checkboxInput {

--- a/src/ui/templates/controls/filteroptions.hbs
+++ b/src/ui/templates/controls/filteroptions.hbs
@@ -65,13 +65,15 @@
             {{/if}}">
             <input
               type="radio"
-              class="js-yext-filter-option yxt-FilterOptions-input"
+              class="js-yext-filter-option yxt-FilterOptions-input yxt-FilterOptions-radioButtonInput"
               id="js-yext-radio-{{../name}}-{{@index}}"
               name="{{../name}}"
               value="{{value}}"
               data-index="{{@index}}"
               {{#if selected}}checked{{/if}}>
-            <label class="singleoption-label" for="js-yext-radio-{{../name}}-{{@index}} js-yxt-FilterOptions-optionLabel">
+            <label
+              class="singleoption-label yxt-FilterOptions-radioButtonLabel"
+              for="js-yext-radio-{{../name}}-{{@index}}">
               <span class="yxt-FilterOptions-optionLabel--name js-yxt-FilterOptions-optionLabel--name">
                 {{label}}
               </span>
@@ -93,7 +95,9 @@
               value="{{value}}"
               data-index="{{@index}}"
               {{#if selected}}checked{{/if}}>
-            <label class="yxt-FilterOptions-optionLabel js-yxt-FilterOptions-optionLabel" for="js-yext-checkbox-{{../name}}-{{@index}}">
+            <label
+              class="yxt-FilterOptions-optionLabel js-yxt-FilterOptions-optionLabel"
+              for="js-yext-checkbox-{{../name}}-{{@index}}">
               <span class="yxt-FilterOptions-optionLabel--name js-yxt-FilterOptions-optionLabel--name">
                 {{label}}
               </span>


### PR DESCRIPTION
Have the cursor be a pointer when it hovers over both the input and
the label (just like for multioption). Fix the for attribute attached
the label I goofed up earlier so clicking it selects the associated button.

TEST=manual
test that single options have cursor:pointer for both label and input, and
clicking either will select the option