### PR TITLE
Add dependabot config file for security monitoring.

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,5 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "monthly"


### PR DESCRIPTION
This change configures Dependabot to run against the develop branch,
periodically checking for out-of-date or insecure dependencies. This PR was
introduced previously here: https://github.com/yext/answers/pull/738.

J=SPR-2371
TEST=none