### PR TITLE
VerticalResults: use ::after for viewAllLink icon

### DIFF
--- a/src/ui/sass/_mixins.scss
+++ b/src/ui/sass/_mixins.scss
@@ -100,3 +100,21 @@
     $hover-decoration: none
   );
 }
+
+// Generally, it is preferable to use an IconComponent when an icon is desired.
+// This mixin is for cases when we want to add an icon in a place where 
+// SDK implementors commonly would add an icon with ::after. Using an IconComponent
+// in those cases would result in a double icon, while adding the desired icon with ::after
+// will only result in the new SDK icon being overriden.
+@mixin Chevron-Icon
+{
+  &::after
+  {
+    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMTYiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAxNiAyNCI+CiAgICA8ZGVmcz4KICAgICAgICA8cGF0aCBpZD0iYSIgZD0iTTEuNTUgOS41NmEuNjguNjggMCAwIDEgLjAwNS0xLjAyM2wuMDI2LS4wMjRhLjgyOC44MjggMCAwIDEgMS4xMDMtLjAwNmwzLjc2OCAzLjQ4NmMuMzAzLjI4LjMuNzM2IDAgMS4wMTRsLTMuNzY4IDMuNDg2YS44MTguODE4IDAgMCAxLTEuMTAzLS4wMDZsLS4wMjYtLjAyNGEuNjg0LjY4NCAwIDAgMS0uMDA0LTEuMDIyTDQuNzMgMTIuNSAxLjU1IDkuNTZ6Ii8+CiAgICA8L2RlZnM+CiAgICA8ZyBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiPgogICAgICAgIDxwYXRoIGQ9Ik0wIDBoOHYyNEgweiIvPgogICAgICAgIDxnIHRyYW5zZm9ybT0idHJhbnNsYXRlKDgpIj4KICAgICAgICAgICAgPHBhdGggZD0iTTAgMGg4djI0SDB6Ii8+CiAgICAgICAgICAgIDxtYXNrIGlkPSJiIiBmaWxsPSIjZmZmIj4KICAgICAgICAgICAgICAgIDx1c2UgeGxpbms6aHJlZj0iI2EiLz4KICAgICAgICAgICAgPC9tYXNrPgogICAgICAgICAgICA8dXNlIGZpbGw9IiMxMjEzMUUiIHhsaW5rOmhyZWY9IiNhIi8+CiAgICAgICAgICAgIDxnIGZpbGw9IiMwZjcwZjAiIG1hc2s9InVybCgjYikiPgogICAgICAgICAgICAgICAgPHBhdGggZD0iTTAgMGg4djI0SDB6Ii8+CiAgICAgICAgICAgIDwvZz4KICAgICAgICA8L2c+CiAgICA8L2c+Cjwvc3ZnPgo=');
+    background-repeat: no-repeat;
+    background-position: 100%;
+    content: "";
+    height: 1em;
+    width: 1em;
+  }
+}

--- a/src/ui/sass/modules/_Results.scss
+++ b/src/ui/sass/modules/_Results.scss
@@ -153,13 +153,6 @@ $results-cards-margin: calc(var(--yxt-base-spacing) / 2) !default;
     border-bottom: var(--yxt-results-border);
   }
 
-  &-viewAll svg
-  {
-    height: calc(var(--yxt-base-spacing) / 2);
-    width: calc(var(--yxt-base-spacing) / 2);
-    color: var(--yxt-color-brand-primary);
-  }
-
   &-viewAllLink
   {
     text-decoration: none;
@@ -170,11 +163,7 @@ $results-cards-margin: calc(var(--yxt-base-spacing) / 2) !default;
       color: $color-brand-hover;
       text-decoration: underline;
     }
-  }
-
-  &-viewAllLabel
-  {
-    margin-right: calc(var(--yxt-base-spacing) / 2);
+    @include Chevron-Icon();
     @include Text(
       $color: var(--yxt-color-brand-primary),
       $weight: var(--yxt-font-weight-semibold),

--- a/src/ui/templates/results/verticalresults.hbs
+++ b/src/ui/templates/results/verticalresults.hbs
@@ -73,8 +73,7 @@
   {{#if (and _config.isUniversal _config.viewMore)}}
     <div class="yxt-Results-viewAll">
       <a class="yxt-Results-viewAllLink" href="{{ verticalURL }}">
-        <div class="yxt-Results-viewAllLabel">{{_config.viewMoreLabel}}</div>
-        <div data-component="IconComponent" data-opts='{ "iconName": "chevron" }'></div>
+        {{_config.viewMoreLabel}}
       </a>
     </div>
   {{/if}}


### PR DESCRIPTION
The AEB currently adds it's own icon to yxt-Results-viewAllLink::after. Since the 
oobx mock for universal results also wants an icon there, we end up with a
very annoying double icon.

This commit changes the viewAllLink icon to use ::after styling instead of
an icon component, setting the desired chevron icon as a base64 encoded
background-image.

Generally, it is preferable to use an IconComponent when an icon is desired.
This mixin is for cases when we want to add an icon in a place where
SDK implementors commonly would add an icon with ::after. Using an IconComponent
in those cases would result in a double icon, while adding the desired icon with ::after
will only result in the new SDK icon being overriden.

TEST=manual
check that we still get a chevron icon with the ::after styling