### PR TITLE
VerticalResults: rename yxt-Results-viewMore -> yxt-Results-viewAll

### DIFF
--- a/src/ui/sass/modules/_Results.scss
+++ b/src/ui/sass/modules/_Results.scss
@@ -72,19 +72,6 @@ $results-cards-margin: calc(var(--yxt-base-spacing) / 2) !default;
     font-size: var(--yxt-results-title-bar-icon-size);
   }
 
-  &-viewAllLink
-  {
-    display: flex;
-    align-items: center;
-
-    @include Text(
-      var(--yxt-results-title-bar-link-font-size),
-      var(--yxt-results-title-bar-link-line-height),
-      var(--yxt-results-title-bar-link-font-weight),
-    );
-    @include Link-1;
-  }
-
   &-filters
   {
     display: flex;
@@ -153,7 +140,7 @@ $results-cards-margin: calc(var(--yxt-base-spacing) / 2) !default;
     flex-flow: row wrap;
   }
 
-  &-viewMore
+  &-viewAll
   {
     display: flex;
     justify-content: center;
@@ -166,17 +153,16 @@ $results-cards-margin: calc(var(--yxt-base-spacing) / 2) !default;
     border-bottom: var(--yxt-results-border);
   }
 
-  &-viewMore svg
+  &-viewAll svg
   {
     height: calc(var(--yxt-base-spacing) / 2);
     width: calc(var(--yxt-base-spacing) / 2);
     color: var(--yxt-color-brand-primary);
   }
 
-  &-viewMoreLink
+  &-viewAllLink
   {
     text-decoration: none;
-    justify-content: center;
     display: flex;
     align-items: center;
     &:hover, &:focus 
@@ -186,7 +172,7 @@ $results-cards-margin: calc(var(--yxt-base-spacing) / 2) !default;
     }
   }
 
-  &-viewMoreLabel
+  &-viewAllLabel
   {
     margin-right: calc(var(--yxt-base-spacing) / 2);
     @include Text(
@@ -280,5 +266,18 @@ $results-cards-margin: calc(var(--yxt-base-spacing) / 2) !default;
     );
 
     text-transform: uppercase;
+  }
+
+  &-viewAllLink
+  {
+    display: flex;
+    align-items: center;
+
+    @include Text(
+      var(--yxt-results-title-bar-link-font-size),
+      var(--yxt-results-title-bar-link-line-height),
+      var(--yxt-results-title-bar-link-font-weight),
+    );
+    @include Link-1;
   }
 }

--- a/src/ui/templates/results/verticalresults.hbs
+++ b/src/ui/templates/results/verticalresults.hbs
@@ -8,7 +8,7 @@
       {{> resultsHeader }}
       {{> map}}
       {{> results}}
-      {{> viewMore}}
+      {{> viewAll}}
     </section>
   {{/if}}
 {{/if}}
@@ -69,11 +69,11 @@
   {{/if}}
 {{/inline}}
 
-{{#*inline "viewMore"}}
+{{#*inline "viewAll"}}
   {{#if (and _config.isUniversal _config.viewMore)}}
-    <div class="yxt-Results-viewMore">
-      <a class="yxt-Results-viewMoreLink" href="{{ verticalURL }}">
-        <div class="yxt-Results-viewMoreLabel">{{_config.viewMoreLabel}}</div>
+    <div class="yxt-Results-viewAll">
+      <a class="yxt-Results-viewAllLink" href="{{ verticalURL }}">
+        <div class="yxt-Results-viewAllLabel">{{_config.viewMoreLabel}}</div>
         <div data-component="IconComponent" data-opts='{ "iconName": "chevron" }'></div>
       </a>
     </div>


### PR DESCRIPTION
In order to be more backwards compatible, we should use the older
viewAllLink css class. Styling for AccordionResults was not changed
with this commit, even though the yxt-Results-viewAllLink class is
now defined in two different places, because the preexisting AccordionResults
specific styling (luckily) completely overrides the new styling.

TEST=manual
checked in chrome inspector that the viewAllLink in AccordionResults
does not carry over any of the new styling. checked that for both on
hover and not, that all css properties from yxt-Results-viewAllLink
are overriden by the more specific .yxt-Accordion .yxt-Results-viewAllLink.