### PR TITLE
VerticalResults/ResultsHeader: add missing event options

### DIFF
--- a/src/ui/templates/results/resultsheader.hbs
+++ b/src/ui/templates/results/resultsheader.hbs
@@ -51,7 +51,11 @@
         {{/unless}}
       {{/each}}
     {{#every _config.isUniversal _config.verticalURL _config.showChangeFilters}}
-      <a class="yxt-ResultsHeader-changeFilters" href="{{ _config.verticalURL }}">
+      <a class="yxt-ResultsHeader-changeFilters" href="{{ _config.verticalURL }}"
+        data-middleclick="active"
+        data-eventtype="FILTERING_WITHIN_SECTION"
+        data-eventoptions='{{eventOptions}}'
+      >
         change filters
       </a>
     {{/every}}

--- a/src/ui/templates/results/verticalresults.hbs
+++ b/src/ui/templates/results/verticalresults.hbs
@@ -71,7 +71,11 @@
 
 {{#*inline "viewAll"}}
   {{#if (and _config.isUniversal _config.viewMore _config.viewMoreLabel verticalURL)}}
-    <a class="yxt-Results-viewAll yxt-Results-viewAllLink" href="{{ verticalURL }}">
+    <a class="yxt-Results-viewAll yxt-Results-viewAllLink" href="{{ verticalURL }}"
+      data-middleclick="active"
+      data-eventtype="VERTICAL_VIEW_ALL"
+      data-eventoptions='{{eventOptions}}'
+    >
       <div class="yxt-Results-viewAllLabel">{{_config.viewMoreLabel}}</div>
       <div data-component="IconComponent" data-opts='{ "iconName": "chevron" }'></div>
     </a>


### PR DESCRIPTION
This commit adds missing analytics events to the updated vertical results/
results header for the view all link and the change filters link, that were present in the older resultssectionheader.hbs.

These use the same event options as the original analytics events.

TEST=manual
check that on click these events fire with a 200 response