### PR TITLE
ResultsHeader: changeFiltersText config option + underline

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,8 @@ ANSWERS.addComponent('UniversalResults', {
         resultsCountSeparator: '|',
         // Whether to display the change filters link in universal results. Defaults to false.
         showChangeFilters: false,
+        // The text for the change filters link. Defaults to 'change filters'.
+        changeFiltersText: 'change filters',
         // The character that separates each field (and its associated filters) within the applied filter bar. Defaults to '|'
         delimiter: '|',
         // The aria-label given to the applied filters bar. Defaults to 'Filters applied to this search:'.

--- a/src/ui/components/results/resultsheadercomponent.js
+++ b/src/ui/components/results/resultsheadercomponent.js
@@ -12,6 +12,7 @@ const DEFAULT_CONFIG = {
   resultsCountSeparator: '|',
   verticalURL: undefined,
   showChangeFilters: false,
+  changeFiltersText: 'change filters',
   removable: false,
   delimiter: '|',
   isUniversal: false,

--- a/src/ui/components/results/resultsheadercomponent.js
+++ b/src/ui/components/results/resultsheadercomponent.js
@@ -12,7 +12,6 @@ const DEFAULT_CONFIG = {
   resultsCountSeparator: '|',
   verticalURL: undefined,
   showChangeFilters: false,
-  changeFiltersText: 'change filters',
   removable: false,
   delimiter: '|',
   isUniversal: false,

--- a/src/ui/components/results/universalresultscomponent.js
+++ b/src/ui/components/results/universalresultscomponent.js
@@ -85,6 +85,8 @@ export default class UniversalResultsComponent extends Component {
         resultsCountSeparator: defaultConfigOption(config, ['appliedFilters.resultsCountSeparator', 'resultsCountSeparator'], '|'),
         // Whether to show a 'change filters' link, linking back to verticalURL.
         showChangeFilters: defaultConfigOption(config, ['appliedFilters.showChangeFilters', 'showChangeFilters'], false),
+        // The text for the change filters link.
+        changeFiltersText: defaultConfigOption(config, ['appliedFilters.changeFiltersText', 'changeFiltersText'], 'change filters'),
         // The symbol placed between different filters with the same fieldName. e.g. Location: Virginia | New York | Miami.
         delimiter: defaultConfigOption(config, ['appliedFilters.delimiter'], '|'),
         // The aria-label given to the applied filters bar.

--- a/src/ui/components/results/universalresultscomponent.js
+++ b/src/ui/components/results/universalresultscomponent.js
@@ -86,7 +86,7 @@ export default class UniversalResultsComponent extends Component {
         // Whether to show a 'change filters' link, linking back to verticalURL.
         showChangeFilters: defaultConfigOption(config, ['appliedFilters.showChangeFilters', 'showChangeFilters'], false),
         // The text for the change filters link.
-        changeFiltersText: defaultConfigOption(config, ['appliedFilters.changeFiltersText', 'changeFiltersText'], 'change filters'),
+        changeFiltersText: defaultConfigOption(config, ['appliedFilters.changeFiltersText', 'changeFiltersText']),
         // The symbol placed between different filters with the same fieldName. e.g. Location: Virginia | New York | Miami.
         delimiter: defaultConfigOption(config, ['appliedFilters.delimiter'], '|'),
         // The aria-label given to the applied filters bar.

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -116,7 +116,7 @@ class VerticalResultsConfig {
        * The text for the change filters link.
        * @type {string}
        */
-      changeFiltersText: defaultConfigOption(config, ['appliedFilters.changeFiltersText', 'changeFiltersText'], 'change filters'),
+      changeFiltersText: defaultConfigOption(config, ['appliedFilters.changeFiltersText', 'changeFiltersText']),
 
       /**
        * The aria-label given to the applied filters bar. Defaults to 'Filters applied to this search:'.

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -113,6 +113,12 @@ class VerticalResultsConfig {
       showChangeFilters: defaultConfigOption(config, ['appliedFilters.showChangeFilters', 'showChangeFilters'], false),
 
       /**
+       * The text for the change filters link.
+       * @type {string}
+       */
+      changeFiltersText: defaultConfigOption(config, ['appliedFilters.changeFiltersText', 'changeFiltersText'], 'change filters'),
+
+      /**
        * The aria-label given to the applied filters bar. Defaults to 'Filters applied to this search:'.
        * @type {string}
        **/
@@ -199,6 +205,7 @@ export default class VerticalResultsComponent extends Component {
       resultsCountSeparator: this._config.appliedFilters.resultsCountSeparator,
       showAppliedFilters: this._config.appliedFilters.show,
       showChangeFilters: this._config.appliedFilters.showChangeFilters,
+      changeFiltersText: this._config.appliedFilters.changeFiltersText,
       showResultCount: this._config.showResultCount,
       removable: this._config.appliedFilters.removable,
       delimiter: this._config.appliedFilters.delimiter,

--- a/src/ui/sass/modules/_ResultsHeader.scss
+++ b/src/ui/sass/modules/_ResultsHeader.scss
@@ -134,7 +134,8 @@ $results-header-universal-background: var(--yxt-color-brand-white) !default;
       $color: var(--yxt-color-brand-primary)
     );
     @include Link(
-      $base-color: var(--yxt-color-brand-primary)
+      $base-color: var(--yxt-color-brand-primary),
+      $base-decoration: underline
     );
   }
 

--- a/src/ui/templates/results/resultsheader.hbs
+++ b/src/ui/templates/results/resultsheader.hbs
@@ -56,7 +56,11 @@
         data-eventtype="FILTERING_WITHIN_SECTION"
         data-eventoptions='{{eventOptions}}'
       >
-        {{_config.changeFiltersText}}
+        {{#if _config.changeFiltersText}}
+          {{_config.changeFiltersText}}
+        {{else}}
+          change filters
+        {{/if}}
       </a>
     {{/every}}
     </div>

--- a/src/ui/templates/results/resultsheader.hbs
+++ b/src/ui/templates/results/resultsheader.hbs
@@ -56,7 +56,7 @@
         data-eventtype="FILTERING_WITHIN_SECTION"
         data-eventoptions='{{eventOptions}}'
       >
-        change filters
+        {{_config.changeFiltersText}}
       </a>
     {{/every}}
     </div>


### PR DESCRIPTION
> Current: the "Change Filters" link is hardcoded, https://github.com/yext/answers/blob/master/src/ui/templates/results/resultsheader.hbs#L59
Expected:
>1) We had an (undocumented) config option, changeFiltersText, and we need to make this backwards compatible – https://github.com/yext/answers/blob/master/src/ui/templates/results/resultssectionheader.hbs#L38
>2) Need an underline by default (for wcag)

TEST=manual
check that has underline by default
test using changeFiltersText and appliedFilters.changeFiltersText can
set the change filters link text, and that
appliedFilters.changeFiltersText has higher priority