### PR TITLE
DateRangeFilter: update display value

### DIFF
--- a/src/ui/components/filters/daterangefiltercomponent.js
+++ b/src/ui/components/filters/daterangefiltercomponent.js
@@ -196,9 +196,7 @@ export default class DateRangeFilterComponent extends Component {
     } else if (min === max) {
       displayValue = this._isExclusive ? '' : min;
     } else {
-      displayValue = this._isExclusive
-        ? `${min} - ${max}`
-        : `Between ${min} and ${max}`;
+      displayValue = `${min} - ${max}`;
     }
     return new FilterMetadata({
       fieldName: this._title,

--- a/tests/ui/components/filters/daterangecomponent.js
+++ b/tests/ui/components/filters/daterangecomponent.js
@@ -15,7 +15,7 @@ describe('date range filter component', () => {
     lessThan: max => `Before ${max}`,
     lessThanEqual: max => `${max} and earlier`,
     exclusiveRange: (min, max) => `${min} - ${max}`,
-    inclusiveRange: (min, max) => `Between ${min} and ${max}`
+    inclusiveRange: (min, max) => `${min} - ${max}`
   };
 
   beforeEach(() => {


### PR DESCRIPTION
> Date range and number ranges follow the format "Between XXX and YYY". Spec says it should just be "XXX - YYY". Can we get rid of the words "between" and "and"?

TEST=manual
check that uses updated display value in applied filters bar