### PR TITLE
Pagination: fix scss &-hidden to &--hidden

### DIFF
--- a/src/ui/sass/modules/_Pagination.scss
+++ b/src/ui/sass/modules/_Pagination.scss
@@ -31,7 +31,7 @@ $pagination-color-hover: var(--yxt-color-text-secondary) !default;
     $color: var(--yxt-pagination-text-color)
   );
 
-  &-hidden {
+  &--hidden {
     visibility: hidden;
   }
 


### PR DESCRIPTION
This probably broke in a rebase. This was letting
you click the previous page button even if you were at
page 1.

TEST=manual
check that cannot go to pages less than 1