### PR TITLE
FilterNode: refactor getSimpleAncestors to getSimpleDescendants

### DIFF
--- a/src/core/filters/combinedfilternode.js
+++ b/src/core/filters/combinedfilternode.js
@@ -65,8 +65,8 @@ export default class CombinedFilterNode extends FilterNode {
    * Recursively get all of the leaf SimpleFilterNodes.
    * @returns {Array<SimpleFilterNode>}
    */
-  getSimpleAncestors () {
-    return this.getChildren().flatMap(fn => fn.getSimpleAncestors());
+  getSimpleDescendants () {
+    return this.getChildren().flatMap(fn => fn.getSimpleDescendants());
   }
 
   /**

--- a/src/core/filters/filternode.js
+++ b/src/core/filters/filternode.js
@@ -31,7 +31,7 @@ export default class FilterNode {
    * Recursively get all of the leaf SimpleFilterNodes.
    * @returns {Array<SimpleFilterNode>}
    */
-  getSimpleAncestors () {}
+  getSimpleDescendants () {}
 
   /**
    * Remove this FilterNode from the FilterRegistry.

--- a/src/core/filters/simplefilternode.js
+++ b/src/core/filters/simplefilternode.js
@@ -63,7 +63,7 @@ export default class SimpleFilterNode extends FilterNode {
    * Since SimpleFilterNodes have no children this just returns itself.
    * @returns {Array<SimpleFilterNode>}
    */
-  getSimpleAncestors () {
+  getSimpleDescendants () {
     return this;
   }
 

--- a/src/core/utils/filternodeutils.js
+++ b/src/core/utils/filternodeutils.js
@@ -24,7 +24,7 @@ export function convertNlpFiltersToFilterNodes (nlpFilters) {
  * @returns {Array<SimpleFilterNode>}
  */
 export function flattenFilterNodes (filterNodes) {
-  return filterNodes.flatMap(fn => fn.getSimpleAncestors());
+  return filterNodes.flatMap(fn => fn.getSimpleDescendants());
 }
 
 /**

--- a/tests/core/filters/combinedfilternode.js
+++ b/tests/core/filters/combinedfilternode.js
@@ -36,7 +36,7 @@ describe('CombinedFilterNode', () => {
       FilterNodeFactory.and(node_f0_v0, node_f0_v1),
       FilterNodeFactory.or(node_f1_v0, node_f1_v1)
     );
-    const simpleFilterNodes = combinedNode.getSimpleAncestors();
+    const simpleFilterNodes = combinedNode.getSimpleDescendants();
     expect(simpleFilterNodes).toHaveLength(4);
     expect(simpleFilterNodes).toContainEqual(node_f0_v0);
     expect(simpleFilterNodes).toContainEqual(node_f1_v0);


### PR DESCRIPTION
This method was named incorrectly. This is method is getting the children
filter nodes, which are descendants (not ancestors).

TEST=manual
test that can check facets and the remove them from the applied filters bar
check that the word `Ancestors` does not exist anywhere in the source code for the sdk