### PR TITLE
ResultsHeader: removableLabelText fix default

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,7 +586,7 @@ ANSWERS.addComponent('VerticalResults', {
     // The aria-label given to the applied filters bar. Defaults to 'Filters applied to this search:'.
     labelText: 'Filters applied to this search:',
     // The aria-label given to the removable filter buttons.
-    removableLabelText: 'Remove'
+    removableLabelText: 'Remove this filter'
   }
 })
 ```

--- a/src/ui/components/results/resultsheadercomponent.js
+++ b/src/ui/components/results/resultsheadercomponent.js
@@ -16,7 +16,7 @@ const DEFAULT_CONFIG = {
   delimiter: '|',
   isUniversal: false,
   labelText: 'Filters applied to this search:',
-  removableLabelText: 'Remove'
+  removableLabelText: 'Remove this filter'
 };
 
 export default class ResultsHeaderComponent extends Component {

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -122,7 +122,7 @@ class VerticalResultsConfig {
        * The aria-label given to the removable filter buttons.
        * @type {string}
        */
-      removableLabelText: defaultConfigOption(config, ['appliedFilters.removableLabelText'], 'Remove')
+      removableLabelText: defaultConfigOption(config, ['appliedFilters.removableLabelText'], 'Remove this filter')
     };
 
     /**


### PR DESCRIPTION
The spec had it as just 'Remove' but apparently this was
supposed to be 'Remove this filter'

TEST=manual
check that defaults to 'Remove this filter'