### PR TITLE
VerticalResults: only update when search complete

### DIFF
--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -171,7 +171,12 @@ export default class VerticalResultsComponent extends Component {
      */
     this._noResultsTemplate = this._noResultsConfig.template;
 
-    this.moduleId = StorageKeys.VERTICAL_RESULTS;
+    this.core.globalStorage.on('update', StorageKeys.VERTICAL_RESULTS, results => {
+      if (results.searchState === SearchStates.SEARCH_COMPLETE) {
+        this.setState(results);
+      }
+    });
+
     /**
      * Vertical config from config, if not present, fall back to global verticalPagesConfig
      * @type {Array.<object>}

--- a/tests/ui/components/results/verticalresultscomponent.js
+++ b/tests/ui/components/results/verticalresultscomponent.js
@@ -7,6 +7,7 @@ import VerticalResultsComponent from '../../../../src/ui/components/results/vert
 const mockCore = {
   globalStorage: {
     set: () => {},
+    on: () => {},
     getState: (storageKey) => {
       if (storageKey === StorageKeys.VERTICAL_PAGES_CONFIG) {
         return { get: () => { return []; } };


### PR DESCRIPTION
> Current: Removing an applied filter hides the entire component and causes a flash
Expected: No flash, the result count edit: and vertical results should remain
I think this is similar to the problem we have with pagination.
can we make it such that we wait to update the vertical results until the new set returns (instead of hiding it)?

This commit changes VerticalResultsComponent to listen to changes to StorageKeys.VERTICAL_RESULTS the same way pagination does, only updating when the search is complete. Previously, VerticalResultsComponent listened to changes to
StorageKeys.VERTICAL_RESULTS by settings it's moduleId, which downstream is
hooked up to call setState when that storage key is updated.

TEST=manual
check that search results still update when removing a filter, applying a filter, and
making a new search