### PR TITLE
Facets: fix acceptance test

### DIFF
--- a/tests/acceptance/blocks/filteroptionscomponent.js
+++ b/tests/acceptance/blocks/filteroptionscomponent.js
@@ -55,7 +55,7 @@ export default class FilterOptionsComponentBlock {
     if (isCollapsed) {
       await this.toggleExpand();
     }
-    const labelSelector = await this.getLabel(label)
+    const labelSelector = await this.getLabel(label);
     await t.click(labelSelector);
   }
 

--- a/tests/acceptance/blocks/filteroptionscomponent.js
+++ b/tests/acceptance/blocks/filteroptionscomponent.js
@@ -17,7 +17,7 @@ export default class FilterOptionsComponentBlock {
   }
 
   async getLabel (label) {
-    return this._selector.find('label').withText(label);
+    return this._selector.find('.yxt-FilterOptions-optionLabel--name').withText(label).parent(0);
   }
 
   /**
@@ -55,8 +55,8 @@ export default class FilterOptionsComponentBlock {
     if (isCollapsed) {
       await this.toggleExpand();
     }
-    const option = await this._getOption(label);
-    await t.click(option);
+    const labelSelector = await this.getLabel(label)
+    await t.click(labelSelector);
   }
 
   /**


### PR DESCRIPTION
There were some changes to the FilterOptions DOM that need to be
reflected in the acceptance tests component block as well.

TEST=auto
acceptance tests succeed again