### PR TITLE
Facets: resetFacets undefined by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -998,7 +998,7 @@ ANSWERS.addComponent('Facets', {
   resetFacet: false,
   // Optional, the label to use for the reset button above
   resetFacetLabel: 'reset',
-  // Optional, show a reset-all button for the facets control
+  // Optional, show a reset-all button for the facets control. Defaults to showing a reset-all button if searchOnChange is false.
   resetFacets: true,
   // Optional, the label to use for the reset-all button above
   resetFacetsLabel: 'reset-all',

--- a/src/ui/components/filters/facetscomponent.js
+++ b/src/ui/components/filters/facetscomponent.js
@@ -40,7 +40,7 @@ class FacetsConfig {
      * If true, show a "reset all" button to reset all facets
      * @type {boolean}
      */
-    this.resetFacets = config.resetFacets === undefined ? true : config.resetFacets;
+    this.resetFacets = config.resetFacets;
 
     /**
      * The label to show for the "reset all" button


### PR DESCRIPTION
FilterBox allows you to show a reset all button regardless of searchOnChange
as of #839. Facets also needed to be changed for this change, since it's a
wrapper over FilterBox.

Before, setting resetFacets to true would only render
a reset button if searchOnChange is true. Now, since you can ask for a reset
button even if searchOnChange is false, resetFacets defaulting to true will
render a reset button even if searchOnChange is true. 
By default the reset button should render when searchOnChange is false, and not render when searchOnChange is true. This defaulting is taken care of in FilterBox, so Facets should
default resetFacets to undefined to keep with preexisting defaults.

TEST=manual
Test that in Facets,
with resetFacets unset
- searchOnChange: true hides the reset button
- searchOnChange: unset shows the reset button
- searchOnChange: false shows the reset button

---
- searchOnChange: true, resetFacets: true shows the reset button
- searchOnChange: false, resetFacets: false hides the reset button