### PR TITLE
Pagination: fix show first/last page button defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -888,10 +888,10 @@ ANSWERS.addComponent('Pagination', {
   },
   // Function invoked when a user clicks to change pages. By default, scrolls the user to the top of the page.
   onPaginate: (newPageNumber, oldPageNumber, totalPages) => {},
-  // DEPRECATED with showFirstAndLastButton.
+  // DEPRECATED, please use showFirstAndLastButton instead.
   // Display a double arrow allowing users to jump to the first page of results. Defaults to showFirstAndLastButton.
   showFirst: true,
-  // DEPRECATED with showFirstAndLastButton.
+  // DEPRECATED, please use showFirstAndLastButton instead.
   // Display a double arrow allowing users to jump to the last page of results. Defaults to showFirstAndLastButton.
   showLast: true,
 });

--- a/README.md
+++ b/README.md
@@ -870,15 +870,15 @@ ANSWERS.addComponent('Pagination', {
   container: '.pagination-component',
   // Required*, the vertical for pagination, *if omitted, will fall back to the search base config
   verticalKey: 'verticalKey',
-  // The maximum number of pages visible to non-mobile users.
+  // Optional, the maximum number of pages visible to non-mobile users. Defaults to 1.
   maxVisiblePagesDesktop: 1,
-  // The maximum number of pages visible to mobile users.
+  // Optional, the maximum number of pages visible to mobile users. Defaults to 1.
   maxVisiblePagesMobile: 1,
-  // Ensure that the page numbers for first and last page are always shown. Not recommended to use with showFirstAndLastButton.
+  // Optional, ensure that the page numbers for first and last page are always shown. Not recommended to use with showFirstAndLastButton. Defaults to false.
   pinFirstAndLastPage: false,
-  // Display double-arrows allowing users to jump to the first and last page of results.
+  // Optional, display double-arrows allowing users to jump to the first and last page of results. Defaults to true.
   showFirstAndLastButton: true,
-  // Optional, label for a page of results
+  // Optional, label for a page of results. Defaults to 'Page'.
   pageLabel: 'Page',
   // Optional, configuration for the pagination behavior when a query returns no results
   noResults: {
@@ -889,10 +889,10 @@ ANSWERS.addComponent('Pagination', {
   // Function invoked when a user clicks to change pages. By default, scrolls the user to the top of the page.
   onPaginate: (newPageNumber, oldPageNumber, totalPages) => {},
   // DEPRECATED with showFirstAndLastButton.
-  // Display a double arrow allowing users to jump to the first page of results
+  // Display a double arrow allowing users to jump to the first page of results. Defaults to showFirstAndLastButton.
   showFirst: true,
   // DEPRECATED with showFirstAndLastButton.
-  // Display a double arrow allowing users to jump to the last page of results
+  // Display a double arrow allowing users to jump to the last page of results. Defaults to showFirstAndLastButton.
   showLast: true,
 });
 ```

--- a/README.md
+++ b/README.md
@@ -870,10 +870,14 @@ ANSWERS.addComponent('Pagination', {
   container: '.pagination-component',
   // Required*, the vertical for pagination, *if omitted, will fall back to the search base config
   verticalKey: 'verticalKey',
-  // Optional, display a double arrow allowing users to jump to the first page of results
-  showFirst: true,
-  // Optional, display a double arrow allowing users to jump to the last page of results
-  showLast: true,
+  // The maximum number of pages visible to non-mobile users.
+  maxVisiblePagesDesktop: 1,
+  // The maximum number of pages visible to mobile users.
+  maxVisiblePagesMobile: 1,
+  // Ensure that the page numbers for first and last page are always shown. Not recommended to use with showFirstAndLastButton.
+  pinFirstAndLastPage: false,
+  // Display double-arrows allowing users to jump to the first and last page of results.
+  showFirstAndLastButton: true,
   // Optional, label for a page of results
   pageLabel: 'Page',
   // Optional, configuration for the pagination behavior when a query returns no results

--- a/README.md
+++ b/README.md
@@ -888,6 +888,12 @@ ANSWERS.addComponent('Pagination', {
   },
   // Function invoked when a user clicks to change pages. By default, scrolls the user to the top of the page.
   onPaginate: (newPageNumber, oldPageNumber, totalPages) => {},
+  // DEPRECATED with showFirstAndLastButton.
+  // Display a double arrow allowing users to jump to the first page of results
+  showFirst: true,
+  // DEPRECATED with showFirstAndLastButton.
+  // Display a double arrow allowing users to jump to the last page of results
+  showLast: true,
 });
 ```
 

--- a/src/ui/components/results/paginationcomponent.js
+++ b/src/ui/components/results/paginationcomponent.js
@@ -49,14 +49,14 @@ export default class PaginationComponent extends Component {
      * @type {boolean}
      * @private
      */
-    this._firstPageButtonEnabled = config.showFirst === undefined ? config.showFirstAndLastButton : config.showFirst;
+    this._firstPageButtonEnabled = config.showFirst === undefined ? this._showFirstAndLastPageButtons : config.showFirst;
 
     /**
      * DEPRECATED
      * @type {boolean}
      * @private
      */
-    this._lastPageButtonEnabled = config.showLast === undefined ? config.showFirstAndLastButton : config.showLast;
+    this._lastPageButtonEnabled = config.showLast === undefined ? this._showFirstAndLastPageButtons : config.showLast;
 
     /**
      * If true, always displays the page numbers for first and last page.


### PR DESCRIPTION
Expected: would default to showFirstAndLastButton
Actual: would default to showFirstAndLastButton if it was user specified, otherwise would be false

The issue was that if showFirstAndLastButton defaulted to true, the component would not use the defaulted value

Also add nik's lost in rebase readme update

TEST=manual
test that by default the last/first buttons are displayed