### PR TITLE
UniversalResults: hide viewAllText if set to blank value

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,8 @@ ANSWERS.addComponent('UniversalResults', {
       renderItem: function(data) {},
       // Optional, override the handlebars template for each item in this vertical
       itemTemplate: `my item {{name}}`,
+      // DEPCREATED, please use viewMoreLabel instead. The text for the view more link. Has the same effect as viewMoreLabel, and is out-prioritized by viewMoreLabel. Defaults to 'View More'.
+      viewAllText: 'View All Results For Vertical'
     }
   },
   // Optional, override the render function for each item in the result list

--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ ANSWERS.addComponent('UniversalResults', {
       renderItem: function(data) {},
       // Optional, override the handlebars template for each item in this vertical
       itemTemplate: `my item {{name}}`,
-      // DEPRECATED, please use viewMoreLabel instead. The text for the view more link. Has the same effect as viewMoreLabel, and is out-prioritized by viewMoreLabel. Defaults to 'View More'.
+      // DEPRECATED, please use viewMoreLabel instead. viewAllText is a synonym for viewMoreLabel, where viewMoreLabel takes precedence over viewAllText. Defaults to 'View More'.
       viewAllText: 'View All Results For Vertical'
     }
   },

--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ ANSWERS.addComponent('UniversalResults', {
       renderItem: function(data) {},
       // Optional, override the handlebars template for each item in this vertical
       itemTemplate: `my item {{name}}`,
-      // DEPCREATED, please use viewMoreLabel instead. The text for the view more link. Has the same effect as viewMoreLabel, and is out-prioritized by viewMoreLabel. Defaults to 'View More'.
+      // DEPRECATED, please use viewMoreLabel instead. The text for the view more link. Has the same effect as viewMoreLabel, and is out-prioritized by viewMoreLabel. Defaults to 'View More'.
       viewAllText: 'View All Results For Vertical'
     }
   },

--- a/src/ui/components/results/universalresultscomponent.js
+++ b/src/ui/components/results/universalresultscomponent.js
@@ -67,7 +67,7 @@ export default class UniversalResultsComponent extends Component {
       // Show a view more link by default, which also links to verticalURL.
       viewMore: true,
       // By default, the view more link has a label of 'View More'.
-      viewMoreLabel: config.viewAllText || 'View More',
+      viewMoreLabel: defaultConfigOption(config, ['viewMoreLabel', 'viewAllText'], 'View More'),
       // Whether to show a result count.
       showResultCount: false,
       // Whether to use AccordionResults (DEPRECATED)

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -129,7 +129,7 @@ class VerticalResultsConfig {
      * Text for the view more button.
      * @type {string}
      */
-    this.viewMoreLabel = config.viewMoreLabel;
+    this.viewMoreLabel = defaultConfigOption(config, ['viewMoreLabel', 'viewAllText'], 'View More');
   }
 }
 
@@ -410,6 +410,5 @@ export default class VerticalResultsComponent extends Component {
 const APPLY_SYNONYMS = (config) => ({
   icon: config.sectionTitleIconName || config.sectionTitleIconUrl,
   title: config.sectionTitle,
-  viewMoreLabel: config.viewAllText,
   ...config
 });

--- a/src/ui/templates/results/verticalresults.hbs
+++ b/src/ui/templates/results/verticalresults.hbs
@@ -70,7 +70,7 @@
 {{/inline}}
 
 {{#*inline "viewAll"}}
-  {{#if (and _config.isUniversal _config.viewMore)}}
+  {{#if (and _config.isUniversal _config.viewMore _config.viewMoreLabel)}}
     <div class="yxt-Results-viewAll">
       <a class="yxt-Results-viewAllLink" href="{{ verticalURL }}">
         <div class="yxt-Results-viewAllLabel">{{_config.viewMoreLabel}}</div>


### PR DESCRIPTION
If somebody manually sets their viewAllText to blank, it should be hidden

TEST=manual
test that setting it to blank will hide it
test that if unset it will still default to 'view more'
test that can use either viewAllText or viewMoreLabel, and that viewMoreLabel takes priority