### PR TITLE
 Add a hardcoded default for js lib version when not in a git repository

### DIFF
--- a/conf/gulp-tasks/library.gulpfile.js
+++ b/conf/gulp-tasks/library.gulpfile.js
@@ -21,8 +21,8 @@ const uglify = require('gulp-uglify-es').default;
 const NAMESPACE = 'ANSWERS';
 
 function getLibVersion () {
-  try { 
-    let insideWorkTree  = require('child_process')
+  try {
+    let insideWorkTree = require('child_process')
       .execSync('git rev-parse --is-inside-work-tree 2>/dev/null')
       .toString().trim();
     if (insideWorkTree) {

--- a/conf/gulp-tasks/library.gulpfile.js
+++ b/conf/gulp-tasks/library.gulpfile.js
@@ -21,9 +21,21 @@ const uglify = require('gulp-uglify-es').default;
 const NAMESPACE = 'ANSWERS';
 
 function getLibVersion () {
-  return require('child_process')
-    .execSync('git describe --tags')
-    .toString().trim();
+  try { 
+    let insideWorkTree  = require('child_process')
+      .execSync('git rev-parse --is-inside-work-tree 2>/dev/null')
+      .toString().trim();
+    if (insideWorkTree) {
+      return require('child_process')
+        .execSync('git describe --tags')
+        .toString().trim();
+    }
+  } catch (e) {
+    // if above command fails, catch error and continue, as we are not in a git repository
+  }
+
+  console.warn('Warning: Not in a github repository, using default hardcoded library version.');
+  return 'TEST';
 }
 
 function bundle () {

--- a/conf/gulp-tasks/library.gulpfile.js
+++ b/conf/gulp-tasks/library.gulpfile.js
@@ -22,10 +22,10 @@ const NAMESPACE = 'ANSWERS';
 
 function getLibVersion () {
   try {
-    let insideWorkTree = require('child_process')
+    const insideWorkTree = require('child_process')
       .execSync('git rev-parse --is-inside-work-tree 2>/dev/null')
       .toString().trim();
-    if (insideWorkTree) {
+    if (insideWorkTree === 'true') {
       return require('child_process')
         .execSync('git describe --tags')
         .toString().trim();


### PR DESCRIPTION
This is for the case when we are building the repository but without git
tracking. This is happening in the case of the netlify tests in our PRs
to master. Add this hardcoded default when we are not in a git working
tree.

J=None
TEST=manual

Check that after a gulp build, the three following files have (1) the
git describe --tags output as the js lib version as normal and (2) TEST
as the js lib version when the .git folder is removed.

* dist/answers.js
* dist/answers-umd.js
* dist/answers-modern.js

Verify the PR tests (starting with master to start the netlify tests,
then changing to correct base branch).