### PR TITLE
ResultsHeader: default background color to white on universal

### DIFF
--- a/src/ui/sass/modules/_Results.scss
+++ b/src/ui/sass/modules/_Results.scss
@@ -115,7 +115,7 @@ $results-cards-margin: calc(var(--yxt-base-spacing) / 2) !default;
     margin-top: 0;
     margin-bottom: 0;
     padding: calc(var(--yxt-base-spacing) / 2) var(--yxt-base-spacing);
-    background-color: $results-filters-background;
+    background-color: var(--yxt-results-filters-background);
     border-right: var(--yxt-results-border);
     border-left: var(--yxt-results-border);
     border-bottom: var(--yxt-results-border);

--- a/src/ui/sass/modules/_Results.scss
+++ b/src/ui/sass/modules/_Results.scss
@@ -1,7 +1,7 @@
 /** @define Results */
 
 $results-title-bar-background: var(--yxt-color-background-highlight) !default;
-$results-filters-background: white !default;
+$results-filters-background: var(--yxt-color-brand-white) !default;
 
 $results-title-bar-text-color: var(--yxt-color-text-primary) !default;
 $results-title-bar-text-font-size: var(--yxt-font-size-md-lg) !default;

--- a/src/ui/sass/modules/_Results.scss
+++ b/src/ui/sass/modules/_Results.scss
@@ -1,7 +1,7 @@
 /** @define Results */
 
 $results-title-bar-background: var(--yxt-color-background-highlight) !default;
-$results-filters-background: var(--yxt-color-brand-white) !default;
+$results-filters-background: white !default;
 
 $results-title-bar-text-color: var(--yxt-color-text-primary) !default;
 $results-title-bar-text-font-size: var(--yxt-font-size-md-lg) !default;

--- a/src/ui/sass/modules/_ResultsHeader.scss
+++ b/src/ui/sass/modules/_ResultsHeader.scss
@@ -2,7 +2,6 @@
 
 $results-header-font-size: var(--yxt-font-size-md) !default;
 $results-header-spacing: var(--yxt-base-spacing) !default;
-$results-header-background: var(--yxt-color-brand-white) !default;
 
 $results-header-color: var(--yxt-color-text-secondary) !default;
 $results-header-font-weight: var(--yxt-font-weight-normal) !default;
@@ -16,10 +15,11 @@ $results-header-filters-font-size: var(--yxt-font-size-md) !default;
 $results-header-filters-color: var(--yxt-color-text-secondary) !default;
 $results-header-filters-line-height: var(--yxt-line-height-md) !default;
 
+$results-header-universal-background: var(--yxt-color-brand-white) !default;
+
 :root {
   --yxt-results-header-font-size: #{$results-header-font-size};
   --yxt-results-header-spacing: #{$results-header-spacing};
-  --yxt-results-header-background: #{$results-header-background};
   --yxt-results-header-color: #{$results-header-color};
   --yxt-results-header-font-weight: #{$results-header-font-weight};
   --yxt-results-header-line-height: #{$results-header-line-height};
@@ -29,6 +29,7 @@ $results-header-filters-line-height: var(--yxt-line-height-md) !default;
   --yxt-results-header-filters-font-size: #{$results-header-filters-font-size};
   --yxt-results-header-filters-color: #{$results-header-filters-color};
   --yxt-results-header-filters-line-height: #{$results-header-filters-line-height};
+  --yxt-results-header-universal-background: #{$results-header-universal-background};
 }
 
 .yxt-ResultsHeader {
@@ -36,7 +37,6 @@ $results-header-filters-line-height: var(--yxt-line-height-md) !default;
   padding-bottom: 0;
   display: flex;
   align-items: baseline;
-  background-color: var(--yxt-results-header-background);
 
   &-wrapper {
     display: flex;
@@ -172,6 +172,7 @@ $results-header-filters-line-height: var(--yxt-line-height-md) !default;
   display: flex;
   align-items: center;
   flex-wrap: wrap;
+  background-color: var(--yxt-results-header-universal-background);
 }
 
 .yxt-ResultsHeader--removable .yxt-ResultsHeader

--- a/src/ui/sass/modules/_ResultsHeader.scss
+++ b/src/ui/sass/modules/_ResultsHeader.scss
@@ -2,6 +2,7 @@
 
 $results-header-font-size: var(--yxt-font-size-md) !default;
 $results-header-spacing: var(--yxt-base-spacing) !default;
+$results-header-background: var(--yxt-color-brand-white) !default;
 
 $results-header-color: var(--yxt-color-text-secondary) !default;
 $results-header-font-weight: var(--yxt-font-weight-normal) !default;
@@ -18,6 +19,7 @@ $results-header-filters-line-height: var(--yxt-line-height-md) !default;
 :root {
   --yxt-results-header-font-size: #{$results-header-font-size};
   --yxt-results-header-spacing: #{$results-header-spacing};
+  --yxt-results-header-background: #{$results-header-background};
   --yxt-results-header-color: #{$results-header-color};
   --yxt-results-header-font-weight: #{$results-header-font-weight};
   --yxt-results-header-line-height: #{$results-header-line-height};
@@ -28,11 +30,13 @@ $results-header-filters-line-height: var(--yxt-line-height-md) !default;
   --yxt-results-header-filters-color: #{$results-header-filters-color};
   --yxt-results-header-filters-line-height: #{$results-header-filters-line-height};
 }
+
 .yxt-ResultsHeader {
   padding: calc(var(--yxt-results-header-spacing) / 4) var(--yxt-results-header-spacing);
   padding-bottom: 0;
   display: flex;
   align-items: baseline;
+  background-color: var(--yxt-results-header-background);
 
   &-wrapper {
     display: flex;

--- a/src/ui/sass/modules/_ResultsHeader.scss
+++ b/src/ui/sass/modules/_ResultsHeader.scss
@@ -15,7 +15,7 @@ $results-header-filters-font-size: var(--yxt-font-size-md) !default;
 $results-header-filters-color: var(--yxt-color-text-secondary) !default;
 $results-header-filters-line-height: var(--yxt-line-height-md) !default;
 
-$results-header-universal-background: var(--yxt-color-brand-white) !default;
+$results-header-universal-background: white !default;
 
 :root {
   --yxt-results-header-font-size: #{$results-header-font-size};

--- a/src/ui/sass/modules/_ResultsHeader.scss
+++ b/src/ui/sass/modules/_ResultsHeader.scss
@@ -15,7 +15,7 @@ $results-header-filters-font-size: var(--yxt-font-size-md) !default;
 $results-header-filters-color: var(--yxt-color-text-secondary) !default;
 $results-header-filters-line-height: var(--yxt-line-height-md) !default;
 
-$results-header-universal-background: white !default;
+$results-header-universal-background: var(--yxt-color-brand-white) !default;
 
 :root {
   --yxt-results-header-font-size: #{$results-header-font-size};


### PR DESCRIPTION
"Current: On universal, the filters no longer has a background color
Expected: On universal, applied filters should have background-color: var(--yxt-results-filters-background) as they did before "

TEST=manual
check that I can set the results-header-background variable to --yxt-color-brand-primary,
to make the background blue, then change it to --yxt-color-brand-white to make it white
set background color of a vertical and universal test page to alicia blue, and checked the results header was only white for the vertical page