### PR TITLE
Facets: patch expand field override

### DIFF
--- a/README.md
+++ b/README.md
@@ -1028,7 +1028,7 @@ ANSWERS.addComponent('Facets', {
       // Optional, if true, display the filter option search input
       searchable: false,
       // Optional, control type, singleoption or multioption
-      control: false,
+      control: 'singleoption',
     }
   },
   // Optional, the label to show on the apply button

--- a/src/ui/components/filters/facetscomponent.js
+++ b/src/ui/components/filters/facetscomponent.js
@@ -225,7 +225,7 @@ export default class FacetsComponent extends Component {
         searchable: this.config.searchable,
         searchLabelText: this.config.searchLabelText,
         placeholderText: this.config.placeholderText,
-        showExpand: fieldOverrides.expand || this.config.expand,
+        expand: fieldOverrides.expand === undefined ? this.config.expand : fieldOverrides.expand,
         ...fieldOverrides
       });
     });

--- a/src/ui/components/filters/facetscomponent.js
+++ b/src/ui/components/filters/facetscomponent.js
@@ -225,7 +225,7 @@ export default class FacetsComponent extends Component {
         searchable: this.config.searchable,
         searchLabelText: this.config.searchLabelText,
         placeholderText: this.config.placeholderText,
-        expand: fieldOverrides.expand === undefined ? this.config.expand : fieldOverrides.expand,
+        showExpand: fieldOverrides.expand === undefined ? this.config.expand : fieldOverrides.expand,
         ...fieldOverrides
       });
     });

--- a/src/ui/components/filters/filterboxcomponent.js
+++ b/src/ui/components/filters/filterboxcomponent.js
@@ -199,9 +199,9 @@ export default class FilterBoxComponent extends Component {
         container: `.js-yext-filterbox-filter${i}`,
         showReset: this.config.resetFilter,
         resetLabel: this.config.resetFilterLabel,
-        showExpand: config.showExpand === undefined ? this.config.expand : config.showExpand,
         isDynamic: this.config.isDynamic,
         ...config,
+        showExpand: config.showExpand === undefined ? this.config.expand : config.showExpand,
         onChange: (filterNode, alwaysSaveFilterNodes, blockSearchOnChange) => {
           const _saveFilterNodes = this.config.searchOnChange || alwaysSaveFilterNodes;
           const _searchOnChange = this.config.searchOnChange && !blockSearchOnChange;

--- a/src/ui/components/filters/filterboxcomponent.js
+++ b/src/ui/components/filters/filterboxcomponent.js
@@ -199,7 +199,7 @@ export default class FilterBoxComponent extends Component {
         container: `.js-yext-filterbox-filter${i}`,
         showReset: this.config.resetFilter,
         resetLabel: this.config.resetFilterLabel,
-        showExpand: this.config.expand,
+        showExpand: config.expand === undefined ? this.config.expand : config.expand,
         isDynamic: this.config.isDynamic,
         ...config,
         onChange: (filterNode, alwaysSaveFilterNodes, blockSearchOnChange) => {

--- a/src/ui/components/filters/filterboxcomponent.js
+++ b/src/ui/components/filters/filterboxcomponent.js
@@ -199,7 +199,7 @@ export default class FilterBoxComponent extends Component {
         container: `.js-yext-filterbox-filter${i}`,
         showReset: this.config.resetFilter,
         resetLabel: this.config.resetFilterLabel,
-        showExpand: config.expand === undefined ? this.config.expand : config.expand,
+        showExpand: config.showExpand === undefined ? this.config.expand : config.showExpand,
         isDynamic: this.config.isDynamic,
         ...config,
         onChange: (filterNode, alwaysSaveFilterNodes, blockSearchOnChange) => {


### PR DESCRIPTION
First thing was expand always being set to true if the top level was set to
true even if the fieldOverride expand was set to false.

Second thing was that going from FilterBox to FilterOptions the config name
changes from expand to showExpand, so relying on Object.assign
to correctly override config doesn't work in this case.

It's super dumb that showExpand and expand are the same config option
but have different names.

TEST=manual
check that after the changes I can set
            fields: {
              c_employeeDepartment: {
                control: 'singleoption',
                expand: false
              }
            }
in my facets config, and the the Employee Department FilterOptions will
not be expandable