### PR TITLE
ResultsHeader: use old scss vars for titlebar

### DIFF
--- a/src/ui/sass/modules/_Results.scss
+++ b/src/ui/sass/modules/_Results.scss
@@ -198,7 +198,7 @@ $results-cards-margin: calc(var(--yxt-base-spacing) / 2) !default;
     display: flex;
     padding: calc(var(--yxt-base-spacing) / 2) var(--yxt-base-spacing);
     align-items: center;
-    background-color:  var(--yxt-color-background-highlight);
+    background-color:  var(--yxt-results-title-bar-background);
   }
 
   &-title
@@ -206,10 +206,10 @@ $results-cards-margin: calc(var(--yxt-base-spacing) / 2) !default;
     margin: 0;
     text-transform: uppercase;
     @include Text(
-      $color: var(--yxt-color-text-primary),
-      $weight: var(--yxt-font-weight-semibold),
-      $line-height: var(--yxt-line-height-lg),
-      $size: var(--yxt-font-size-md-lg),
+      var(--yxt-results-title-bar-text-font-size),
+      var(--yxt-results-title-bar-text-line-height),
+      var(--yxt-font-weight-semibold),
+      $color: var(--yxt-results-title-bar-text-color)
     );
   }
 }


### PR DESCRIPTION
Use the old scss variables for yxt-Results-titleBar where possible.
The only value that cannot use a preexisting scss variable is the
font-weight, which in the mock was changed from 700 to 600.

>"Current:
.yxt-Results-Titlebar {
background: var(--yxt-color-background-highlight)
}
.yxt-Results-title {
  color: var(--yxt-color-text-primary)
}
Expected -- use the previous variables instead, unless there was a reason we changed them (see scss from 1.3.0)
  .yxt-Results-titleBar {
    background-color: var(--yxt-results-title-bar-background);
  }
  .yxt-Results-title {
    color: var(--yxt-results-title-bar-text-color);
  }
for yxt-Results-title:
>- we just aren't targetting the scss correctly? I see it here
>- it looks like this defaults to var(--yxt-color-text-primary) so we should be good if we update"

TEST=manual
check that background-color of yxt-Results-titleBar is the same
check that yxt-Results-title has some color, font-weight, line-height,
and font-size as before.
do quick scan for other preexisting scss variables