### PR TITLE
FilterBox: 0 padding-left on reset button when no apply button

### DIFF
--- a/src/ui/sass/modules/_FilterBox.scss
+++ b/src/ui/sass/modules/_FilterBox.scss
@@ -50,7 +50,9 @@
       $weight: var(--yxt-font-weight-semibold),
       $color: var(--yxt-color-brand-primary));
 
-    @include TextButton();
+    @include TextButton(
+      $padding: 5px 10px 5px 0px
+    );
 
     text-decoration: underline;
 
@@ -58,12 +60,11 @@
       text-decoration: none;
     }
 
-    margin-left: 10px;
     letter-spacing: 0.5px;
+  }
 
-    &--noApplyButton {
-      padding-left: 0;
-      margin-left: 0;
-    }
+  &-apply + &-reset {
+    padding-left: 5px;
+    margin-left: 10px;
   }
 }

--- a/src/ui/sass/modules/_FilterBox.scss
+++ b/src/ui/sass/modules/_FilterBox.scss
@@ -62,6 +62,7 @@
     letter-spacing: 0.5px;
 
     &--noApplyButton {
+      padding-left: 0;
       margin-left: 0;
     }
   }

--- a/src/ui/templates/filters/filterbox.hbs
+++ b/src/ui/templates/filters/filterbox.hbs
@@ -21,7 +21,7 @@
         </button>
       {{/if}}
       {{~#if showReset ~}}
-        <button type="button" class="js-yxt-FilterBox-reset yxt-FilterBox-reset{{#unless showApplyButton}} yxt-FilterBox-reset--noApplyButton{{/unless}}">
+        <button type="button" class="js-yxt-FilterBox-reset yxt-FilterBox-reset">
           {{resetLabel}}
         </button>
       {{/if}}


### PR DESCRIPTION
A new feature was added where you are able to render only a reset-all button or only render an
apply button for FilterBox. Before, these two were always rendered together.

This commit updates the spacing around the reset-all button when there is no apply button, so that it lines up better with the rest of the filter box. This was not possible before, so it is not a breaking css change

TEST=manual
check that with an apply button AND reset button, styling is the same as before
with only a reset button, margin-left and padding-left are set to 0