### PR TITLE
VerticalResults: use <h2> for yxt-Results-title

### DIFF
--- a/src/ui/sass/modules/_Results.scss
+++ b/src/ui/sass/modules/_Results.scss
@@ -213,6 +213,7 @@ $results-cards-margin: calc(var(--yxt-base-spacing) / 2) !default;
 
   &-title
   {
+    margin: 0;
     text-transform: uppercase;
     @include Text(
       $color: var(--yxt-color-text-primary),

--- a/src/ui/templates/results/verticalresults.hbs
+++ b/src/ui/templates/results/verticalresults.hbs
@@ -31,11 +31,11 @@
           data-component="IconComponent"
           data-opts='{ "iconName": "{{ _config.icon }}" }'></div>
       {{else}}
-        <div  class="yxt-Results-titleIconWrapper"
+        <div class="yxt-Results-titleIconWrapper"
           data-component="IconComponent"
           data-opts='{ "iconUrl": "{{ _config.icon }}" }'></div>
       {{/if}}
-      <div class="yxt-Results-title">{{_config.title}}</div>
+      <h2 class="yxt-Results-title">{{_config.title}}</h2>
     </div>
   {{/if}}
 {{/inline}}


### PR DESCRIPTION
To match resultssectionheader.hbs

TEST=manual
check that answers.yext.com's yxt-Results-title has margin: 0 from the css reset.
We can expect all consulting sites to apply this css reset, so adding margin: 0 is not a breaking change.
check that visually looks the same out of the box whether it is h2 or div