### PR TITLE
VerticalResults: move filternode calculation logic outside of component

### DIFF
--- a/src/core/filters/filterregistry.js
+++ b/src/core/filters/filterregistry.js
@@ -26,6 +26,22 @@ export default class FilterRegistry {
   }
 
   /**
+   * Returns an array containing all of the filternodes stored in global storage.
+   * @returns {Array<FilterNode>}
+   */
+  getAppliedFilterNodes () {
+    const globalStorageFilterNodes = [
+      ...this.getStaticFilterNodes(),
+      ...this.getFacetFilterNodes()
+    ];
+    const locationRadiusFilterNode = this.getFilterNodeByKey(StorageKeys.LOCATION_RADIUS);
+    if (locationRadiusFilterNode) {
+      globalStorageFilterNodes.push(locationRadiusFilterNode);
+    }
+    return globalStorageFilterNodes;
+  }
+
+  /**
    * Get all of the {@link FilterNode}s for static filters.
    * @returns {Array<FilterNode>}
    */

--- a/src/core/utils/filternodeutils.js
+++ b/src/core/utils/filternodeutils.js
@@ -1,0 +1,41 @@
+import FilterNodeFactory from '../filters/filternodefactory';
+import Filter from '../models/filter';
+import FilterMetadata from '../filters/filtermetadata';
+
+/**
+ * Converts an array of {@link AppliedQueryFilter}s into equivalent {@link SimpleFilterNode}s.
+ * @param {Array<AppliedQueryFilter>} nlpFilters
+ * @returns {Array<SimpleFilterNode>}
+ */
+export function convertNlpFiltersToFilterNodes (nlpFilters) {
+  return nlpFilters.map(nlpFilter => FilterNodeFactory.from({
+    filter: Filter.from(nlpFilter.filter),
+    metadata: new FilterMetadata({
+      fieldName: nlpFilter.key,
+      displayValue: nlpFilter.value
+    })
+  }));
+}
+
+export function flattenIntoSimpleFilterNodes (filterNodes) {
+  return filterNodes.flatMap(fn => fn.getSimpleAncestors());
+}
+
+/**
+ * Returns the given array of {@link FilterNode}s,
+ * removing FilterNodes that are empty or have a field id listed as a hidden.
+ * @param {Array<FilterNode>} filterNodes
+ * @param {Array<string>} hiddenFields
+ * @returns {Array<FilterNode>}
+ */
+export function purifyFilterNodes (filterNodes, hiddenFields) {
+  return filterNodes
+    .filter(fn => {
+      const { fieldName, displayValue } = fn.getMetadata();
+      if (!fieldName || !displayValue) {
+        return false;
+      }
+      const fieldId = fn.getFilter().getFilterKey();
+      return !hiddenFields.includes(fieldId);
+    });
+}

--- a/tests/ui/components/results/verticalresultscomponent.js
+++ b/tests/ui/components/results/verticalresultscomponent.js
@@ -16,6 +16,9 @@ const mockCore = {
       }
     }
   },
+  filterRegistry: {
+    getAppliedFilterNodes: () => []
+  },
   getStaticFilterNodes: () => [],
   getFacetFilterNodes: () => [],
   getLocationRadiusFilterNode: () => null


### PR DESCRIPTION
The _convertNlpFiltersToFilterNodes, _getAppliedFilterNodes, and _processFilterNodes methods inside VerticalResults component were moved into common locations.

A future commit will move these calls inside the ResultsHeader, so that
the ResultsHeader can hook up a globalStorage listener that updates
after DYNAMIC_FILTERS is updated.

TEST=manual, auto
updated unit tests
checked that I can still select a facet, it will be removable, and clicking
  the removable tag will remove the facet and trigger a search