### PR TITLE
Pagination: useFacets when running search

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -217,7 +217,7 @@ export default class Core {
    * @param {string} verticalKey The vertical key to use in the search
    */
   verticalPage (verticalKey) {
-    this.verticalSearch(verticalKey, {}, {
+    this.verticalSearch(verticalKey, { useFacets: true }, {
       id: this.globalStorage.getState(StorageKeys.QUERY_ID)
     });
   }


### PR DESCRIPTION
Pagination was not applying facets when running a new search.

TEST=manual
set search limit to 3, choose facets with more than 3 results
check that going to the second page still uses the applied facets