### PR TITLE
ResultsHeader: display facets from response, not request

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -187,6 +187,7 @@ export default class Core {
 
         if (data[StorageKeys.DYNAMIC_FILTERS]) {
           this.globalStorage.set(StorageKeys.DYNAMIC_FILTERS, data[StorageKeys.DYNAMIC_FILTERS]);
+          this.globalStorage.set(StorageKeys.RESULTS_HEADER, data[StorageKeys.DYNAMIC_FILTERS]);
         }
         if (data[StorageKeys.SPELL_CHECK]) {
           this.globalStorage.set(StorageKeys.SPELL_CHECK, data[StorageKeys.SPELL_CHECK]);

--- a/src/core/filters/filterregistry.js
+++ b/src/core/filters/filterregistry.js
@@ -26,6 +26,22 @@ export default class FilterRegistry {
   }
 
   /**
+   * Returns an array containing all of the filternodes stored in global storage.
+   * @returns {Array<FilterNode>}
+   */
+  getAppliedFilterNodes () {
+    const globalStorageFilterNodes = [
+      ...this.getStaticFilterNodes(),
+      ...this.getFacetFilterNodes()
+    ];
+    const locationRadiusFilterNode = this.getFilterNodeByKey(StorageKeys.LOCATION_RADIUS);
+    if (locationRadiusFilterNode) {
+      globalStorageFilterNodes.push(locationRadiusFilterNode);
+    }
+    return globalStorageFilterNodes;
+  }
+
+  /**
    * Get all of the {@link FilterNode}s for static filters.
    * @returns {Array<FilterNode>}
    */

--- a/src/core/filters/filterregistry.js
+++ b/src/core/filters/filterregistry.js
@@ -29,7 +29,7 @@ export default class FilterRegistry {
    * Returns an array containing all of the filternodes stored in global storage.
    * @returns {Array<FilterNode>}
    */
-  getAppliedFilterNodes () {
+  getAllFilterNodes () {
     const globalStorageFilterNodes = [
       ...this.getStaticFilterNodes(),
       ...this.getFacetFilterNodes()

--- a/src/core/storage/storagekeys.js
+++ b/src/core/storage/storagekeys.js
@@ -32,5 +32,6 @@ export default {
   LOCALE: 'locale',
   SORT_BYS: 'sort-bys',
   NO_RESULTS_CONFIG: 'no-results-config',
-  LOCATION_RADIUS: 'location-radius'
+  LOCATION_RADIUS: 'location-radius',
+  RESULTS_HEADER: 'results-header'
 };

--- a/src/core/utils/filternodeutils.js
+++ b/src/core/utils/filternodeutils.js
@@ -20,7 +20,7 @@ export function convertNlpFiltersToFilterNodes (nlpFilters) {
 /**
  * Flattens an array of {@link FilterNode}s into an array
  * of their constituent leaf {@link SimpleFilterNode}s.
- * @param {Array<FilterNode>} filterNodes 
+ * @param {Array<FilterNode>} filterNodes
  * @returns {Array<SimpleFilterNode>}
  */
 export function flattenFilterNodes (filterNodes) {

--- a/src/core/utils/filternodeutils.js
+++ b/src/core/utils/filternodeutils.js
@@ -1,0 +1,41 @@
+import FilterNodeFactory from '../filters/filternodefactory';
+import Filter from '../models/filter';
+import FilterMetadata from '../filters/filtermetadata';
+
+/**
+ * Converts an array of {@link AppliedQueryFilter}s into equivalent {@link SimpleFilterNode}s.
+ * @param {Array<AppliedQueryFilter>} nlpFilters
+ * @returns {Array<SimpleFilterNode>}
+ */
+export function convertNlpFiltersToFilterNodes (nlpFilters) {
+  return nlpFilters.map(nlpFilter => FilterNodeFactory.from({
+    filter: Filter.from(nlpFilter.filter),
+    metadata: new FilterMetadata({
+      fieldName: nlpFilter.key,
+      displayValue: nlpFilter.value
+    })
+  }));
+}
+
+export function flattenIntoSimpleFilterNodes (filterNodes) {
+  return filterNodes.flatMap(fn => fn.getSimpleAncestors());
+}
+
+/**
+ * Returns the given array of {@link FilterNode}s,
+ * removing FilterNodes that are empty or have a field id listed as a hidden.
+ * @param {Array<FilterNode>} filterNodes
+ * @param {Array<string>} hiddenFields
+ * @returns {Array<FilterNode>}
+ */
+export function purifyFilterNodes (filterNodes, hiddenFields) {
+  return filterNodes
+    .filter(fn => {
+      const { fieldName, displayValue } = fn.getMetadata();
+      if (!fieldName || !displayValue) {
+        return false;
+      }
+      const fieldId = fn.getFilter().getFilterKey();
+      return !hiddenFields.includes(fieldId);
+    });
+}

--- a/src/core/utils/filternodeutils.js
+++ b/src/core/utils/filternodeutils.js
@@ -17,6 +17,12 @@ export function convertNlpFiltersToFilterNodes (nlpFilters) {
   }));
 }
 
+/**
+ * Flattens an array of {@link FilterNode}s into an array of all of their
+ * leaf {@link SimpleFilterNode}s.
+ * @param {Array<FilterNode>} filterNodes 
+ * @returns {Array<SimpleFilterNode>}
+ */
 export function flattenFilterNodes (filterNodes) {
   return filterNodes.flatMap(fn => fn.getSimpleAncestors());
 }

--- a/src/core/utils/filternodeutils.js
+++ b/src/core/utils/filternodeutils.js
@@ -18,8 +18,8 @@ export function convertNlpFiltersToFilterNodes (nlpFilters) {
 }
 
 /**
- * Flattens an array of {@link FilterNode}s into an array of all of their
- * leaf {@link SimpleFilterNode}s.
+ * Flattens an array of {@link FilterNode}s into an array
+ * of their constituent leaf {@link SimpleFilterNode}s.
  * @param {Array<FilterNode>} filterNodes 
  * @returns {Array<SimpleFilterNode>}
  */

--- a/src/core/utils/filternodeutils.js
+++ b/src/core/utils/filternodeutils.js
@@ -17,7 +17,7 @@ export function convertNlpFiltersToFilterNodes (nlpFilters) {
   }));
 }
 
-export function flattenIntoSimpleFilterNodes (filterNodes) {
+export function flattenFilterNodes (filterNodes) {
   return filterNodes.flatMap(fn => fn.getSimpleAncestors());
 }
 
@@ -28,7 +28,7 @@ export function flattenIntoSimpleFilterNodes (filterNodes) {
  * @param {Array<string>} hiddenFields
  * @returns {Array<FilterNode>}
  */
-export function purifyFilterNodes (filterNodes, hiddenFields) {
+export function pruneFilterNodes (filterNodes, hiddenFields) {
   return filterNodes
     .filter(fn => {
       const { fieldName, displayValue } = fn.getMetadata();

--- a/src/ui/components/results/resultsheadercomponent.js
+++ b/src/ui/components/results/resultsheadercomponent.js
@@ -4,6 +4,11 @@ import Component from '../component';
 import StorageKeys from '../../../core/storage/storagekeys';
 import DOM from '../../dom/dom';
 import { groupArray } from '../../../core/utils/arrayutils';
+import {
+  convertNlpFiltersToFilterNodes,
+  flattenIntoSimpleFilterNodes,
+  purifyFilterNodes
+} from '../../../core/utils/filternodeutils';
 
 const DEFAULT_CONFIG = {
   showResultCount: true,
@@ -16,7 +21,8 @@ const DEFAULT_CONFIG = {
   delimiter: '|',
   isUniversal: false,
   labelText: 'Filters applied to this search:',
-  removableLabelText: 'Remove this filter'
+  removableLabelText: 'Remove this filter',
+  hiddenFields: []
 };
 
 export default class ResultsHeaderComponent extends Component {
@@ -38,18 +44,14 @@ export default class ResultsHeaderComponent extends Component {
     this.resultsLength = data.resultsLength || 0;
 
     /**
-     * Array of applied filterNodes. These are allowed to be removable, but
-     * if config.removable is set as false these will not render as removable.
-     * @type {Array<FilterNode>}
+     * Array of nlp filters in the search response.
+     * @type {Array<AppliedQueryFilter>}
      */
-    this.appliedFilterNodes = data.appliedFilterNodes || [];
+    this.nlpFilterNodes = convertNlpFiltersToFilterNodes(data.nlpFilters || []);
 
-    /**
-     * Array of nlp filterNodes to display.
-     * These will not render as removable even if config.removable is true.
-     * @type {Array<FilterNode>}
-     */
-    this.nlpFilterNodes = data.nlpFilterNodes || [];
+    this.core.globalStorage.on('update', StorageKeys.FACET_FILTER_NODE, () => {
+      this.setState();
+    });
   }
 
   static areDuplicateNamesAllowed () {
@@ -108,7 +110,7 @@ export default class ResultsHeaderComponent extends Component {
    * not objects, so we need to reformat the grouped applied filters.
    * @returns {Array<Object>}
    */
-  _getAppliedFiltersArray () {
+  _parseAppliedFiltersToArray () {
     const groupedFilters = this._groupAppliedFilters();
     return Object.keys(groupedFilters).map(label => ({
       label: label,
@@ -116,9 +118,21 @@ export default class ResultsHeaderComponent extends Component {
     }));
   }
 
+  /**
+   * Pulls applied filter nodes from {@link FilterRegistry}, then retrives an array of
+   * the leaf nodes, and then removes hidden or empty {@link FilterNode}s. Then appends
+   * the currently applied nlp filters.
+   */
+  _calculateAppliedFilterNodes () {
+    const filterNodes = this.core.filterRegistry.getAppliedFilterNodes();
+    const simpleFilterNodes = flattenIntoSimpleFilterNodes(filterNodes);
+    return purifyFilterNodes(simpleFilterNodes, this._config.hiddenFields);
+  }
+
   setState (data) {
     const offset = this.core.globalStorage.getState(StorageKeys.SEARCH_OFFSET);
-    const appliedFiltersArray = this._getAppliedFiltersArray();
+    this.appliedFilterNodes = this._calculateAppliedFilterNodes();
+    const appliedFiltersArray = this._parseAppliedFiltersToArray();
     const shouldShowFilters = appliedFiltersArray.length > 0 && this._config.showAppliedFilters;
     return super.setState({
       ...data,

--- a/src/ui/components/results/resultsheadercomponent.js
+++ b/src/ui/components/results/resultsheadercomponent.js
@@ -6,8 +6,8 @@ import DOM from '../../dom/dom';
 import { groupArray } from '../../../core/utils/arrayutils';
 import {
   convertNlpFiltersToFilterNodes,
-  flattenIntoSimpleFilterNodes,
-  purifyFilterNodes
+  flattenFilterNodes,
+  pruneFilterNodes
 } from '../../../core/utils/filternodeutils';
 
 const DEFAULT_CONFIG = {
@@ -115,7 +115,7 @@ export default class ResultsHeaderComponent extends Component {
    * not objects, so we need to reformat the grouped applied filters.
    * @returns {Array<Object>}
    */
-  _parseAppliedFiltersToArray () {
+  _createAppliedFiltersArray () {
     const groupedFilters = this._groupAppliedFilters();
     return Object.keys(groupedFilters).map(label => ({
       label: label,
@@ -129,15 +129,15 @@ export default class ResultsHeaderComponent extends Component {
    * the currently applied nlp filters.
    */
   _calculateAppliedFilterNodes () {
-    const filterNodes = this.core.filterRegistry.getAppliedFilterNodes();
-    const simpleFilterNodes = flattenIntoSimpleFilterNodes(filterNodes);
-    return purifyFilterNodes(simpleFilterNodes, this._config.hiddenFields);
+    const filterNodes = this.core.filterRegistry.getAllFilterNodes();
+    const simpleFilterNodes = flattenFilterNodes(filterNodes);
+    return pruneFilterNodes(simpleFilterNodes, this._config.hiddenFields);
   }
 
   setState (data) {
     const offset = this.core.globalStorage.getState(StorageKeys.SEARCH_OFFSET);
     this.appliedFilterNodes = this._calculateAppliedFilterNodes();
-    const appliedFiltersArray = this._parseAppliedFiltersToArray();
+    const appliedFiltersArray = this._createAppliedFiltersArray();
     const shouldShowFilters = appliedFiltersArray.length > 0 && this._config.showAppliedFilters;
     return super.setState({
       ...data,

--- a/src/ui/components/results/resultsheadercomponent.js
+++ b/src/ui/components/results/resultsheadercomponent.js
@@ -49,9 +49,20 @@ export default class ResultsHeaderComponent extends Component {
      */
     this.nlpFilterNodes = convertNlpFiltersToFilterNodes(data.nlpFilters || []);
 
-    this.core.globalStorage.on('update', StorageKeys.FACET_FILTER_NODE, () => {
-      this.setState();
-    });
+    /**
+     * TODO (SPR-2455): Child components cannot set manual event listeners to globalStorage
+     * without duplicate listeners, and cannot set a moduleId if any other components
+     * also listen to the same StorageKey, otherwise those components can have their listeners
+     * erased if said child component's parent rerenders. One workaround is to create
+     * a unique StorageKey as needed, and so that cleaning up these listeners does not have
+     * adverse affects on other components.
+     */
+    this.core.globalStorage.on('update', StorageKeys.RESULTS_HEADER, () => this.setState());
+  }
+
+  remove () {
+    this.core.globalStorage.off('update', StorageKeys.RESULTS_HEADER);
+    return super.remove();
   }
 
   static areDuplicateNamesAllowed () {

--- a/src/ui/components/results/resultsheadercomponent.js
+++ b/src/ui/components/results/resultsheadercomponent.js
@@ -50,19 +50,13 @@ export default class ResultsHeaderComponent extends Component {
     this.nlpFilterNodes = convertNlpFiltersToFilterNodes(data.nlpFilters || []);
 
     /**
-     * TODO (SPR-2455): Child components cannot set manual event listeners to globalStorage
-     * without duplicate listeners, and cannot set a moduleId if any other components
-     * also listen to the same StorageKey, otherwise those components can have their listeners
-     * erased if said child component's parent rerenders. One workaround is to create
-     * a unique StorageKey as needed, and so that cleaning up these listeners does not have
-     * adverse affects on other components.
+     * TODO (SPR-2455): Ideally, we would be able to set moduleId to DYNAMIC_FILTERS, the actual data
+     * we are listening to changes to, instead of this bespoke RESULTS_HEADER storage key.
+     * The issue is that when two components share a moduleId, if that moduleId listener is ever
+     * unregistered with the off() method, all listeners to that moduleId are unregistered.
+     * With child components, this is something that happens whenever the parent component rerenders.
      */
-    this.core.globalStorage.on('update', StorageKeys.RESULTS_HEADER, () => this.setState());
-  }
-
-  remove () {
-    this.core.globalStorage.off('update', StorageKeys.RESULTS_HEADER);
-    return super.remove();
+    this.moduleId = StorageKeys.RESULTS_HEADER;
   }
 
   static areDuplicateNamesAllowed () {

--- a/src/ui/templates/results/resultsheader.hbs
+++ b/src/ui/templates/results/resultsheader.hbs
@@ -1,15 +1,17 @@
-<div class="yxt-ResultsHeader
-  {{~#if _config.isUniversal}} yxt-ResultsHeader--universal yxt-Results-filters{{/if}}
-  {{~#if _config.removable}} yxt-ResultsHeader--removable{{/if}}">
-  {{> resultscount}}
-  {{#if showResultSeparator}}
-    <div class="yxt-ResultsHeader-resultsCountSeparator">{{_config.resultsCountSeparator}}</div>
-  {{/if}}
-  {{> filters}}
-</div>
+{{#if (or shouldShowFilters (and _config.showResultCount resultsCount))}}
+  <div class="yxt-ResultsHeader
+    {{~#if _config.isUniversal}} yxt-ResultsHeader--universal yxt-Results-filters{{/if}}
+    {{~#if _config.removable}} yxt-ResultsHeader--removable{{/if}}">
+    {{> resultscount}}
+    {{#if showResultSeparator}}
+      <div class="yxt-ResultsHeader-resultsCountSeparator">{{_config.resultsCountSeparator}}</div>
+    {{/if}}
+    {{> filters}}
+  </div>
+{{/if}}
 
 {{#*inline "resultscount"}}
-  {{#every _config.showResultCount resultsCount}}
+  {{#if (and _config.showResultCount resultsCount)}}
     <div class="yxt-ResultsHeader-resultsCount" aria-label="{{resultsCountStart}} through {{resultsCountEnd}} of {{resultsCount}}">
       <div aria-hidden="true">
         <span class="yxt-ResultsHeader-resultsCountStart">{{resultsCountStart}}</span>
@@ -19,7 +21,7 @@
         <span class="yxt-ResultsHeader-resultsCountTotal">{{resultsCount}}</span>
       </div>
     </div>
-  {{/every}}
+  {{/if}}
 {{/inline}}
 
 {{#*inline "filters"}}

--- a/src/ui/templates/results/verticalresults.hbs
+++ b/src/ui/templates/results/verticalresults.hbs
@@ -41,9 +41,7 @@
 {{/inline}}
 
 {{#*inline 'resultsHeader'}}
-  {{#if showResultsHeader}}
-    <div data-component="ResultsHeader"></div>
-  {{/if}}
+  <div data-component="ResultsHeader"></div>
 {{/inline}}
 
 {{#*inline "results"}}

--- a/tests/ui/components/results/resultsheadercomponent.js
+++ b/tests/ui/components/results/resultsheadercomponent.js
@@ -13,9 +13,9 @@ describe('ResultsHeaderComponent\'s applied filters', () => {
   let remove_f0_v0_fn, remove_f0_v1_fn, remove_f1_v0_fn, remove_f1_v1_fn;
   let COMPONENT_MANAGER = mockManager(
     {
-      getStaticFilterNodes: () => [],
-      getFacetFilterNodes: () => [],
-      getLocationRadiusFilterNode: () => null
+      filterRegistry: {
+        getAppliedFilterNodes: () => []
+      }
     },
     ResultsHeaderComponent.defaultTemplateName()
   );
@@ -169,23 +169,21 @@ describe('ResultsHeaderComponent\'s applied filters', () => {
     const verticalSearchFn = jest.fn();
     COMPONENT_MANAGER = mockManager(
       {
-        getStaticFilterNodes: () => [],
-        getFacetFilterNodes: () => [],
-        getLocationRadiusFilterNode: () => null,
-        verticalSearch: verticalSearchFn
+        verticalSearch: verticalSearchFn,
+        filterRegistry: {
+          getAppliedFilterNodes: () => [ node_f0_v0, node_f0_v1, node_f1_v0 ]
+        }
       },
       ResultsHeaderComponent.defaultTemplateName()
     );
 
     // Initialize and mount component
-    const simpleFilterNodes = [ node_f0_v0, node_f0_v1, node_f1_v0 ];
     resultsHeaderComponent = COMPONENT_MANAGER.create('ResultsHeader', {
       container: '#test-component',
       removable: true,
       verticalKey: 'a vertical key',
       data: {
-        appliedFilterNodes: simpleFilterNodes,
-        nlpFilterNodes: []
+        nlpFilters: []
       }
     });
     const wrapper = mount(resultsHeaderComponent);

--- a/tests/ui/components/results/resultsheadercomponent.js
+++ b/tests/ui/components/results/resultsheadercomponent.js
@@ -14,7 +14,7 @@ describe('ResultsHeaderComponent\'s applied filters', () => {
   let COMPONENT_MANAGER = mockManager(
     {
       filterRegistry: {
-        getAppliedFilterNodes: () => []
+        getAllFilterNodes: () => []
       }
     },
     ResultsHeaderComponent.defaultTemplateName()
@@ -171,7 +171,7 @@ describe('ResultsHeaderComponent\'s applied filters', () => {
       {
         verticalSearch: verticalSearchFn,
         filterRegistry: {
-          getAppliedFilterNodes: () => [ node_f0_v0, node_f0_v1, node_f1_v0 ]
+          getAllFilterNodes: () => [ node_f0_v0, node_f0_v1, node_f1_v0 ]
         }
       },
       ResultsHeaderComponent.defaultTemplateName()


### PR DESCRIPTION
This commit moves applied filter display logic into the ResultsHeader,
instead of VerticalResults, and also sets up the component to listen
to changes to DYNAMIC_FILTERS. Now, the applied filters bar will display the facets calculated from the response, instead of the facets sent in the request.

Originally, I wanted to just make VerticalResults listen to changes to
DYNAMIC_FILTERS. However, VerticalResults already listens to changes
to VERTICAL_RESULTS, and the sdk does not play nice when a component
tries to listen to multiple StorageKeys. In order to do this the filter calculation
logic needed to be moved into the ResultsHeader.

Due to some complications below, it was necessary to create a bespoke storageKey that mirrors DYNAMIC_FILTERS.

Just registering a listener to DYNAMIC_FILTERS inside the ResultsHeader doesn't work, though
because every time VerticalResults (the parent component) has its setState called, a new ResultsHeader component will be created from scratch, and that new component will register a new, duplicate event listener, without cleaning up the old one. Cleaning up the old event listener to DYNAMIC_FILTERS breaks Facets, which also listen to DYNAMIC_FILTERS, because the current implementation of the off() method erases all event listeners for a moduleId, and cannot be targeted at a specific listener. This problem was worked around by adding a unique ResultsHeader StorageKey, and SPR-2455 was created to investigate this spaghetti code.

A future commit will add collision handling when an NLP filter and facet
share the same display value + fieldId.

TEST=manual
test that results header will not render if showResultCount and appliedFilters.show are both false
test that facets/filters can still be removed from the applied filters bar
test that checking a facet, applying it, then removing it and applying again does not display the removed facet
  in the applied filters bar (i.e. we display facets received from the response, not sent in the request)
test that when I search "consulting", both an nlp filter tag and a facet removable filter tag will be rendered, and that
  clicking the removable tag will remove the selected facet and trigger a new search