### PR TITLE
Merge v1.4.0 QA into develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1045,7 +1045,7 @@ ANSWERS.addComponent('Facets', {
       // Optional, if true, display the filter option search input
       searchable: false,
       // Optional, control type, singleoption or multioption
-      control: false,
+      control: 'singleoption',
     }
   },
   // Optional, the label to show on the apply button

--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ ANSWERS.addComponent('UniversalResults', {
   container: '.universal-results-container',
   // Optional, configuration for each vertical's results
   config: {
-    'locations': { // The verticalKey
+    'people': { // The verticalKey
       card: {
         // Configuration for the cards in this vertical, see Cards
       },
@@ -494,9 +494,9 @@ ANSWERS.addComponent('UniversalResults', {
       title: 'People',
       // Icon to display to the left of the title. Must be one of our built-in icons, defaults to 'star'
       icon: 'star',
-      // The url for both the viewMore link and the change-filters link. Defaults to '/{{VERTICAL_KEY}}.html',
-      // in this case that is '/people.html'
-      url: '/people/about.html',
+      // The url for both the viewMore link and the change-filters link. Defaults to '{{VERTICAL_KEY}}.html',
+      // in this case that is 'people.html'
+      url: 'people.html',
       // Whether to display a view more link. Defaults to true
       viewMore: true,
       // The text for the view more link, if viewMore is true. Defaults to 'View More'

--- a/README.md
+++ b/README.md
@@ -1039,7 +1039,7 @@ ANSWERS.addComponent('Facets', {
   searchLabelText: 'Search for a filter option',
   // Optional, field-specific overrides for a filter
   fields: {
-    'c_customFieldName':  { // Field id to override e.g. c_customFieldName, buildin.location
+    'c_customFieldName':  { // Field id to override e.g. c_customFieldName, builtin.location
       // Optional, the placeholder text used for the filter option search input
       placeholderText: 'Search here...',
       // Optional, if true, display the filter option search input
@@ -1100,7 +1100,7 @@ ANSWERS.addComponent('FilterSearch', {
   searchParameters: {
     // List of fields to query for
     fields: [{
-      // Field id to query for e.g. c_customFieldName, buildin.location
+      // Field id to query for e.g. c_customFieldName, builtin.location
       fieldId: 'builtin.location',
       // Entity type api name e.g. healthcareProfessional, location, ce_person
       entityTypeId: 'ce_person',
@@ -1135,9 +1135,6 @@ ANSWERS.addComponent('FilterOptions', {
   // The type of options to filter by, either 'STATIC_FILTER' or 'RADIUS_FILTER'.
   // Defaults to 'STATIC_FILTER'.
   optionType: 'STATIC_FILTER',
-  // If true, the filter value is saved on change and sent with the next search.
-  // Defaults to false.
-  storeOnChange: true,
   // Required, list of options
   options: [
     /** Depends on the above optionType, either 'STATIC_FILTER' or 'RADIUS_FILTER', see below. **/
@@ -1351,7 +1348,7 @@ ANSWERS.addComponent('GeoLocationFilter', {
   searchParameters: {
     // List of fields to query for
     fields: [{
-      // Field id to query for e.g. c_customFieldName, buildin.location
+      // Field id to query for e.g. c_customFieldName, builtin.location
       fieldId: 'builtin.location',
       // Entity type api name e.g. healthcareProfessional, location, ce_person
       entityTypeId: 'ce_person',

--- a/README.md
+++ b/README.md
@@ -1015,7 +1015,7 @@ ANSWERS.addComponent('Facets', {
   resetFacet: false,
   // Optional, the label to use for the reset button above
   resetFacetLabel: 'reset',
-  // Optional, show a reset-all button for the facets control
+  // Optional, show a reset-all button for the facets control. Defaults to showing a reset-all button if searchOnChange is false.
   resetFacets: true,
   // Optional, the label to use for the reset-all button above
   resetFacetsLabel: 'reset-all',

--- a/README.md
+++ b/README.md
@@ -503,7 +503,7 @@ ANSWERS.addComponent('UniversalResults', {
       viewMoreLabel: 'View More!',
       // Config for the applied filters bar in the results header.
       appliedFilters: {
-        // If true, show any applied filters that were applied to the universal search. Defaults to false
+        // If true, show any applied filters that were applied to the universal search. Defaults to true
         show: true,
         // If appliedFilters.show is true, whether to display the field name of an applied filter, e.g. "Location: Virginia" vs just "Virginia". Defaults to false.
         showFieldNames: false,
@@ -591,7 +591,7 @@ ANSWERS.addComponent('VerticalResults', {
   },
   // Configuration for the applied filters bar in the header.
   appliedFilters: {
-    // If true, show any applied filters that were applied to the universal search. Defaults to false
+    // If true, show any applied filters that were applied to the vertical search. Defaults to true
     show: true,
     // If appliedFilters.show is true, whether to display the field name of an applied filter, e.g. "Location: Virginia" vs just "Virginia". Defaults to false.
     showFieldNames: false,

--- a/src/core/utils/urlutils.js
+++ b/src/core/utils/urlutils.js
@@ -42,9 +42,10 @@ export function getAnalyticsUrl (env = PRODUCTION, conversionTrackingEnabled = f
 }
 
 /**
- * Returns the passed in url with the query appended to it.
+ * Returns the passed in url, with all url params from the current url, as well as any
+ * pasased in params, appended to it.
  * @param {string} url
- * @param {params} Object
+ * @param {Object} params
  * @returns {string}
  */
 export function addParamsToUrl (url, params = {}) {

--- a/src/ui/components/filters/daterangefiltercomponent.js
+++ b/src/ui/components/filters/daterangefiltercomponent.js
@@ -196,9 +196,7 @@ export default class DateRangeFilterComponent extends Component {
     } else if (min === max) {
       displayValue = this._isExclusive ? '' : min;
     } else {
-      displayValue = this._isExclusive
-        ? `${min} - ${max}`
-        : `Between ${min} and ${max}`;
+      displayValue = `${min} - ${max}`;
     }
     return new FilterMetadata({
       fieldName: this._title,

--- a/src/ui/components/filters/facetscomponent.js
+++ b/src/ui/components/filters/facetscomponent.js
@@ -225,7 +225,7 @@ export default class FacetsComponent extends Component {
         searchable: this.config.searchable,
         searchLabelText: this.config.searchLabelText,
         placeholderText: this.config.placeholderText,
-        showExpand: fieldOverrides.expand || this.config.expand,
+        showExpand: fieldOverrides.expand === undefined ? this.config.expand : fieldOverrides.expand,
         ...fieldOverrides
       });
     });

--- a/src/ui/components/filters/facetscomponent.js
+++ b/src/ui/components/filters/facetscomponent.js
@@ -40,7 +40,7 @@ class FacetsConfig {
      * If true, show a "reset all" button to reset all facets
      * @type {boolean}
      */
-    this.resetFacets = config.resetFacets === undefined ? true : config.resetFacets;
+    this.resetFacets = config.resetFacets;
 
     /**
      * The label to show for the "reset all" button

--- a/src/ui/components/filters/filterboxcomponent.js
+++ b/src/ui/components/filters/filterboxcomponent.js
@@ -199,9 +199,9 @@ export default class FilterBoxComponent extends Component {
         container: `.js-yext-filterbox-filter${i}`,
         showReset: this.config.resetFilter,
         resetLabel: this.config.resetFilterLabel,
-        showExpand: this.config.expand,
         isDynamic: this.config.isDynamic,
         ...config,
+        showExpand: config.showExpand === undefined ? this.config.expand : config.showExpand,
         onChange: (filterNode, alwaysSaveFilterNodes, blockSearchOnChange) => {
           const _saveFilterNodes = this.config.searchOnChange || alwaysSaveFilterNodes;
           const _searchOnChange = this.config.searchOnChange && !blockSearchOnChange;

--- a/src/ui/components/filters/geolocationcomponent.js
+++ b/src/ui/components/filters/geolocationcomponent.js
@@ -205,7 +205,7 @@ export default class GeoLocationComponent extends Component {
 
   _handleSubmit (query, filter) {
     this.query = query;
-    this._saveDataToStorage(query, Filter.fromResponse(filter), `"${query}"`);
+    this._saveDataToStorage(query, Filter.fromResponse(filter), `${query}`);
     this._enabled = false;
   }
 

--- a/src/ui/components/results/universalresultscomponent.js
+++ b/src/ui/components/results/universalresultscomponent.js
@@ -63,7 +63,7 @@ export default class UniversalResultsComponent extends Component {
       // Icon in the titlebar
       icon: config.sectionTitleIconName || config.sectionTitleIconUrl || 'star',
       // Url that links to the vertical search for this vertical.
-      verticalURL: config.url || verticalKey + '.html',
+      verticalURL: 'url' in config ? config.url : verticalKey + '.html',
       // Show a view more link by default, which also links to verticalURL.
       viewMore: true,
       // By default, the view more link has a label of 'View More'.

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -226,11 +226,8 @@ export default class VerticalResultsComponent extends Component {
   }
 
   getVerticalURL (data = {}) {
-    if ('verticalURL' in this._config) {
-      return this._config.verticalURL;
-    }
     const verticalConfig = this._verticalsConfig.find(config => config.verticalKey === this.verticalKey) || {};
-    const verticalURL = verticalConfig.url || data.verticalURL || this.verticalKey + '.html';
+    const verticalURL = this._config.verticalURL || verticalConfig.url || data.verticalURL || this.verticalKey + '.html';
     return addParamsToUrl(verticalURL, { query: this.query });
   }
 

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -226,6 +226,9 @@ export default class VerticalResultsComponent extends Component {
   }
 
   getVerticalURL (data = {}) {
+    if ('verticalURL' in this._config) {
+      return this._config.verticalURL;
+    }
     const verticalConfig = this._verticalsConfig.find(config => config.verticalKey === this.verticalKey) || {};
     const verticalURL = verticalConfig.url || data.verticalURL || this.verticalKey + '.html';
     return addParamsToUrl(verticalURL, { query: this.query });

--- a/src/ui/components/search/filtersearchcomponent.js
+++ b/src/ui/components/search/filtersearchcomponent.js
@@ -161,7 +161,7 @@ export default class FilterSearchComponent extends Component {
       filter: filter,
       metadata: {
         fieldName: this.title,
-        displayValue: `"${query}"`
+        displayValue: `${query}`
       },
       remove: () => this._removeFilterNode()
     });

--- a/src/ui/sass/modules/_DirectAnswer.scss
+++ b/src/ui/sass/modules/_DirectAnswer.scss
@@ -81,7 +81,11 @@ $direct-answer-footer-height: var(--yxt-module-footer-height) !default;
   {
     display: flex;
     margin-right: calc(var(--yxt-base-spacing) / 2);
-    height: 18px;
+
+    &.yxt-Results-titleIconWrapper
+    {
+      color: inherit;
+    }
   }
 
   &-entityName

--- a/src/ui/sass/modules/_FilterBox.scss
+++ b/src/ui/sass/modules/_FilterBox.scss
@@ -50,7 +50,9 @@
       $weight: var(--yxt-font-weight-semibold),
       $color: var(--yxt-color-brand-primary));
 
-    @include TextButton();
+    @include TextButton(
+      $padding: 5px 10px 5px 0px
+    );
 
     text-decoration: underline;
 
@@ -58,11 +60,11 @@
       text-decoration: none;
     }
 
-    margin-left: 10px;
     letter-spacing: 0.5px;
+  }
 
-    &--noApplyButton {
-      margin-left: 0;
-    }
+  &-apply + &-reset {
+    padding-left: 5px;
+    margin-left: 10px;
   }
 }

--- a/src/ui/sass/modules/_Results.scss
+++ b/src/ui/sass/modules/_Results.scss
@@ -12,8 +12,6 @@ $results-title-bar-link-font-size: var(--yxt-font-size-md) !default;
 $results-title-bar-link-line-height: var(--yxt-line-height-xxlg) !default;
 $results-title-bar-link-font-weight: var(--yxt-font-weight-semibold) !default;
 
-$results-title-bar-icon-size: 18px !default;
-
 $results-filters-text-color: var(--yxt-color-text-primary) !default;
 $results-filters-text-font-size: var(--yxt-font-size-md) !default;
 $results-filters-text-line-height: var(--yxt-line-height-md) !default;
@@ -37,7 +35,6 @@ $results-cards-margin: calc(var(--yxt-base-spacing) / 2) !default;
   --yxt-results-title-bar-link-font-size: #{$results-title-bar-link-font-size};
   --yxt-results-title-bar-link-line-height: #{$results-title-bar-link-line-height};
   --yxt-results-title-bar-link-font-weight: #{$results-title-bar-link-font-weight};
-  --yxt-results-title-bar-icon-size: #{$results-title-bar-icon-size};
   --yxt-results-filters-text-color: #{$results-filters-text-color};
   --yxt-results-filters-text-font-size: #{$results-filters-text-font-size};
   --yxt-results-filters-text-line-height: #{$results-filters-text-line-height};
@@ -69,7 +66,6 @@ $results-cards-margin: calc(var(--yxt-base-spacing) / 2) !default;
   {
     display: flex;
     margin-right: calc(var(--yxt-base-spacing) / 2);
-    font-size: var(--yxt-results-title-bar-icon-size);
     color: var(--yxt-color-brand-primary);
   }
 

--- a/src/ui/sass/modules/_Results.scss
+++ b/src/ui/sass/modules/_Results.scss
@@ -2,6 +2,7 @@
 
 $results-title-bar-background: var(--yxt-color-background-highlight) !default;
 $results-filters-background: white !default;
+$results-view-more-background: var(--yxt-color-background-highlight) !default;
 
 $results-title-bar-text-color: var(--yxt-color-text-primary) !default;
 $results-title-bar-text-font-size: var(--yxt-font-size-md-lg) !default;
@@ -28,6 +29,7 @@ $results-cards-margin: calc(var(--yxt-base-spacing) / 2) !default;
 :root {
   --yxt-results-title-bar-background: #{$results-title-bar-background};
   --yxt-results-filters-background: #{$results-filters-background};
+  --yxt-results-view-more-background: #{$results-view-more-background};
   --yxt-results-title-bar-text-color: #{$results-title-bar-text-color};
   --yxt-results-title-bar-text-font-size: #{$results-title-bar-text-font-size};
   --yxt-results-title-bar-text-line-height: #{$results-title-bar-text-line-height};
@@ -144,10 +146,19 @@ $results-cards-margin: calc(var(--yxt-base-spacing) / 2) !default;
     margin-top: 0;
     margin-bottom: 0;
     padding: calc(var(--yxt-base-spacing) / 2) var(--yxt-base-spacing);
-    background-color: var(--yxt-results-filters-background);
+    background-color: var(--yxt-results-view-more-background);
     border-right: var(--yxt-results-border);
     border-left: var(--yxt-results-border);
     border-bottom: var(--yxt-results-border);
+    text-decoration: none;
+    display: flex;
+    align-items: center;
+
+    &:hover .yxt-Results-viewAllLabel,
+    &:focus .yxt-Results-viewAllLabel
+    {
+      text-decoration: underline;
+    }
   }
 
   &-viewAll svg
@@ -159,14 +170,15 @@ $results-cards-margin: calc(var(--yxt-base-spacing) / 2) !default;
 
   &-viewAllLink
   {
-    text-decoration: none;
     display: flex;
     align-items: center;
-    &:hover, &:focus 
-    {
-      color: $color-brand-hover;
-      text-decoration: underline;
-    }
+
+    @include Text(
+      var(--yxt-results-title-bar-link-font-size),
+      var(--yxt-results-title-bar-link-line-height),
+      var(--yxt-results-title-bar-link-font-weight),
+    );
+    @include Link-1;
   }
 
   &-viewAllLabel
@@ -258,19 +270,6 @@ $results-cards-margin: calc(var(--yxt-base-spacing) / 2) !default;
     );
 
     text-transform: uppercase;
-  }
-
-  &-viewAllLink
-  {
-    display: flex;
-    align-items: center;
-
-    @include Text(
-      var(--yxt-results-title-bar-link-font-size),
-      var(--yxt-results-title-bar-link-line-height),
-      var(--yxt-results-title-bar-link-font-weight),
-    );
-    @include Link-1;
   }
 
   &-titleIconWrapper

--- a/src/ui/sass/modules/_ResultsHeader.scss
+++ b/src/ui/sass/modules/_ResultsHeader.scss
@@ -32,13 +32,15 @@ $results-header-universal-background: var(--yxt-color-brand-white) !default;
   --yxt-results-header-universal-background: #{$results-header-universal-background};
 }
 
-.yxt-ResultsHeader {
+.yxt-ResultsHeader
+{
   padding: calc(var(--yxt-results-header-spacing) / 4) var(--yxt-results-header-spacing);
   padding-bottom: 0;
   display: flex;
   align-items: baseline;
 
-  &-wrapper {
+  &-wrapper
+  {
     display: flex;
     flex-wrap: wrap;
     align-items: baseline;

--- a/src/ui/templates/filters/filterbox.hbs
+++ b/src/ui/templates/filters/filterbox.hbs
@@ -21,7 +21,7 @@
         </button>
       {{/if}}
       {{~#if showReset ~}}
-        <button type="button" class="js-yxt-FilterBox-reset yxt-FilterBox-reset{{#unless showApplyButton}} yxt-FilterBox-reset--noApplyButton{{/unless}}">
+        <button type="button" class="js-yxt-FilterBox-reset yxt-FilterBox-reset">
           {{resetLabel}}
         </button>
       {{/if}}

--- a/src/ui/templates/results/directanswer.hbs
+++ b/src/ui/templates/results/directanswer.hbs
@@ -3,7 +3,7 @@
 {{else}}
   <div class="yxt-DirectAnswer">
     <div class="yxt-DirectAnswer-title">
-      <div class="yxt-Results-titleIconWrapper"
+      <div class="yxt-DirectAnswer-titleIconWrapper yxt-Results-titleIconWrapper"
           data-component="IconComponent"
           data-opts='{
               "iconName": "{{iconName}}",

--- a/src/ui/templates/results/resultsheader.hbs
+++ b/src/ui/templates/results/resultsheader.hbs
@@ -51,7 +51,11 @@
         {{/unless}}
       {{/each}}
     {{#every _config.isUniversal _config.verticalURL _config.showChangeFilters}}
-      <a class="yxt-ResultsHeader-changeFilters" href="{{ _config.verticalURL }}">
+      <a class="yxt-ResultsHeader-changeFilters" href="{{ _config.verticalURL }}"
+        data-middleclick="active"
+        data-eventtype="FILTERING_WITHIN_SECTION"
+        data-eventoptions='{{eventOptions}}'
+      >
         change filters
       </a>
     {{/every}}

--- a/src/ui/templates/results/resultsheader.hbs
+++ b/src/ui/templates/results/resultsheader.hbs
@@ -1,5 +1,5 @@
 <div class="yxt-ResultsHeader
-  {{~#if _config.isUniversal}} yxt-ResultsHeader--universal{{/if}}
+  {{~#if _config.isUniversal}} yxt-ResultsHeader--universal yxt-Results-filters{{/if}}
   {{~#if _config.removable}} yxt-ResultsHeader--removable{{/if}}">
   {{> resultscount}}
   {{#if showResultSeparator}}

--- a/src/ui/templates/results/verticalresults.hbs
+++ b/src/ui/templates/results/verticalresults.hbs
@@ -70,12 +70,10 @@
 {{/inline}}
 
 {{#*inline "viewAll"}}
-  {{#if (and _config.isUniversal _config.viewMore _config.viewMoreLabel)}}
-    <div class="yxt-Results-viewAll">
-      <a class="yxt-Results-viewAllLink" href="{{ verticalURL }}">
-        <div class="yxt-Results-viewAllLabel">{{_config.viewMoreLabel}}</div>
-        <div data-component="IconComponent" data-opts='{ "iconName": "chevron" }'></div>
-      </a>
-    </div>
+  {{#if (and _config.isUniversal _config.viewMore _config.viewMoreLabel verticalURL)}}
+    <a class="yxt-Results-viewAll yxt-Results-viewAllLink" href="{{ verticalURL }}">
+      <div class="yxt-Results-viewAllLabel">{{_config.viewMoreLabel}}</div>
+      <div data-component="IconComponent" data-opts='{ "iconName": "chevron" }'></div>
+    </a>
   {{/if}}
 {{/inline}}

--- a/src/ui/templates/results/verticalresults.hbs
+++ b/src/ui/templates/results/verticalresults.hbs
@@ -71,7 +71,11 @@
 
 {{#*inline "viewAll"}}
   {{#if (and _config.isUniversal _config.viewMore _config.viewMoreLabel verticalURL)}}
-    <a class="yxt-Results-viewAll yxt-Results-viewAllLink" href="{{ verticalURL }}">
+    <a class="yxt-Results-viewAll yxt-Results-viewAllLink" href="{{ verticalURL }}"
+      data-middleclick="active"
+      data-eventtype="VERTICAL_VIEW_ALL"
+      data-eventoptions='{{eventOptions}}'
+    >
       <div class="yxt-Results-viewAllLabel">{{_config.viewMoreLabel}}</div>
       <div data-component="IconComponent" data-opts='{ "iconName": "chevron" }'></div>
     </a>

--- a/tests/ui/components/filters/daterangecomponent.js
+++ b/tests/ui/components/filters/daterangecomponent.js
@@ -15,7 +15,7 @@ describe('date range filter component', () => {
     lessThan: max => `Before ${max}`,
     lessThanEqual: max => `${max} and earlier`,
     exclusiveRange: (min, max) => `${min} - ${max}`,
-    inclusiveRange: (min, max) => `Between ${min} and ${max}`
+    inclusiveRange: (min, max) => `${min} - ${max}`
   };
 
   beforeEach(() => {

--- a/tests/ui/components/filters/filtersearchcomponent.js
+++ b/tests/ui/components/filters/filtersearchcomponent.js
@@ -21,7 +21,7 @@ describe('FilterSearch', () => {
       filter: filter,
       metadata: {
         fieldName: title,
-        displayValue: `"${query}"`
+        displayValue: `${query}`
       }
     });
     expect(filterNode.filter).toEqual(expectedFilterNode.filter);

--- a/tests/ui/components/filters/geolocationcomponent.js
+++ b/tests/ui/components/filters/geolocationcomponent.js
@@ -32,7 +32,7 @@ describe('GeoLocationFilter', () => {
       filter: Filter.fromResponse(filter),
       metadata: {
         fieldName: title,
-        displayValue: `"${query}"`
+        displayValue: `${query}`
       }
     });
     expect(filterNode.filter).toEqual(expectedFilterNode.filter);

--- a/tests/ui/components/results/verticalresultscomponent.js
+++ b/tests/ui/components/results/verticalresultscomponent.js
@@ -107,4 +107,55 @@ describe('vertical results component', () => {
     expect(resultsCountSeparator).toEqual('');
     expect(showAppliedFilters).toBeNull();
   });
+
+  describe('creates verticalURL correctly', () => {
+    let component;
+    delete global.window.location;
+    global.window = Object.create(window);
+    global.window.location = {
+      search: '?query=virginia&otherParam=123'
+    };
+
+    beforeEach(() => {
+      component = COMPONENT_MANAGER.create('VerticalResults', {});
+      component.query = 'my-query';
+      component.verticalKey = 'key';
+    });
+
+    it('if unset defaults to vertical key', () => {
+      expect(component.getVerticalURL()).toEqual('key.html?query=my-query&otherParam=123');
+    });
+
+    it('if null defaults to vertical key', () => {
+      component = COMPONENT_MANAGER.create('VerticalResults', {
+        verticalURL: null
+      });
+      component.query = 'my-query';
+      component.verticalKey = 'key';
+      expect(component.getVerticalURL()).toEqual('key.html?query=my-query&otherParam=123');
+    });
+
+    it('works with transformData', () => {
+      expect(component.getVerticalURL({
+        verticalURL: 'transform-data'
+      })).toEqual('transform-data?query=my-query&otherParam=123');
+    });
+
+    it('defaults to matching config in verticalPages', () => {
+      component._verticalsConfig = [{
+        verticalKey: 'key',
+        url: 'vertical-pages'
+      }];
+      expect(component.getVerticalURL()).toEqual('vertical-pages?query=my-query&otherParam=123');
+    });
+
+    it('can be set', () => {
+      component = COMPONENT_MANAGER.create('VerticalResults', {
+        verticalURL: 'vertical-url'
+      });
+      component.query = 'my-query';
+      component.verticalKey = 'key';
+      expect(component.getVerticalURL()).toEqual('vertical-url?query=my-query&otherParam=123');
+    });
+  });
 });


### PR DESCRIPTION
## QA Updates

* Readme/jsdoc fixes
* DateRangeFilter: applied filters bar display value should always use `${min} - ${max}`, instead of having different displayValues for inclusive vs exclusive ranges
* Facets: fix showExpand fieldOverride
* AppliedFilters: Remove quotes from display value for GeoLocationFilter and FilterSearch
* UniversalResults: fix `url` config option being ignored by VerticalResults
* Add backwards compatibility to styling changes to .yxt-Results-viewAll`, `.yxt-Results-filters`, by using a combination of old + new css class for updated styling. This isn't 100% backwards compatible and has no guarantee to work with layout related css, but it will work for things like color, and display: none. 
* Css for the FilterBox reset-all button when there is only the reset-all button and no apply button has been updated for better vertical alignment. The ability to only have a reset-all button, with no apply button, is net new, and should not be breaking.
* Background for .yxt-Results-viewAll has been changed from white to #fafafa following a comment from jeremy. This css class is net new, and is applied along with the older '.yxt-Results-viewAllLabel' css class.
* UniversalResult's "View More" and "Change Filters" links were missing analytics events previously present in resultssectionheader.hbs.

