### PR TITLE
DirectAnswers: color: inherit for icon

### DIFF
--- a/src/ui/sass/modules/_DirectAnswer.scss
+++ b/src/ui/sass/modules/_DirectAnswer.scss
@@ -81,7 +81,7 @@ $direct-answer-footer-height: var(--yxt-module-footer-height) !default;
   {
     display: flex;
     margin-right: calc(var(--yxt-base-spacing) / 2);
-    height: 18px;
+    color: inherit;
   }
 
   &-entityName

--- a/src/ui/sass/modules/_DirectAnswer.scss
+++ b/src/ui/sass/modules/_DirectAnswer.scss
@@ -81,7 +81,11 @@ $direct-answer-footer-height: var(--yxt-module-footer-height) !default;
   {
     display: flex;
     margin-right: calc(var(--yxt-base-spacing) / 2);
-    color: inherit;
+
+    &.yxt-Results-titleIconWrapper
+    {
+      color: inherit;
+    }
   }
 
   &-entityName

--- a/src/ui/templates/results/directanswer.hbs
+++ b/src/ui/templates/results/directanswer.hbs
@@ -3,7 +3,7 @@
 {{else}}
   <div class="yxt-DirectAnswer">
     <div class="yxt-DirectAnswer-title">
-      <div class="yxt-Results-titleIconWrapper"
+      <div class="yxt-DirectAnswer-titleIconWrapper yxt-Results-titleIconWrapper"
           data-component="IconComponent"
           data-opts='{
               "iconName": "{{iconName}}",


### PR DESCRIPTION
.yxt-Results-titleIconWrapper was previously changed to have color: $color-brand-primary.
This css class was also being used in DirectAnswers, which caused an undesired color change.
Double checked, and yxt-Results-titleIconWrapper is only being used in DirectAnswers and
VerticalResults.

This commit adds the currently unused yxt-DirectAnswer-titleIconWrapper class to the
`<div>`. It has the exact same styling as yxt-Results-titleIconWrapper, except for color: inherit.

TEST=manual
test that by default the direct answers icon color is white