### PR TITLE
Assorted updates around RTF link Analytics and configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1880,7 +1880,7 @@ The Answers SDK exposes a `formatRichText` function which translates CommonMark 
 ensure that a Rich Text Formatted value is shown properly on the page. To use this function, call it like so:
 
 ```js
-ANSWERS.formatRichText(rtfFieldValue, targetConfig, eventOptionsFieldName)
+ANSWERS.formatRichText(rtfFieldValue, eventOptionsFieldName, targetConfig)
 ```
 
 For instance, this function can be used in the `dataMappings` of a Card to display an RTF attribute. 
@@ -1891,7 +1891,7 @@ specified, the `eventOptions` will include a `fieldName` attribute with the give
 The `targetConfig` parameter dictates where the link is opened: the current window, a new tab, etc. It can have the following forms:
 
 ```js
-targetConfig = { link: '_blank', phone: '_self', email: '_parent' }
+targetConfig = { url: '_blank', phone: '_self', email: '_parent' }
 targetConfig = '_blank'
 ```
 

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -81,8 +81,8 @@ class Answers {
      * A reference to the formatRichText function.
      * @type {Function}
      */
-    this.formatRichText = (markdown, targetConfig, eventOptionsFieldName) =>
-      RichTextFormatter.format(markdown, targetConfig, eventOptionsFieldName);
+    this.formatRichText = (markdown, eventOptionsFieldName, targetConfig) =>
+      RichTextFormatter.format(markdown, eventOptionsFieldName, targetConfig);
 
     /**
      * A local reference to the component manager

--- a/src/core/utils/richtextformatter.js
+++ b/src/core/utils/richtextformatter.js
@@ -13,14 +13,14 @@ class RichTextFormatterImpl {
    * links.
    *
    * @param {string} fieldValue A Rich Text field value.
-   * @param {Object|string} targetConfig Configuration object specifying the 'target' behavior for
-   *                        the various types of links. If a string is provided, it is assumed that
-   *                        is the 'target' behavior across all types of links. This parameter is optional.
    * @param {string} fieldName The name of the field, to be included in the payload of a click
    *                           analytics event. This parameter is optional.
+   * @param {Object|string} targetConfig Configuration object specifying the 'target' behavior for
+   *                          the various types of links. If a string is provided, it is assumed that
+   *                          is the 'target' behavior across all types of links. This parameter is optional.
    * @returns {string} The HTML representation of the field value, serialized as a string.
    */
-  format (fieldValue, targetConfig, fieldName) {
+  format (fieldValue, fieldName, targetConfig) {
     if (typeof fieldValue !== 'string') {
       throw new AnswersCoreError(
         `Rich text "${fieldValue}" needs to be a string. Currently is a ${typeof fieldValue}`
@@ -68,7 +68,7 @@ class RichTextFormatterImpl {
       target = target || targetConfig.phone;
     } else {
       ctaType = 'VIEW_WEBSITE';
-      target = target || targetConfig.link;
+      target = target || targetConfig.url;
     }
 
     tokens[idx].attrSet('data-cta-type', ctaType);

--- a/src/ui/components/cards/cardcomponent.js
+++ b/src/ui/components/cards/cardcomponent.js
@@ -92,11 +92,9 @@ export default class CardComponent extends Component {
       directAnswer: false,
       verticalKey: this._config.data.verticalKey,
       searcher: this._config.isUniversal ? 'UNIVERSAL' : 'VERTICAL',
-      entityId: this._config.data.result.id
+      entityId: this._config.data.result.id,
+      url: event.target.href
     };
-    if (ctaType !== 'TAP_TO_CALL') {
-      analyticsOptions.url = event.target.href;
-    }
     if (!fieldName) {
       console.warn('Field name not provided for RTF click analytics');
     } else {

--- a/src/ui/components/results/directanswercomponent.js
+++ b/src/ui/components/results/directanswercomponent.js
@@ -137,11 +137,9 @@ export default class DirectAnswerComponent extends Component {
       directAnswer: true,
       fieldName: this.getState('answer').fieldApiName,
       searcher: 'UNIVERSAL',
-      entityId: relatedItem.data.id
+      entityId: relatedItem.data.id,
+      url: event.target.href
     };
-    if (ctaType !== 'TAP_TO_CALL') {
-      analyticsOptions.url = event.target.href;
-    }
 
     const analyticsEvent = new AnalyticsEvent(ctaType);
     analyticsEvent.addOptions(analyticsOptions);

--- a/tests/core/utils/richtextformatter.js
+++ b/tests/core/utils/richtextformatter.js
@@ -24,7 +24,7 @@ describe('adds cta-type data attribute to links', () => {
         '<p><u><a href="tel:+17326183404" data-cta-type="TAP_TO_CALL">phone link</a></u></p>\n' +
         '<p><u><a href="mailto:oshi@yext.com" data-cta-type="EMAIL">email link</a></u></p>\n' +
         '</div>';
-    expect(RichTextFormatter.format(richText, null, 'someField')).toEqual(expectedHTML);
+    expect(RichTextFormatter.format(richText, 'someField')).toEqual(expectedHTML);
   });
 });
 
@@ -40,7 +40,7 @@ describe('adds target attribute to links', () => {
       '<p><u><a href="tel:+17326183404" data-cta-type="TAP_TO_CALL" target="_blank">phone link</a></u></p>\n' +
       '<p><u><a href="mailto:oshi@yext.com" data-cta-type="EMAIL" target="_blank">email link</a></u></p>\n' +
       '</div>';
-    expect(RichTextFormatter.format(richText, '_blank', 'someField')).toEqual(expectedHTML);
+    expect(RichTextFormatter.format(richText, 'someField', '_blank')).toEqual(expectedHTML);
   });
 
   it('adds attributes correctly when targetConfig is an object', () => {
@@ -54,7 +54,7 @@ describe('adds target attribute to links', () => {
       '<p><u><a href="tel:+17326183404" data-cta-type="TAP_TO_CALL" target="_blank">phone link</a></u></p>\n' +
       '<p><u><a href="mailto:oshi@yext.com" data-cta-type="EMAIL">email link</a></u></p>\n' +
       '</div>';
-    const targetConfig = { phone: '_blank', link: '_self' };
-    expect(RichTextFormatter.format(richText, targetConfig, 'someField')).toEqual(expectedHTML);
+    const targetConfig = { phone: '_blank', url: '_self' };
+    expect(RichTextFormatter.format(richText, 'someField', targetConfig)).toEqual(expectedHTML);
   });
 });


### PR DESCRIPTION
This PR includes the following updates around RTF links:

- The formatRichText function now has the signature
  formatRichText(fieldValue, fieldName, targetConfig).
- The targetConfig.link parameter has been renamed targetConfig.url.
- A URL is included in the Analytics payload for 'TAP_TO_CALL' events.

J=SPR-2370
TEST=manual

Tested the following manually:

- 'TAP_TO_CALL' events include a URL in the eventOptions payload.
- targetConfig.url can be used the change the 'target' behavior of a URL-type
  RTF link.
- The new formatRichText signature works as expected.