### PR TITLE
VerticalResults: add back removed styling from #569

### DIFF
--- a/src/ui/sass/modules/_Results.scss
+++ b/src/ui/sass/modules/_Results.scss
@@ -72,6 +72,72 @@ $results-cards-margin: calc(var(--yxt-base-spacing) / 2) !default;
     font-size: var(--yxt-results-title-bar-icon-size);
   }
 
+  &-viewAllLink
+  {
+    display: flex;
+    align-items: center;
+
+    @include Text(
+      var(--yxt-results-title-bar-link-font-size),
+      var(--yxt-results-title-bar-link-line-height),
+      var(--yxt-results-title-bar-link-font-weight),
+    );
+    @include Link-1;
+  }
+
+  &-filters
+  {
+    display: flex;
+    margin-top: 0;
+    margin-bottom: 0;
+    padding: calc(var(--yxt-base-spacing) / 2) var(--yxt-base-spacing);
+    background-color: var(--yxt-results-filters-background);
+    border-top: var(--yxt-results-border);
+    border-right: var(--yxt-border-default);
+    border-left: var(--yxt-border-default);
+    border-bottom: none;
+  }
+
+  &-filter
+  {
+    display: flex;
+    align-items: center;
+
+    &:not(:first-child)::before
+    {
+      content: '';
+      width: 1px;
+      top: 0;
+      height: 40%;
+      margin-left: var(--yxt-base-spacing);
+      margin-right: var(--yxt-base-spacing);
+      display: inline-block;
+    }
+  }
+
+  &-filterValue
+  {
+    @include Text(
+      var(--yxt-results-filters-text-font-size),
+      var(--yxt-results-filters-text-line-height),
+      var(--yxt-results-filters-text-font-weight),
+      $color: var(--yxt-results-filters-text-color)
+    );
+  }
+
+  &-changeFilters
+  {
+    @include Text(
+      var(--yxt-results-filters-link-font-size),
+      var(--yxt-results-filters-link-line-height),
+      var(--yxt-results-filters-link-font-weight),
+      $color: var(--yxt-color-brand-primary)
+    );
+    @include Link-2;
+
+    margin-left: calc(var(--yxt-base-spacing) / 2);
+  }
+
   &-map
   {
     height: 300px;

--- a/src/ui/sass/modules/_ResultsHeader.scss
+++ b/src/ui/sass/modules/_ResultsHeader.scss
@@ -125,11 +125,14 @@ $results-header-universal-background: var(--yxt-color-brand-white) !default;
     margin-left: calc(var(--yxt-results-header-spacing) / 2);
     margin-bottom: calc(var(--yxt-results-header-spacing) / 4);
     padding-right: var(--yxt-results-header-spacing);
+    @include Text(
+      var(--yxt-results-filters-link-font-size),
+      var(--yxt-results-filters-link-line-height),
+      var(--yxt-results-filters-link-font-weight),
+      $color: var(--yxt-color-brand-primary)
+    );
     @include Link(
       $base-color: var(--yxt-color-brand-primary)
-    );
-    @include Text(
-      $line-height: 20px
     );
   }
 

--- a/src/ui/sass/modules/_ResultsHeader.scss
+++ b/src/ui/sass/modules/_ResultsHeader.scss
@@ -63,6 +63,7 @@ $results-header-universal-background: var(--yxt-color-brand-white) !default;
     border-top: 0;
     display: flex;
     flex-wrap: wrap;
+    align-items: center;
   }
 
   &-filterLabel


### PR DESCRIPTION
This commit reverts unnecessary styling changes in #569. Namely the removal of css classes. Also makes changes to ResultsHeader.scss to be more backwards compatible with preexisting yxt-Results styling

TEST=manual
no visible changes on my local testing site