### PR TITLE
ResultsHeader: shrink margin-right for nonremovable applied filters

### DIFF
--- a/src/ui/sass/modules/_ResultsHeader.scss
+++ b/src/ui/sass/modules/_ResultsHeader.scss
@@ -74,7 +74,7 @@ $results-header-filters-line-height: var(--yxt-line-height-md) !default;
 
   &-filterValue
   {
-    margin-right: calc(var(--yxt-results-header-spacing) / 2);
+    margin-right: calc(var(--yxt-results-header-spacing) / 4);
     margin-bottom: 4px;
     display: flex;
   }


### PR DESCRIPTION
Rose thought the spacing was too big (I like the new spacing too).

TEST=manual
check margin-right on universal and vertical