### PR TITLE
ResultsHeader: align elements

### DIFF
--- a/src/ui/sass/modules/_ResultsHeader.scss
+++ b/src/ui/sass/modules/_ResultsHeader.scss
@@ -137,6 +137,7 @@ $results-header-filters-line-height: var(--yxt-line-height-md) !default;
     padding-left: 5px;
     padding-right: 4px;
     margin-right: calc(var(--yxt-results-header-spacing) / 2);
+    white-space: nowrap;
     @include Text(
       $size: var(--yxt-font-size-sm),
       $color: var(--yxt-color-text-neutral),

--- a/src/ui/sass/modules/_ResultsHeader.scss
+++ b/src/ui/sass/modules/_ResultsHeader.scss
@@ -30,6 +30,7 @@ $results-header-filters-line-height: var(--yxt-line-height-md) !default;
 }
 .yxt-ResultsHeader {
   padding: calc(var(--yxt-results-header-spacing) / 4) var(--yxt-results-header-spacing);
+  padding-bottom: 0;
   display: flex;
   align-items: baseline;
 
@@ -94,6 +95,7 @@ $results-header-filters-line-height: var(--yxt-line-height-md) !default;
   {
     color: var(--yxt-results-header-filters-color);
     margin-right: calc(var(--yxt-results-header-spacing) / 2);
+    margin-bottom: calc(var(--yxt-results-header-spacing) / 4);
     @include Text(
       $size: var(--yxt-results-header-filters-font-size),
       $line-height: var(--yxt-results-header-filters-line-height),
@@ -105,6 +107,7 @@ $results-header-filters-line-height: var(--yxt-line-height-md) !default;
   {
     color: var(--yxt-results-header-filters-color);
     margin-right: calc(var(--yxt-results-header-spacing) / 2);
+    margin-bottom: calc(var(--yxt-results-header-spacing) / 4);
     @include Text(
       $size: var(--yxt-results-header-filters-font-size),
       $line-height: var(--yxt-results-header-filters-line-height),
@@ -115,6 +118,7 @@ $results-header-filters-line-height: var(--yxt-line-height-md) !default;
   &-changeFilters
   {
     margin-left: calc(var(--yxt-results-header-spacing) / 2);
+    margin-bottom: calc(var(--yxt-results-header-spacing) / 4);
     padding-right: var(--yxt-results-header-spacing);
     @include Link(
       $base-color: var(--yxt-color-brand-primary)


### PR DESCRIPTION
Spacing was slightly misaligned. I think we have to put margin-bottom
on the elements within the header instead of on the container, otherwise
the margin-bottom on the removable filter tags needs to be removed,
which causes them to be stacked without spacing when they
overflow into multiple rows.

TEST=manual
check that all elements in the results header have the same bottom spacing
check that on universal top and bottom spacing of the bar is even