### PR TITLE
Use MasterSwitchApi to block only the invocation of onReady.

### DIFF
--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -229,7 +229,7 @@ class Answers {
       }
 
       this._handlePonyfillCssVariables(
-        parsedConfig.disableCssVariablesPonyfill, 
+        parsedConfig.disableCssVariablesPonyfill,
         this._invokeOnReady.bind(this));
       return this;
     }
@@ -239,7 +239,7 @@ class Answers {
     this.templates = new DefaultTemplatesLoader(templates => {
       this.renderer.init(templates);
       this._handlePonyfillCssVariables(
-        parsedConfig.disableCssVariablesPonyfill, 
+        parsedConfig.disableCssVariablesPonyfill,
         this._invokeOnReady.bind(this));
     });
 

--- a/tests/core/utils/masterswitchapi.js
+++ b/tests/core/utils/masterswitchapi.js
@@ -49,6 +49,15 @@ describe('checking Answers Status page', () => {
     return masterSwitchApi.isDisabled('abc123', 'someexperience')
       .then(isDisabled => expect(isDisabled).toBeFalsy());
   });
+
+  it('behaves correctly when timeout is reached', () => {
+    const mockedRequest =
+      jest.fn(() => new Promise(resolve => setTimeout(resolve, 200)));
+    const masterSwitchApi = createMasterSwitchApi(mockedRequest);
+
+    return masterSwitchApi.isDisabled('abc123', 'someexperience')
+      .then(isDisabled => expect(isDisabled).toBeFalsy());
+  });
 });
 
 /**


### PR DESCRIPTION
Previously, the MasterSwitchApi call blocked much of the SDK initialization, as well as onReady, until it was determined that the page was enabled. This caused problems, however. Some instance methods do not work properly unless the SDK initialization is complete. Prior to the introduction of the Status checking, initialization was guaranteed to be complete immediately after any call to Answers.init. It was not necessary to wait until onReady had fired. With the Status check blocking most of the initialization, this synchronous behavior was not guaranteed.

The AEB relied on this old behavior. It called setConversionsOptIn right after invoking Answers.init. However, this setter needs eligibleForAnalytics to be initialized. Otherwise, it will not work correctly. This was the cause of the Conversion Tracking Enablement TechOps.

With this change, the MasterSwitchApi blocks only onReady. Now, the call to Answers.init will, again, synchronously initialize the SDK. Also included in this PR is a timeout for the Status check. The default timeout is 100ms. If nothing is returned in this time, the experience is assumed to be enabled.

T=331657
TEST=manual

Tested the following in IE11 and Chrome:

- onReady is fired correctly when the site is enabled.
- onReady is not fired when the site is disabled.
- onReady is fired when the Status request times out.
- I pointed one of the AEB sites from the TechOps to my local copy of Answers. The onReady fired as expected and the conversion tracking was properly enabled.