### PR TITLE
Filters: Allow field level overrides for showCount, pass through expanded

### DIFF
--- a/src/ui/components/filters/facetscomponent.js
+++ b/src/ui/components/filters/facetscomponent.js
@@ -225,6 +225,7 @@ export default class FacetsComponent extends Component {
         searchable: this.config.searchable,
         searchLabelText: this.config.searchLabelText,
         placeholderText: this.config.placeholderText,
+        showExpand: fieldOverrides.expand || this.config.expand,
         ...fieldOverrides
       });
     });

--- a/src/ui/components/filters/filterboxcomponent.js
+++ b/src/ui/components/filters/filterboxcomponent.js
@@ -154,16 +154,10 @@ export default class FilterBoxComponent extends Component {
      */
     this._filterNodes = [];
 
-    if (!this.config.showCount) {
-      this.config.filterConfigs.forEach(config => {
-        config.options.forEach(option => {
-          option.countLabel = null;
-        });
-      });
-    }
-
     this.config.filterConfigs.forEach(config => {
-      if (config.showCount !== undefined && !config.showCount) {
+      let hideCount = config.showCount === undefined ? !this.config.showCount : !config.showCount;
+
+      if (hideCount) {
         config.options.forEach(option => {
           option.countLabel = null;
         });

--- a/src/ui/components/filters/filterboxcomponent.js
+++ b/src/ui/components/filters/filterboxcomponent.js
@@ -161,6 +161,14 @@ export default class FilterBoxComponent extends Component {
         });
       });
     }
+
+    this.config.filterConfigs.forEach(config => {
+      if (config.showCount !== undefined && !config.showCount) {
+        config.options.forEach(option => {
+          option.countLabel = null;
+        });
+      }
+    });
   }
 
   static get type () {


### PR DESCRIPTION
v1.4.0 QA: showCount and expanded should be passed through from the "fields" config in Facets.

TEST=manual

On local test experience, set "expanded: false" at a field-level in config with "expanded: true" at the component-level config. See field's filter un-expanded and the rest of the fields in the component expanded. Set "showCount: false" at a field-level config. See the count is hidden for the field, but it still displays for all the other fields.