### PR TITLE
FilterSearch + GeolocationFilter: remove quotes from filter metadata

### DIFF
--- a/src/ui/components/filters/geolocationcomponent.js
+++ b/src/ui/components/filters/geolocationcomponent.js
@@ -205,7 +205,7 @@ export default class GeoLocationComponent extends Component {
 
   _handleSubmit (query, filter) {
     this.query = query;
-    this._saveDataToStorage(query, Filter.fromResponse(filter), `"${query}"`);
+    this._saveDataToStorage(query, Filter.fromResponse(filter), `${query}`);
     this._enabled = false;
   }
 

--- a/src/ui/components/search/filtersearchcomponent.js
+++ b/src/ui/components/search/filtersearchcomponent.js
@@ -161,7 +161,7 @@ export default class FilterSearchComponent extends Component {
       filter: filter,
       metadata: {
         fieldName: this.title,
-        displayValue: `"${query}"`
+        displayValue: `${query}`
       },
       remove: () => this._removeFilterNode()
     });

--- a/tests/ui/components/filters/filtersearchcomponent.js
+++ b/tests/ui/components/filters/filtersearchcomponent.js
@@ -21,7 +21,7 @@ describe('FilterSearch', () => {
       filter: filter,
       metadata: {
         fieldName: title,
-        displayValue: `"${query}"`
+        displayValue: `${query}`
       }
     });
     expect(filterNode.filter).toEqual(expectedFilterNode.filter);

--- a/tests/ui/components/filters/geolocationcomponent.js
+++ b/tests/ui/components/filters/geolocationcomponent.js
@@ -32,7 +32,7 @@ describe('GeoLocationFilter', () => {
       filter: Filter.fromResponse(filter),
       metadata: {
         fieldName: title,
-        displayValue: `"${query}"`
+        displayValue: `${query}`
       }
     });
     expect(filterNode.filter).toEqual(expectedFilterNode.filter);


### PR DESCRIPTION
>"Certain filter values appear in quotes, which they shouldn't. For example, any filter produced by the FilterSearch component will appear in quotes
Same problem for values from GeolocationFilter (e.g. `"New York, New York, United States"`).
Can we get rid of the quotes?"

TEST=manual
tested that geolocation and filtersearch filters dont have quotes in the applied filters bar