### PR TITLE
DirectAnswer: allow for custom component

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,8 @@ The Direct Answer Component will render the BEST result, if found, based on the 
 ANSWERS.addComponent('DirectAnswer', {
   // Required, the selector for the container element where the component will be injected
   container: '.direct-answer-container',
+  // Optional, a custom card component to use.
+  defaultCard: 'MyCustomCard',
   // Optional, the selector for the form used for submitting the feedback
   formEl: '.js-directAnswer-feedback-form',
   // Optional, the selector to bind ui interaction to for reporting

--- a/src/ui/components/results/directanswercomponent.js
+++ b/src/ui/components/results/directanswercomponent.js
@@ -86,8 +86,10 @@ export default class DirectAnswerComponent extends Component {
    * we want to wire up the behavior for interacting with the quality feedback reporting (thumbsup/down)
    */
   onMount () {
-    // Avoid bindings if the feedback has previously been submitted
-    if (this.getState('feedbackSubmitted') === true) {
+    const isUsingCustomCard = this._config.defaultCard;
+    const feedbackSubmitted = this.getState('feedbackSubmitted') === true;
+    // Avoid bindings if the feedback has previously been submitted or is using a custom card.
+    if (isUsingCustomCard || feedbackSubmitted) {
       return this;
     }
 
@@ -180,5 +182,12 @@ export default class DirectAnswerComponent extends Component {
       });
 
     this.analyticsReporter.report(event);
+  }
+
+  addChild (data, type, opts) {
+    if (type === this._config.defaultCard) {
+      return super.addChild(this.getState(), type, opts);
+    }
+    return super.addChild(data, type, opts);
   }
 }

--- a/src/ui/components/results/directanswercomponent.js
+++ b/src/ui/components/results/directanswercomponent.js
@@ -86,14 +86,15 @@ export default class DirectAnswerComponent extends Component {
    * we want to wire up the behavior for interacting with the quality feedback reporting (thumbsup/down)
    */
   onMount () {
-    // Avoid bindings if the feedback has previously been submitted
-    if (this.getState('feedbackSubmitted') === true) {
+    const isUsingCustomCard = this._config.defaultCard;
+    const feedbackSubmitted = this.getState('feedbackSubmitted') === true;
+    // Avoid bindings if the feedback has previously been submitted or is using a custom card.
+    if (isUsingCustomCard || feedbackSubmitted) {
       return this;
     }
 
     // For WCAG compliance, the feedback should be a submittable form
-    const formEl = DOM.query(this._container, this._formEl);
-    formEl && DOM.on(this._formEl, 'submit', (e) => {
+    DOM.on(this._formEl, 'submit', (e) => {
       const formEl = e.target;
       const checkedValue = DOM.query(formEl, 'input:checked').value === 'true';
 
@@ -105,10 +106,8 @@ export default class DirectAnswerComponent extends Component {
 
     // Is this actually necessary? I guess it's only necessary if the
     // submit button is hidden.
-    const thumbsUpEl = DOM.query(this._container, this._thumbsUpSelector);
-    thumbsUpEl && DOM.on(this._thumbsUpSelector, 'click', () => { DOM.trigger(this._formEl, 'submit'); });
-    const thumbsDownEl = DOM.query(this._container, this._thumbsDownSelector);
-    thumbsDownEl && DOM.on(this._thumbsDownSelector, 'click', () => { DOM.trigger(this._formEl, 'submit'); });
+    DOM.on(this._thumbsUpSelector, 'click', () => { DOM.trigger(this._formEl, 'submit'); });
+    DOM.on(this._thumbsDownSelector, 'click', () => { DOM.trigger(this._formEl, 'submit'); });
 
     const rtfElement = DOM.query(this._container, '.js-yxt-rtfValue');
     rtfElement && DOM.on(rtfElement, 'click', e => this._handleRtfClickAnalytics(e));

--- a/src/ui/components/results/directanswercomponent.js
+++ b/src/ui/components/results/directanswercomponent.js
@@ -86,15 +86,14 @@ export default class DirectAnswerComponent extends Component {
    * we want to wire up the behavior for interacting with the quality feedback reporting (thumbsup/down)
    */
   onMount () {
-    const isUsingCustomCard = this._config.defaultCard;
-    const feedbackSubmitted = this.getState('feedbackSubmitted') === true;
-    // Avoid bindings if the feedback has previously been submitted or is using a custom card.
-    if (isUsingCustomCard || feedbackSubmitted) {
+    // Avoid bindings if the feedback has previously been submitted
+    if (this.getState('feedbackSubmitted') === true) {
       return this;
     }
 
     // For WCAG compliance, the feedback should be a submittable form
-    DOM.on(this._formEl, 'submit', (e) => {
+    const formEl = DOM.query(this._container, this._formEl);
+    formEl && DOM.on(this._formEl, 'submit', (e) => {
       const formEl = e.target;
       const checkedValue = DOM.query(formEl, 'input:checked').value === 'true';
 
@@ -106,8 +105,10 @@ export default class DirectAnswerComponent extends Component {
 
     // Is this actually necessary? I guess it's only necessary if the
     // submit button is hidden.
-    DOM.on(this._thumbsUpSelector, 'click', () => { DOM.trigger(this._formEl, 'submit'); });
-    DOM.on(this._thumbsDownSelector, 'click', () => { DOM.trigger(this._formEl, 'submit'); });
+    const thumbsUpEl = DOM.query(this._container, this._thumbsUpSelector);
+    thumbsUpEl && DOM.on(this._thumbsUpSelector, 'click', () => { DOM.trigger(this._formEl, 'submit'); });
+    const thumbsDownEl = DOM.query(this._container, this._thumbsDownSelector);
+    thumbsDownEl && DOM.on(this._thumbsDownSelector, 'click', () => { DOM.trigger(this._formEl, 'submit'); });
 
     const rtfElement = DOM.query(this._container, '.js-yxt-rtfValue');
     rtfElement && DOM.on(rtfElement, 'click', e => this._handleRtfClickAnalytics(e));
@@ -152,6 +153,7 @@ export default class DirectAnswerComponent extends Component {
   }
 
   setState (data) {
+    this.directAnswer = data;
     return super.setState(Object.assign({}, data, {
       eventOptions: this.eventOptions(data),
       viewDetailsText: this._viewDetailsText
@@ -186,7 +188,7 @@ export default class DirectAnswerComponent extends Component {
 
   addChild (data, type, opts) {
     if (type === this._config.defaultCard) {
-      return super.addChild(this.getState(), type, opts);
+      return super.addChild(this.directAnswer, type, opts);
     }
     return super.addChild(data, type, opts);
   }

--- a/src/ui/components/results/directanswercomponent.js
+++ b/src/ui/components/results/directanswercomponent.js
@@ -27,6 +27,12 @@ export default class DirectAnswerComponent extends Component {
     super({ ...DEFAULT_CONFIG, ...config }, systemConfig);
 
     /**
+     * The user given config, without any defaults applied.
+     * @type {Object}
+     */
+    this._userConfig = { ...config };
+
+    /**
      * Recieve updates from storage based on this index
      * @type {StorageKey}
      */
@@ -187,7 +193,10 @@ export default class DirectAnswerComponent extends Component {
 
   addChild (data, type, opts) {
     if (type === this._config.defaultCard) {
-      return super.addChild(this.directAnswer, type, opts);
+      return super.addChild(this.directAnswer, type, {
+        ...this._userConfig,
+        ...opts
+      });
     }
     return super.addChild(data, type, opts);
   }

--- a/src/ui/templates/results/directanswer.hbs
+++ b/src/ui/templates/results/directanswer.hbs
@@ -1,88 +1,88 @@
 {{#if _config.defaultCard}}
-<div class="yxt-DirectAnswer" data-component="{{_config.defaultCard}}"></div>
+  <div class="yxt-DirectAnswer--customComponent" data-component="{{_config.defaultCard}}"></div>
 {{else}}
-<div class="yxt-DirectAnswer">
-  <div class="yxt-DirectAnswer-title">
-    <div class="yxt-Results-titleIconWrapper"
-         data-component="IconComponent"
-         data-opts='{
-            "iconName": "{{iconName}}",
-            "iconUrl": "{{customIconUrl}}"
-          }'
-         data-prop="icon"
-    ></div>
-    <h2 class="yxt-DirectAnswer-titleText">
-      <span class="yxt-DirectAnswer-entityName">
-        {{answer.entityName}}
-      </span>
-      <span class="yxt-DirectAnswer-slash">
-        /
-      </span>
-      <span class="yxt-DirectAnswer-fieldName">
-        {{answer.fieldName}}
-      </span>
-    </h2>
-  </div>
-  <div class="yxt-DirectAnswer-content">
-    <div class="yxt-DirectAnswer-fieldValue">
-      {{{answer.value}}}
+  <div class="yxt-DirectAnswer">
+    <div class="yxt-DirectAnswer-title">
+      <div class="yxt-Results-titleIconWrapper"
+          data-component="IconComponent"
+          data-opts='{
+              "iconName": "{{iconName}}",
+              "iconUrl": "{{customIconUrl}}"
+            }'
+          data-prop="icon"
+      ></div>
+      <h2 class="yxt-DirectAnswer-titleText">
+        <span class="yxt-DirectAnswer-entityName">
+          {{answer.entityName}}
+        </span>
+        <span class="yxt-DirectAnswer-slash">
+          /
+        </span>
+        <span class="yxt-DirectAnswer-fieldName">
+          {{answer.fieldName}}
+        </span>
+      </h2>
     </div>
-    {{#if relatedItem.data.website}}
-      <div class="yxt-DirectAnswer-viewMoreWrapper">
-        <a class="yxt-DirectAnswer-viewMore"
-           href="{{relatedItem.data.website}}"
-           data-middleclick="active"
-           data-eventtype="CTA_CLICK"
-           data-eventoptions="{{eventOptions}}"
-           target="{{#if _config.linkTarget}}{{_config.linkTarget}}{{else}}_blank{{/if}}">
-          {{viewDetailsText}}
-        </a>
+    <div class="yxt-DirectAnswer-content">
+      <div class="yxt-DirectAnswer-fieldValue">
+        {{{answer.value}}}
       </div>
-    {{/if}}
-  </div>
-  <div class="yxt-DirectAnswer-footerWrapper">
-    <div class="yxt-DirectAnswer-footer">
-      {{#if feedbackSubmitted}}
-      <div class="yxt-DirectAnswer-footerText">
-          {{_config.footerTextOnSubmission}}
-      </div>
-      {{else}}
-        <div class="yxt-DirectAnswer-footerText">
-          {{_config.footerText}}
+      {{#if relatedItem.data.website}}
+        <div class="yxt-DirectAnswer-viewMoreWrapper">
+          <a class="yxt-DirectAnswer-viewMore"
+            href="{{relatedItem.data.website}}"
+            data-middleclick="active"
+            data-eventtype="CTA_CLICK"
+            data-eventoptions="{{eventOptions}}"
+            target="{{#if _config.linkTarget}}{{_config.linkTarget}}{{else}}_blank{{/if}}">
+            {{viewDetailsText}}
+          </a>
         </div>
-        <form class="yxt-DirectAnswer-thumbs js-directAnswer-feedback-form">
-          <label class="yxt-DirectAnswer-thumb">
-            <span class="yxt-DirectAnswer-thumbUpIcon"
-                 data-component="IconComponent"
-                 data-opts='{"iconName": "thumb"}'
-                 data-prop="icon"
-            ></span>
-            <input type="radio"
-                   name="feedback"
-                   value="true"
-                   class="yxt-DirectAnswer-feedback yxt-DirectAnswer-thumbUpButton js-directAnswer-thumbUp">
-            <span class="sr-only">
-              {{_config.positiveFeedbackSrText}}
-            </span>
-          </label>
-          <label class="yxt-DirectAnswer-thumb">
-            <span class="yxt-DirectAnswer-thumbDownIcon"
-                 data-component="IconComponent"
-                 data-opts='{"iconName": "thumb"}'
-                 data-prop="icon"
-            ></span>
-            <input type="radio"
-                   name="feedback"
-                   value="false"
-                   class="yxt-DirectAnswer-feedback yxt-DirectAnswer-thumbDownButton js-directAnswer-thumbDown">
-            <span class="sr-only">
-              {{_config.negativeFeedbackSrText}}
-            </span>
-          </label>
-          <button type="submit" class="sr-only sr-only-focusable">Send feedback</button>
-        </form>
       {{/if}}
     </div>
+    <div class="yxt-DirectAnswer-footerWrapper">
+      <div class="yxt-DirectAnswer-footer">
+        {{#if feedbackSubmitted}}
+        <div class="yxt-DirectAnswer-footerText">
+            {{_config.footerTextOnSubmission}}
+        </div>
+        {{else}}
+          <div class="yxt-DirectAnswer-footerText">
+            {{_config.footerText}}
+          </div>
+          <form class="yxt-DirectAnswer-thumbs js-directAnswer-feedback-form">
+            <label class="yxt-DirectAnswer-thumb">
+              <span class="yxt-DirectAnswer-thumbUpIcon"
+                  data-component="IconComponent"
+                  data-opts='{"iconName": "thumb"}'
+                  data-prop="icon"
+              ></span>
+              <input type="radio"
+                    name="feedback"
+                    value="true"
+                    class="yxt-DirectAnswer-feedback yxt-DirectAnswer-thumbUpButton js-directAnswer-thumbUp">
+              <span class="sr-only">
+                {{_config.positiveFeedbackSrText}}
+              </span>
+            </label>
+            <label class="yxt-DirectAnswer-thumb">
+              <span class="yxt-DirectAnswer-thumbDownIcon"
+                  data-component="IconComponent"
+                  data-opts='{"iconName": "thumb"}'
+                  data-prop="icon"
+              ></span>
+              <input type="radio"
+                    name="feedback"
+                    value="false"
+                    class="yxt-DirectAnswer-feedback yxt-DirectAnswer-thumbDownButton js-directAnswer-thumbDown">
+              <span class="sr-only">
+                {{_config.negativeFeedbackSrText}}
+              </span>
+            </label>
+            <button type="submit" class="sr-only sr-only-focusable">Send feedback</button>
+          </form>
+        {{/if}}
+      </div>
+    </div>
   </div>
-</div>
 {{/if}}

--- a/src/ui/templates/results/directanswer.hbs
+++ b/src/ui/templates/results/directanswer.hbs
@@ -1,3 +1,6 @@
+{{#if _config.defaultCard}}
+<div class="yxt-DirectAnswer" data-component="{{_config.defaultCard}}"></div>
+{{else}}
 <div class="yxt-DirectAnswer">
   <div class="yxt-DirectAnswer-title">
     <div class="yxt-Results-titleIconWrapper"
@@ -82,3 +85,4 @@
     </div>
   </div>
 </div>
+{{/if}}


### PR DESCRIPTION
This commit allows users the use a custom component for DirectAnswer.
The main difference between this and directly adding a custom component
with ANSWERS.addComponent is that you don't have to import StorageKeys
from the SDK.

I tried to find a way to directly call this.addChild() within the onMount()
of the direct answer component, to reduce the number of unnecessary containers
in the DOM. I found that when doing this the SDK will create an additional copy
of the original container, and decided not to mess with it after a while.

TEST=manual
tested with below component

class CustomDA1 extends ANSWERS.Component {
  constructor(config = {}, systemConfig = {}) {
    super(config, systemConfig);
    this.setTemplate('{{log this}}<div>{{answer.value}}</div>')
  }

  setState(data) {
    return super.setState(data);
  }

  static get type() {
    return 'CustomDA1';
  }
}
ANSWERS.registerComponentType(CustomDA1);

saw that direct answer data was being passed through both in the {{log this}} and
that it can be used in the template.