### PR TITLE
 use xlarge unit test circleci resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
   unit_test:
     docker:
       - image: circleci/node:7.10
-    resource_class: large
+    resource_class: xlarge
     working_directory: ~/answers
     steps:
       - setup-workspace


### PR DESCRIPTION
We are bumping the resource class to the next tier so that v1.4.0 PRs
will run unit test tests correctly without out of memory errors.

J/T=None
TEST=manual

circleci config validate
Verify the PR unit tests run without out of memory errors