### PR TITLE
Add ability to configure 'target' behavior of rich text content.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1860,14 +1860,22 @@ The Answers SDK exposes a `formatRichText` function which translates CommonMark 
 ensure that a Rich Text Formatted value is shown properly on the page. To use this function, call it like so:
 
 ```js
-ANSWERS.formatRichText(rtfFieldValue, target, eventOptionsFieldName)
+ANSWERS.formatRichText(rtfFieldValue, targetConfig, eventOptionsFieldName)
 ```
 
 For instance, this function can be used in the `dataMappings` of a Card to display an RTF attribute. 
 
 When clicking any link in the resultant HTML, an `AnalyticsEvent` will be fired. If the `eventOptionsFieldName` has been
-specified, the `eventOptions` will include a `fieldName` attribute with the given value. The `target` parameter dictates
-where the link is opened: the current window, a new tab, etc. This parameter, like `eventOptionsFieldName`, is optional.
+specified, the `eventOptions` will include a `fieldName` attribute with the given value. 
+
+The `targetConfig` parameter dictates where the link is opened: the current window, a new tab, etc. It can have the following forms:
+
+```js
+targetConfig = { link: '_blank', phone: '_self', email: '_parent' }
+targetConfig = '_blank'
+```
+
+When `targetConfig` is a string, it is assumed that any link, regardless of type, has the specified `target` behavior. This parameter, like `eventOptionsFieldName`, is optional. When not provided, no `target` attribute is supplied to the links.
 
 Note that when using this function, you must ensure that the relevant Handlebars template correctly unescapes the output HTML.
 

--- a/README.md
+++ b/README.md
@@ -1860,13 +1860,16 @@ The Answers SDK exposes a `formatRichText` function which translates CommonMark 
 ensure that a Rich Text Formatted value is shown properly on the page. To use this function, call it like so:
 
 ```js
-ANSWERS.formatRichText(rtfFieldValue, eventOptionsFieldName)
+ANSWERS.formatRichText(rtfFieldValue, target, eventOptionsFieldName)
 ```
 
 For instance, this function can be used in the `dataMappings` of a Card to display an RTF attribute. 
 
 When clicking any link in the resultant HTML, an `AnalyticsEvent` will be fired. If the `eventOptionsFieldName` has been
-specified, the `eventOptions` will include a `fieldName` attribute with the given value. Note that when using this function, you must ensure that the relevant Handlebars template correctly unescapes the output HTML.
+specified, the `eventOptions` will include a `fieldName` attribute with the given value. The `target` parameter dictates
+where the link is opened: the current window, a new tab, etc. This parameter, like `eventOptionsFieldName`, is optional.
+
+Note that when using this function, you must ensure that the relevant Handlebars template correctly unescapes the output HTML.
 
 # CSS Variable Styling
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1865,9 +1865,9 @@
       "dev": true
     },
     "@yext/rtf-converter": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@yext/rtf-converter/-/rtf-converter-1.1.1.tgz",
-      "integrity": "sha512-iPbLYRITyvFGF7JxEtcNatWImG5nrL7HshGZh7eOyVmZgcn1FABNyQO6idfJpj2SFb57nirftXA7AA2wE4yMSg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@yext/rtf-converter/-/rtf-converter-1.2.0.tgz",
+      "integrity": "sha512-uQAxTXN631sickvkSfxrdDGs2jZi1gvThqpce/IU0G2xRTcRlqOXKweDIgkckDaYdawv6FfdrkIGkczOt7SZiQ==",
       "requires": {
         "markdown-it": "^10.0.0",
         "markdown-it-plugin-underline": "0.0.1"
@@ -11284,9 +11284,9 @@
       },
       "dependencies": {
         "entities": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.2.tgz",
-          "integrity": "sha512-dmD3AvJQBUjKpcNkoqr+x+IF0SdRtPz9Vk0uTy4yWqga9ibB6s4v++QFWNohjiUGoMlF552ZvNyXDxz5iW0qmw=="
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+          "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Javascript Answers Programming Interface",
   "main": "gulpfile.js",
   "dependencies": {
-    "@yext/rtf-converter": "^1.1.1",
+    "@yext/rtf-converter": "^1.2.0",
     "core-js": "^3.6.5",
     "css-vars-ponyfill": "^2.3.1",
     "handlebars": "^4.7.2",

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -81,8 +81,8 @@ class Answers {
      * A reference to the formatRichText function.
      * @type {Function}
      */
-    this.formatRichText = (markdown, eventOptionsFieldName) =>
-      RichTextFormatter.format(markdown, eventOptionsFieldName);
+    this.formatRichText = (markdown, target, eventOptionsFieldName) =>
+      RichTextFormatter.format(markdown, target, eventOptionsFieldName);
 
     /**
      * A local reference to the component manager

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -81,8 +81,8 @@ class Answers {
      * A reference to the formatRichText function.
      * @type {Function}
      */
-    this.formatRichText = (markdown, target, eventOptionsFieldName) =>
-      RichTextFormatter.format(markdown, target, eventOptionsFieldName);
+    this.formatRichText = (markdown, targetConfig, eventOptionsFieldName) =>
+      RichTextFormatter.format(markdown, targetConfig, eventOptionsFieldName);
 
     /**
      * A local reference to the component manager

--- a/src/core/utils/richtextformatter.js
+++ b/src/core/utils/richtextformatter.js
@@ -7,26 +7,34 @@ import { AnswersCoreError } from '../errors/errors';
  * HTML conversions.
  */
 class RichTextFormatterImpl {
-  constructor () {
-    RtfConverter.addPlugin(iterator, 'url_new_win', 'link_open', this._urlTransformer);
-  }
-
   /**
    * Generates an HTML representation of the provided Rich Text field value. Note that
    * the HTML will contain a wrapper div. This is to support click analytics for Rich Text
    * links.
    *
    * @param {string} fieldValue A Rich Text field value.
+   * @param {string} target The 'target' attribute to supply to any link. This is optional.
+   *                        If no value is specified, the links will not have a 'target' attribute.
    * @param {string} fieldName The name of the field, to be included in the payload of a click
    *                           analytics event. This parameter is optional.
    * @returns {string} The HTML representation of the field value, serialized as a string.
    */
-  format (fieldValue, fieldName) {
+  format (fieldValue, target, fieldName) {
     if (typeof fieldValue !== 'string') {
       throw new AnswersCoreError(
         `Rich text "${fieldValue}" needs to be a string. Currently is a ${typeof fieldValue}`
       );
     }
+
+    const pluginName = 'url_transformer';
+    // Because all invocations of this method share the same {@link RtfConverter}, we must make sure to
+    // disable any other custom plugins applied previously.
+    RtfConverter.disablePlugin(pluginName);
+    RtfConverter.addPlugin(
+      iterator,
+      pluginName,
+      'link_open',
+      (tokens, idx) => this._urlTransformer(tokens, idx, target));
 
     fieldName = fieldName || '';
     const html =
@@ -40,7 +48,7 @@ class RichTextFormatterImpl {
    * An inline token parser for use with the {@link iterator} Markdown-it plugin.
    * This token parser adds a cta-type data attribute to any link it encounters.
    */
-  _urlTransformer (tokens, idx) {
+  _urlTransformer (tokens, idx, target) {
     const href = tokens[idx].attrGet('href');
     let ctaType = 'VIEW_WEBSITE';
     if (href.startsWith('mailto')) {
@@ -48,10 +56,10 @@ class RichTextFormatterImpl {
     } else if (href.startsWith('tel')) {
       ctaType = 'TAP_TO_CALL';
     }
-    tokens[idx].attrPush(['data-cta-type', ctaType]);
+    tokens[idx].attrSet('data-cta-type', ctaType);
+    target && tokens[idx].attrSet('target', target);
   }
 }
 
 const RichTextFormatter = new RichTextFormatterImpl();
-
 export default RichTextFormatter;

--- a/src/core/utils/richtextformatter.js
+++ b/src/core/utils/richtextformatter.js
@@ -13,34 +13,37 @@ class RichTextFormatterImpl {
    * links.
    *
    * @param {string} fieldValue A Rich Text field value.
-   * @param {string} target The 'target' attribute to supply to any link. This is optional.
-   *                        If no value is specified, the links will not have a 'target' attribute.
+   * @param {Object|string} targetConfig Configuration object specifying the 'target' behavior for
+   *                        the various types of links. If a string is provided, it is assumed that
+   *                        is the 'target' behavior across all types of links. This parameter is optional.
    * @param {string} fieldName The name of the field, to be included in the payload of a click
    *                           analytics event. This parameter is optional.
    * @returns {string} The HTML representation of the field value, serialized as a string.
    */
-  format (fieldValue, target, fieldName) {
+  format (fieldValue, targetConfig, fieldName) {
     if (typeof fieldValue !== 'string') {
       throw new AnswersCoreError(
         `Rich text "${fieldValue}" needs to be a string. Currently is a ${typeof fieldValue}`
       );
     }
 
-    const pluginName = 'url_transformer';
-    // Because all invocations of this method share the same {@link RtfConverter}, we must make sure to
-    // disable any other custom plugins applied previously.
-    RtfConverter.disablePlugin(pluginName);
+    const pluginName = this._generatePluginName();
     RtfConverter.addPlugin(
       iterator,
       pluginName,
       'link_open',
-      (tokens, idx) => this._urlTransformer(tokens, idx, target));
+      (tokens, idx) => this._urlTransformer(tokens, idx, targetConfig));
 
     fieldName = fieldName || '';
     const html =
       `<div class="js-yxt-rtfValue" data-field-name="${fieldName}">\n` +
       `${RtfConverter.toHTML(fieldValue)}` +
       '</div>';
+
+    // Because all invocations of this method share the same {@link RtfConverter}, we must make sure to
+    // disable the plugin added above. Otherwise, it will be applied in all subsequent conversions.
+    RtfConverter.disablePlugin(pluginName);
+
     return html;
   }
 
@@ -48,16 +51,41 @@ class RichTextFormatterImpl {
    * An inline token parser for use with the {@link iterator} Markdown-it plugin.
    * This token parser adds a cta-type data attribute to any link it encounters.
    */
-  _urlTransformer (tokens, idx, target) {
+  _urlTransformer (tokens, idx, targetConfig) {
+    targetConfig = targetConfig || {};
+    let target;
+    if (typeof targetConfig === 'string') {
+      target = targetConfig;
+    }
+
     const href = tokens[idx].attrGet('href');
-    let ctaType = 'VIEW_WEBSITE';
+    let ctaType;
     if (href.startsWith('mailto')) {
       ctaType = 'EMAIL';
+      target = target || targetConfig.email;
     } else if (href.startsWith('tel')) {
       ctaType = 'TAP_TO_CALL';
+      target = target || targetConfig.phone;
+    } else {
+      ctaType = 'VIEW_WEBSITE';
+      target = target || targetConfig.link;
     }
+
     tokens[idx].attrSet('data-cta-type', ctaType);
     target && tokens[idx].attrSet('target', target);
+  }
+
+  /**
+   * A function that generates a unique UUID to serve as the name for a
+   * Markdown-it plugin.
+   *
+   * @returns {string} the UUID.
+   */
+  _generatePluginName () {
+    function s4 () {
+      return Math.floor((1 + Math.random()) * 0x10000).toString(16).substring(1);
+    }
+    return s4() + s4() + '-' + s4() + '-' + s4() + '-' + s4() + '-' + s4() + s4() + s4();
   }
 }
 

--- a/tests/core/utils/richtextformatter.js
+++ b/tests/core/utils/richtextformatter.js
@@ -1,7 +1,7 @@
 import RichTextFormatter from '../../../src/core/utils/richtextformatter';
 
 describe('formats rich text to HTML', () => {
-  it('adds correct data attributes for links', () => {
+  it('adds cta-type data attribute correctly', () => {
     const richText =
         '**I AM BOLD** now I am not *I AM ITALICS* now I am not ++BRASAAAAAP++\n\n' +
         '* ++I am underline list++\n\n' +
@@ -24,6 +24,15 @@ describe('formats rich text to HTML', () => {
         '<p><u><a href="tel:+17326183404" data-cta-type="TAP_TO_CALL">phone link</a></u></p>\n' +
         '<p><u><a href="mailto:oshi@yext.com" data-cta-type="EMAIL">email link</a></u></p>\n' +
         '</div>';
-    expect(RichTextFormatter.format(richText, 'someField')).toEqual(expectedHTML);
+    expect(RichTextFormatter.format(richText, null, 'someField')).toEqual(expectedHTML);
+  });
+
+  it('adds target attribute correctly', () => {
+    const richText = '++[url link](http://google.com)++';
+    const expectedHTML =
+        '<div class="js-yxt-rtfValue" data-field-name="someField">\n' +
+        '<p><u><a href="http://google.com" data-cta-type="VIEW_WEBSITE" target="_blank">url link</a></u></p>\n' +
+        '</div>';
+    expect(RichTextFormatter.format(richText, '_blank', 'someField')).toEqual(expectedHTML);
   });
 });

--- a/tests/core/utils/richtextformatter.js
+++ b/tests/core/utils/richtextformatter.js
@@ -1,7 +1,7 @@
 import RichTextFormatter from '../../../src/core/utils/richtextformatter';
 
-describe('formats rich text to HTML', () => {
-  it('adds cta-type data attribute correctly', () => {
+describe('adds cta-type data attribute to links', () => {
+  it('adds attribute correctly', () => {
     const richText =
         '**I AM BOLD** now I am not *I AM ITALICS* now I am not ++BRASAAAAAP++\n\n' +
         '* ++I am underline list++\n\n' +
@@ -26,13 +26,35 @@ describe('formats rich text to HTML', () => {
         '</div>';
     expect(RichTextFormatter.format(richText, null, 'someField')).toEqual(expectedHTML);
   });
+});
 
-  it('adds target attribute correctly', () => {
-    const richText = '++[url link](http://google.com)++';
+describe('adds target attribute to links', () => {
+  it('adds attributes correctly when targetConfig is a string', () => {
+    const richText =
+      '++[url link](http://google.com)++\n\n' +
+      '++[phone link](tel:+17326183404)++\n\n' +
+      '++[email link](mailto:oshi@yext.com)++\n';
     const expectedHTML =
-        '<div class="js-yxt-rtfValue" data-field-name="someField">\n' +
-        '<p><u><a href="http://google.com" data-cta-type="VIEW_WEBSITE" target="_blank">url link</a></u></p>\n' +
-        '</div>';
+      '<div class="js-yxt-rtfValue" data-field-name="someField">\n' +
+      '<p><u><a href="http://google.com" data-cta-type="VIEW_WEBSITE" target="_blank">url link</a></u></p>\n' +
+      '<p><u><a href="tel:+17326183404" data-cta-type="TAP_TO_CALL" target="_blank">phone link</a></u></p>\n' +
+      '<p><u><a href="mailto:oshi@yext.com" data-cta-type="EMAIL" target="_blank">email link</a></u></p>\n' +
+      '</div>';
     expect(RichTextFormatter.format(richText, '_blank', 'someField')).toEqual(expectedHTML);
+  });
+
+  it('adds attributes correctly when targetConfig is an object', () => {
+    const richText =
+      '++[url link](http://google.com)++\n\n' +
+      '++[phone link](tel:+17326183404)++\n\n' +
+      '++[email link](mailto:oshi@yext.com)++\n';
+    const expectedHTML =
+      '<div class="js-yxt-rtfValue" data-field-name="someField">\n' +
+      '<p><u><a href="http://google.com" data-cta-type="VIEW_WEBSITE" target="_self">url link</a></u></p>\n' +
+      '<p><u><a href="tel:+17326183404" data-cta-type="TAP_TO_CALL" target="_blank">phone link</a></u></p>\n' +
+      '<p><u><a href="mailto:oshi@yext.com" data-cta-type="EMAIL">email link</a></u></p>\n' +
+      '</div>';
+    const targetConfig = { phone: '_blank', link: '_self' };
+    expect(RichTextFormatter.format(richText, targetConfig, 'someField')).toEqual(expectedHTML);
   });
 });


### PR DESCRIPTION
This PR adds a 'target' parameter to the SDK's formatRichText function. This
parameter, when specified, sets the 'target' attribute of all the formatted RTF
links. It is optional.

J=SPR-2134
TEST=auto, manual

Added unit tests for the updated formatRichText function. Manually verified:
- Passing a 'target' of '_blank' to formatRichText added the correct 'target'
  attribute to all of the link anchor tags.
- When I did not provide a 'target' to formatRichText, the link anchor tags had
  no 'target' attribute.