### PR TITLE
ResultsHeader: add yxt-Results-filters css class for compatibility

### DIFF
--- a/src/ui/sass/modules/_ResultsHeader.scss
+++ b/src/ui/sass/modules/_ResultsHeader.scss
@@ -32,13 +32,20 @@ $results-header-universal-background: var(--yxt-color-brand-white) !default;
   --yxt-results-header-universal-background: #{$results-header-universal-background};
 }
 
-.yxt-ResultsHeader {
+.yxt-ResultsHeader
+{
+  // reset styling from yxt-Results-filters, a css class added for backwards compatibility
+  margin: inherit;
+  background-color: inherit;
+  border: inherit;
+
   padding: calc(var(--yxt-results-header-spacing) / 4) var(--yxt-results-header-spacing);
   padding-bottom: 0;
   display: flex;
   align-items: baseline;
 
-  &-wrapper {
+  &-wrapper
+  {
     display: flex;
     flex-wrap: wrap;
     align-items: baseline;

--- a/src/ui/sass/modules/_ResultsHeader.scss
+++ b/src/ui/sass/modules/_ResultsHeader.scss
@@ -34,11 +34,6 @@ $results-header-universal-background: var(--yxt-color-brand-white) !default;
 
 .yxt-ResultsHeader
 {
-  // reset styling from yxt-Results-filters, a css class added for backwards compatibility
-  margin: inherit;
-  background-color: inherit;
-  border: inherit;
-
   padding: calc(var(--yxt-results-header-spacing) / 4) var(--yxt-results-header-spacing);
   padding-bottom: 0;
   display: flex;

--- a/src/ui/templates/results/resultsheader.hbs
+++ b/src/ui/templates/results/resultsheader.hbs
@@ -1,5 +1,5 @@
 <div class="yxt-ResultsHeader
-  {{~#if _config.isUniversal}} yxt-ResultsHeader--universal{{/if}}
+  {{~#if _config.isUniversal}} yxt-Results-filters yxt-ResultsHeader--universal{{/if}}
   {{~#if _config.removable}} yxt-ResultsHeader--removable{{/if}}">
   {{> resultscount}}
   {{#if showResultSeparator}}

--- a/src/ui/templates/results/resultsheader.hbs
+++ b/src/ui/templates/results/resultsheader.hbs
@@ -1,5 +1,5 @@
 <div class="yxt-ResultsHeader
-  {{~#if _config.isUniversal}} yxt-Results-filters yxt-ResultsHeader--universal{{/if}}
+  {{~#if _config.isUniversal}} yxt-ResultsHeader--universal yxt-Results-filters{{/if}}
   {{~#if _config.removable}} yxt-ResultsHeader--removable{{/if}}">
   {{> resultscount}}
   {{#if showResultSeparator}}


### PR DESCRIPTION
This commit adds the yxt-Results-filters css class to yxt-ResultsHeader,
so that if yxt-Results-filters was being display: none'd, then the ResultsHeader
will also be display: none'd. This is only done on universal. On universal, since
v0.13.0 the newer yxt-ResultsHeader has already been in use, and adding this class
on vertical pages is more likely to confuse us than help us in the future.

TEST=manual
test that on local verizon site with display: none, nlp filters no longer show
up on universal