### PR TITLE
VerticalResults: add query to view all link

### DIFF
--- a/src/core/utils/urlutils.js
+++ b/src/core/utils/urlutils.js
@@ -42,9 +42,10 @@ export function getAnalyticsUrl (env = PRODUCTION, conversionTrackingEnabled = f
 }
 
 /**
- * Returns the passed in url with the query appended to it.
+ * Returns the passed in url, with all url params from the current url, as well as any
+ * pasased in params, appended to it.
  * @param {string} url
- * @param {params} Object
+ * @param {Object} params
  * @returns {string}
  */
 export function addParamsToUrl (url, params = {}) {

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -227,7 +227,7 @@ export default class VerticalResultsComponent extends Component {
 
   getVerticalURL (data = {}) {
     if ('verticalURL' in this._config) {
-      return this._config.verticalURL;
+      return addParamsToUrl(this._config.verticalURL, { query: this.query });
     }
     const verticalConfig = this._verticalsConfig.find(config => config.verticalKey === this.verticalKey) || {};
     const verticalURL = verticalConfig.url || data.verticalURL || this.verticalKey + '.html';

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -226,11 +226,8 @@ export default class VerticalResultsComponent extends Component {
   }
 
   getVerticalURL (data = {}) {
-    if ('verticalURL' in this._config) {
-      return addParamsToUrl(this._config.verticalURL || '', { query: this.query });
-    }
     const verticalConfig = this._verticalsConfig.find(config => config.verticalKey === this.verticalKey) || {};
-    const verticalURL = verticalConfig.url || data.verticalURL || this.verticalKey + '.html';
+    const verticalURL = this._config.verticalURL || verticalConfig.url || data.verticalURL || this.verticalKey + '.html';
     return addParamsToUrl(verticalURL, { query: this.query });
   }
 
@@ -252,7 +249,7 @@ export default class VerticalResultsComponent extends Component {
     const hasAppliedFilters = this.appliedFilterNodes.length || this.nlpFilterNodes.length;
     const showResultsHeader = this.resultsHeaderOpts.showResultCount ||
       (this.resultsHeaderOpts.showAppliedFilters && hasAppliedFilters);
-    this.query = this.core.globalStorage.getState(StorageKeys.QUERY);
+    this.query = this.core.globalStorage.getState(StorageKeys.QUERY) || '';
     return super.setState(Object.assign({ results: [] }, data, {
       isPreSearch: searchState === SearchStates.PRE_SEARCH,
       isSearchLoading: searchState === SearchStates.SEARCH_LOADING,

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -249,7 +249,7 @@ export default class VerticalResultsComponent extends Component {
     const hasAppliedFilters = this.appliedFilterNodes.length || this.nlpFilterNodes.length;
     const showResultsHeader = this.resultsHeaderOpts.showResultCount ||
       (this.resultsHeaderOpts.showAppliedFilters && hasAppliedFilters);
-    this.query = this.core.globalStorage.getState(StorageKeys.QUERY) || '';
+    this.query = this.core.globalStorage.getState(StorageKeys.QUERY);
     return super.setState(Object.assign({ results: [] }, data, {
       isPreSearch: searchState === SearchStates.PRE_SEARCH,
       isSearchLoading: searchState === SearchStates.SEARCH_LOADING,

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -227,7 +227,7 @@ export default class VerticalResultsComponent extends Component {
 
   getVerticalURL (data = {}) {
     if ('verticalURL' in this._config) {
-      return addParamsToUrl(this._config.verticalURL, { query: this.query });
+      return addParamsToUrl(this._config.verticalURL || '', { query: this.query });
     }
     const verticalConfig = this._verticalsConfig.find(config => config.verticalKey === this.verticalKey) || {};
     const verticalURL = verticalConfig.url || data.verticalURL || this.verticalKey + '.html';

--- a/tests/ui/components/results/verticalresultscomponent.js
+++ b/tests/ui/components/results/verticalresultscomponent.js
@@ -107,4 +107,55 @@ describe('vertical results component', () => {
     expect(resultsCountSeparator).toEqual('');
     expect(showAppliedFilters).toBeNull();
   });
+
+  describe('creates verticalURL correctly', () => {
+    let component;
+    delete global.window.location;
+    global.window = Object.create(window);
+    global.window.location = {
+      search: '?query=virginia&otherParam=123'
+    };
+
+    beforeEach(() => {
+      component = COMPONENT_MANAGER.create('VerticalResults', {});
+      component.query = 'my-query';
+      component.verticalKey = 'key';
+    });
+
+    it('if unset defaults to vertical key', () => {
+      expect(component.getVerticalURL()).toEqual('key.html?query=my-query&otherParam=123');
+    });
+
+    it('if null defaults to vertical key', () => {
+      component = COMPONENT_MANAGER.create('VerticalResults', {
+        verticalURL: null
+      });
+      component.query = 'my-query';
+      component.verticalKey = 'key';
+      expect(component.getVerticalURL()).toEqual('key.html?query=my-query&otherParam=123');
+    });
+
+    it('works with transformData', () => {
+      expect(component.getVerticalURL({
+        verticalURL: 'transform-data'
+      })).toEqual('transform-data?query=my-query&otherParam=123');
+    });
+
+    it('defaults to matching config in verticalPages', () => {
+      component._verticalsConfig = [{
+        verticalKey: 'key',
+        url: 'vertical-pages'
+      }];
+      expect(component.getVerticalURL()).toEqual('vertical-pages?query=my-query&otherParam=123');
+    });
+
+    it('can be set', () => {
+      component = COMPONENT_MANAGER.create('VerticalResults', {
+        verticalURL: 'vertical-url'
+      });
+      component.query = 'my-query';
+      component.verticalKey = 'key';
+      expect(component.getVerticalURL()).toEqual('vertical-url?query=my-query&otherParam=123');
+    });
+  });
 });


### PR DESCRIPTION
If the url was passed in from the config, the `query` url param was not being set. This is needed when going from universal to vertical search so that the same query is run on page load.

TEST=manual
test that locally, query will be passed through
test setting url to unset, null, undefined, '', defaults to <verticalKey>.html