### PR TITLE
UniversalResults: make viewMore config option work

### DIFF
--- a/src/ui/templates/results/verticalresults.hbs
+++ b/src/ui/templates/results/verticalresults.hbs
@@ -70,7 +70,7 @@
 {{/inline}}
 
 {{#*inline "viewMore"}}
-  {{#if _config.isUniversal}}
+  {{#if (and _config.isUniversal _config.viewMore)}}
     <div class="yxt-Results-viewMore">
       <a class="yxt-Results-viewMoreLink" href="{{ verticalURL }}">
         <div class="yxt-Results-viewMoreLabel">{{_config.viewMoreLabel}}</div>


### PR DESCRIPTION
This option is supposed to prevent the viewMore div from
rendering if false. It was being ignored.

TEST=manual
check that I can set viewMore to false (and that the default is true))
and that the viewMore box will not render in this case. check that
setting it to true will render the box