### PR TITLE
VerticalResults: rename titlebar css class to same as resultssectionheader.hbs

### DIFF
--- a/src/ui/sass/modules/_Results.scss
+++ b/src/ui/sass/modules/_Results.scss
@@ -59,19 +59,6 @@ $results-cards-margin: calc(var(--yxt-base-spacing) / 2) !default;
     margin-top: var(--yxt-base-spacing);
   }
 
-  &-titleBar
-  {
-    display: flex;
-    justify-content: space-between;
-    padding-left: var(--yxt-base-spacing);
-    padding-right: var(--yxt-base-spacing);
-    padding-top: calc(var(--yxt-base-spacing) / 2);
-    padding-bottom: calc(var(--yxt-base-spacing) / 2);
-    background-color: var(--yxt-results-title-bar-background);
-    border: var(--yxt-border-legacy);
-    border-bottom: none;
-  }
-
   &-left
   {
     display: flex;
@@ -83,18 +70,6 @@ $results-cards-margin: calc(var(--yxt-base-spacing) / 2) !default;
     display: flex;
     margin-right: calc(var(--yxt-base-spacing) / 2);
     font-size: var(--yxt-results-title-bar-icon-size);
-  }
-
-  &-title
-  {
-    @include Text(
-      var(--yxt-results-title-bar-text-font-size),
-      var(--yxt-results-title-bar-text-line-height),
-      var(--yxt-results-title-bar-text-font-weight),
-      $color: var(--yxt-results-title-bar-text-color)
-    );
-
-    text-transform: uppercase;
   }
 
   &-map
@@ -156,7 +131,7 @@ $results-cards-margin: calc(var(--yxt-base-spacing) / 2) !default;
     );
   }
 
-  &-title
+  &-titleBar
   {
     border: var(--yxt-results-border);
     display: flex;
@@ -165,12 +140,12 @@ $results-cards-margin: calc(var(--yxt-base-spacing) / 2) !default;
     background-color:  var(--yxt-color-background-highlight);
   }
 
-  &-title svg, &-title img 
+  &-titleBar svg, &-titleBar img 
   {
     color: var(--yxt-color-brand-primary);
   }
 
-  &-titleLabel 
+  &-title
   {
     text-transform: uppercase;
     @include Text(
@@ -209,5 +184,34 @@ $results-cards-margin: calc(var(--yxt-base-spacing) / 2) !default;
     border-top: var(--yxt-border-legacy);
     border-left: var(--yxt-border-legacy);
     border-right: var(--yxt-border-legacy);
+  }
+}
+
+// Legacy AccordionResults specific styling
+.yxt-Accordion .yxt-Results
+{
+  &-titleBar
+  {
+    display: flex;
+    justify-content: space-between;
+    padding-left: var(--yxt-base-spacing);
+    padding-right: var(--yxt-base-spacing);
+    padding-top: calc(var(--yxt-base-spacing) / 2);
+    padding-bottom: calc(var(--yxt-base-spacing) / 2);
+    background-color: var(--yxt-results-title-bar-background);
+    border: var(--yxt-border-legacy);
+    border-bottom: none;
+  }
+
+  &-title
+  {
+    @include Text(
+      var(--yxt-results-title-bar-text-font-size),
+      var(--yxt-results-title-bar-text-line-height),
+      var(--yxt-results-title-bar-text-font-weight),
+      $color: var(--yxt-results-title-bar-text-color)
+    );
+
+    text-transform: uppercase;
   }
 }

--- a/src/ui/templates/results/verticalresults.hbs
+++ b/src/ui/templates/results/verticalresults.hbs
@@ -4,7 +4,8 @@
   {{/if}}
   {{#if resultsPresent}}
     <section class="yxt-Results yxt-Results--{{_config.modifier}}{{#if _config.isUniversal}} yxt-Results--universal{{/if}}">
-      {{> header}}
+      {{> titleBar}}
+      {{> resultsHeader }}
       {{> map}}
       {{> results}}
       {{> viewMore}}
@@ -22,9 +23,9 @@
 {{/inline}}
 
 
-{{#*inline "header"}}
+{{#*inline "titleBar"}}
   {{#if _config.isUniversal}}
-    <div class="yxt-Results-title">
+    <div class="yxt-Results-titleBar">
       {{#if iconIsBuiltIn}}
         <div class="yxt-Results-titleIconWrapper"
           data-component="IconComponent"
@@ -34,9 +35,12 @@
           data-component="IconComponent"
           data-opts='{ "iconUrl": "{{ _config.icon }}" }'></div>
       {{/if}}
-      <div class="yxt-Results-titleLabel">{{_config.title}}</div>
+      <div class="yxt-Results-title">{{_config.title}}</div>
     </div>
   {{/if}}
+{{/inline}}
+
+{{#*inline 'resultsHeader'}}
   {{#if showResultsHeader}}
     <div data-component="ResultsHeader"></div>
   {{/if}}


### PR DESCRIPTION
"Current: New class name for universal results section title (it's now yxt-Results-title)
Expected: Use the old class name instead (yxt-Results-titleBar)"

TEST=manual
check that accordion results and universal results w/vertical results looks correct.
check that titleBar svg is still 18x18