### PR TITLE
Icons: Center close icon in viewbox

### DIFF
--- a/src/ui/icons/close.js
+++ b/src/ui/icons/close.js
@@ -1,9 +1,10 @@
 import SVGIcon from './icon.js';
 export default new SVGIcon({
   name: 'close',
+  viewBox: '0 1 24 24',
   complexContents: `
-    <path d="M7 8l9.716 9.716m0-9.716L7 17.716" 
-          stroke="currentColor" 
+    <path d="M7 8l9.716 9.716m0-9.716L7 17.716"
+          stroke="currentColor"
           stroke-width="2"/>
   `
 });


### PR DESCRIPTION
Previously, the close SVG's path was not centered in its viewbox, as you can see it the screenshot below it is slightly too low.
<img width="1099" alt="Screen Shot 2020-06-05 at 4 14 03 PM" src="https://user-images.githubusercontent.com/39104038/83926641-ab7f8880-a747-11ea-8834-2a5b331e71de.png">

Update close SVG icon so that the path (X) is in the center of the viewbox.

TEST=manual,visual

Serve site and look at the (centered) SVG in the browser and see that the path is centered within the SVG.