### PR TITLE
ResultsHeader: different filter spacing when removable

### DIFF
--- a/src/ui/sass/modules/_ResultsHeader.scss
+++ b/src/ui/sass/modules/_ResultsHeader.scss
@@ -42,7 +42,7 @@ $results-header-filters-line-height: var(--yxt-line-height-md) !default;
 
   &-resultsCount
   {
-    margin-right: calc(var(--yxt-results-header-spacing) / 2);
+    margin-right: calc(var(--yxt-results-header-spacing) / 4);
     margin-bottom: 4px;
     white-space: nowrap;
     @include Text(
@@ -64,7 +64,7 @@ $results-header-filters-line-height: var(--yxt-line-height-md) !default;
   &-filterLabel
   {
     display: flex;
-    margin-right: 5px;
+    margin-right: calc(var(--yxt-results-header-spacing) / 4);
     margin-bottom: 4px;
     @include Text(
       $size: var(--yxt-results-header-filters-font-size),
@@ -94,7 +94,7 @@ $results-header-filters-line-height: var(--yxt-line-height-md) !default;
   &-resultsCountSeparator
   {
     color: var(--yxt-results-header-filters-color);
-    margin-right: calc(var(--yxt-results-header-spacing) / 2);
+    margin-right: calc(var(--yxt-results-header-spacing) / 4);
     margin-bottom: calc(var(--yxt-results-header-spacing) / 4);
     @include Text(
       $size: var(--yxt-results-header-filters-font-size),
@@ -106,7 +106,7 @@ $results-header-filters-line-height: var(--yxt-line-height-md) !default;
   &-filterSeparator
   {
     color: var(--yxt-results-header-filters-color);
-    margin-right: calc(var(--yxt-results-header-spacing) / 2);
+    margin-right: calc(var(--yxt-results-header-spacing) / 4);
     margin-bottom: calc(var(--yxt-results-header-spacing) / 4);
     @include Text(
       $size: var(--yxt-results-header-filters-font-size),
@@ -168,4 +168,16 @@ $results-header-filters-line-height: var(--yxt-line-height-md) !default;
   display: flex;
   align-items: center;
   flex-wrap: wrap;
+}
+
+.yxt-ResultsHeader--removable .yxt-ResultsHeader
+{
+  &-resultsCount,
+  &-filterLabel,
+  &-filterValue,
+  &-resultsCountSeparator,
+  &-filterSeparator
+  {
+    margin-right: calc(var(--yxt-results-header-spacing) / 2);
+  }
 }

--- a/src/ui/templates/results/resultsheader.hbs
+++ b/src/ui/templates/results/resultsheader.hbs
@@ -1,4 +1,6 @@
-<div class="yxt-ResultsHeader{{#if _config.isUniversal}} yxt-ResultsHeader--universal{{/if}}">
+<div class="yxt-ResultsHeader
+  {{~#if _config.isUniversal}} yxt-ResultsHeader--universal{{/if}}
+  {{~#if _config.removable}} yxt-ResultsHeader--removable{{/if}}">
   {{> resultscount}}
   {{#if showResultSeparator}}
     <div class="yxt-ResultsHeader-resultsCountSeparator">{{_config.resultsCountSeparator}}</div>


### PR DESCRIPTION
item below
"Current: Margin-right for .yxt-ResultsHeader-resultsCount, yxt-ResultsHeader-filterLabel, yxt-ResultsHeader-filterValue  AND .yxt-ResultsHeader-filterSeparator, .yxt-ResultsHeader-resultsCountSeparator is calc(var(--yxt-results-header-spacing)/2)
Expected: When removable: false and always on universal, margin-right for these classes is calc(var(--yxt-results-header-spacing)/4)

I know this differs from the mocks there's just a lot of space right now that feels unnecessary. We need them for removability because there's supposed to be 1rem of spacing between touch targets.  "

TEST=manual
check that on universal, or vertical with appliedFilters.removable = false, has spacing of 4px
check that with appliedFilters.removable = true, has spacing of 8px