### PR TITLE
VerticalResults: reduce icon color specificity

### DIFF
--- a/src/ui/sass/modules/_Results.scss
+++ b/src/ui/sass/modules/_Results.scss
@@ -70,6 +70,7 @@ $results-cards-margin: calc(var(--yxt-base-spacing) / 2) !default;
     display: flex;
     margin-right: calc(var(--yxt-base-spacing) / 2);
     font-size: var(--yxt-results-title-bar-icon-size);
+    color: var(--yxt-color-brand-primary);
   }
 
   &-filters
@@ -192,11 +193,6 @@ $results-cards-margin: calc(var(--yxt-base-spacing) / 2) !default;
     background-color:  var(--yxt-color-background-highlight);
   }
 
-  &-titleBar svg, &-titleBar img 
-  {
-    color: var(--yxt-color-brand-primary);
-  }
-
   &-title
   {
     margin: 0;
@@ -279,5 +275,10 @@ $results-cards-margin: calc(var(--yxt-base-spacing) / 2) !default;
       var(--yxt-results-title-bar-link-font-weight),
     );
     @include Link-1;
+  }
+
+  &-titleIconWrapper
+  {
+    color: inherit;
   }
 }


### PR DESCRIPTION
The default color of the title icon was changed to color-brand-primary,
where before it was set to inherit. This change makes it easier to
override the sdk default color.

TEST=manual
checked that icon color still defaults to color-brand-primary
check that on accordionresults color defaults to text color (default black)