### PR TITLE
DirectAnswer: add readme for custom DA card, fix fieldType

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,12 +469,12 @@ ANSWERS.addComponent('DirectAnswer', {
 })
 ```
 
-## Custom Direct Answer Card
+## Creating a Custom Direct Answer Card
 
-You can customize the look and behavior of your DirectAnswer, you can create a custom Direct Answer card.
+You can customize the look and behavior of your Direct Answer by creating a custom Direct Answer card.
 
-A custom Direct Answer card is given the directAnswer data from the query, the same data the built-in component
-operates on. That object will look something like the below:
+A custom Direct Answer card is given the same data as the built-in card.
+That data will look something like the below:
 
 ```js
 {
@@ -503,7 +503,8 @@ operates on. That object will look something like the below:
 }
 ```
 
-A Direct Answer custom card needs a corresponding template. This can be added either inline by changing the component's constructor to:
+A custom Direct Answer card needs a corresponding template.
+This can be added either inline by changing the component's constructor to:
 
 ```js
     constructor(config, systemConfig) {
@@ -516,13 +517,13 @@ Or by including a custom template bundle, and adding:
 
 ```js
   static defaultTemplateName () {
-    return 'CustomDirectAnswerTemplateName';
+    return 'CustomDirectAnswerTemplate';
   }
 ```
 
-Where 'YourTemplateName' is the name of the template registered onto the Handlebars renderer.
+Where 'CustomDirectAnswerTemplate' is the name the template is registered under.
 
-The example custom Direct Answer card will use the Handlebars template below.
+We will use the following template for our example card.
 
 ```hbs
   <div class="customDirectAnswer">
@@ -561,7 +562,7 @@ The example custom Direct Answer card will use the Handlebars template below.
   {{/inline}}
 ```
 
-Some css to flip the thumbs up icon the right way.
+This specific example needs some css to flip the thumbs up icon the right way.
 
 ```css
   .customDirectAnswer-thumbsUpIcon svg {
@@ -569,57 +570,23 @@ Some css to flip the thumbs up icon the right way.
   }
 ```
 
-This is an example of a possible custom Direct Answer card. It has custom rendering that depends on
-the fieldType of the directAnswer, as well as a custom analytics event.
+This is the javascript class for our custom Direct Answer card.
+It applies custom formatting to the Direct Answer, registers analytics events
+to the thumbs up/down icons, and passes custom event options into the template.
 
 ```js
-  class CustomDirectAnswerClassName extends ANSWERS.Component {
+  class CustomDirectAnswerClass extends ANSWERS.Component {
     constructor(config, systemConfig) {
       // If you need to override the constructor, make sure to call super(config, systemConfig) first.
       super(config, systemConfig);
 
-      // For simplicity's sake, this custom Direct Answer card sets the template using setTemplate(), as opposed to
+      // For simplicity's sake, we set this card's template using setTemplate(), as opposed to
       // a custom template bundle.
-      this.setTemplate(`
-        <div class="customDirectAnswer">
-          <div class="customDirectAnswer-type">
-            {{type}}
-          </div>
-          <div class="customDirectAnswer-value">
-            {{#each customValue}}
-            {{#if url}}
-              {{> valueLink }}
-            {{else}}
-              {{{this}}}
-            {{/if}}
-            {{/each}}
-          </div>
-          {{> feedback}}
-        </div>
-
-        {{#*inline 'feedback'}}
-        <span class="customDirectAnswer-thumbsUpIcon js-customDirectAnswer-thumbsUpIcon"
-          data-component="IconComponent"
-          data-opts='{"iconName": "thumb"}'
-        ></span>
-        <span class="customDirectAnswer-thumbsDownIcon js-customDirectAnswer-thumbsDownIcon"
-          data-component="IconComponent"
-          data-opts='{"iconName": "thumb"}'
-        ></span>
-        {{/inline}}
-
-        {{#*inline 'valueLink'}}
-        <a class="customDirectAnswer-fieldValueLink" href="{{{url}}}"
-          {{#if @root/eventType}}data-eventtype="{{@root/eventType}}"{{/if}}
-          {{#if @root/eventOptions}}data-eventoptions='{{{ json @root/eventOptions }}}'{{/if}}>
-          {{{displayText}}}
-        </a>
-        {{/inline}}
-      `);
+      this.setTemplate(`<div> your template here </div>`)
     }
 
     /**
-     * The setState method allows you to pass variables directly into your template.
+     * setState() lets you pass variables directly into your template.
      * Here, data is the directAnswer data from the query.
      * Below, we pass through a custom direct answers value, customValue.
      * @param {Object} data
@@ -653,7 +620,7 @@ the fieldType of the directAnswer, as well as a custom analytics event.
     }
 
     /**
-     * reportQuality will send the quality feedback to analytics
+     * reportQuality() sends an analytics event (either THUMBS_UP or THUMBS_DOWN).
      * @param {boolean} isGood true if the answer is what you were looking for
      */
     reportQuality(isGood) {
@@ -665,7 +632,7 @@ the fieldType of the directAnswer, as well as a custom analytics event.
     }
 
     /**
-     * Formats a directAnswer answer based on its fieldType.
+     * Formats a Direct Answer value based on its fieldType.
      * @param {Object} answer the answer property in the directAnswer model
      * @returns {string}
      */ 
@@ -687,7 +654,7 @@ the fieldType of the directAnswer, as well as a custom analytics event.
     }
 
     /**
-     * Computes a custom direct answer. If answer.value is an array, this method
+     * Computes a custom Direct Answer. If answer.value is an array, this method
      * formats every value in the array and returns it, otherwise it just formats the single
      * given value.
      * @param {Object} answer
@@ -712,7 +679,7 @@ the fieldType of the directAnswer, as well as a custom analytics event.
   }
 
   // Don't forget to register your Direct Answer card within the SDK. Otherwise the SDK won't recognize your card name!
-  ANSWERS.registerComponentType(CustomDirectAnswerClassName);
+  ANSWERS.registerComponentType(CustomDirectAnswerClass);
 ```
 
 ## Universal Results Component

--- a/README.md
+++ b/README.md
@@ -433,6 +433,7 @@ ANSWERS.addComponent('DirectAnswer', {
   // Required, the selector for the container element where the component will be injected
   container: '.direct-answer-container',
   // Optional, a custom direct answer card to use, which is the default when there are no matching card overrides.
+  // See the Custom Direct Answer Card section below.
   defaultCard: 'MyDefaultDirectAnswer',
   // Optional, the selector for the form used for submitting the feedback
   formEl: '.js-directAnswer-feedback-form',
@@ -466,6 +467,72 @@ ANSWERS.addComponent('DirectAnswer', {
     }
   ]
 })
+```
+
+## Custom Direct Answer Card
+
+```js
+  class MyClassName extends ANSWERS.Component {
+    constructor(config = {}, systemConfig = {}) {
+      super(config, systemConfig);
+
+      // Add your Handlebars template here.
+      this.setTemplate(`
+        <div class="myDirectAnswer">
+          My Direct Answer Custom Template
+          <div class="myDirectAnswer-type">
+            {{type}}
+          </div>
+          <div class="myDirectAnswer-value">
+            {{directAnswerPrefix}}
+            {{answer.value}}
+          </div>
+        </div>
+      `)
+    }
+
+    /**
+     * Here, data is the directAnswer data from the query. You can expect an object that looks something
+     * like.
+     * {
+     *   type: "FIELD_VALUE",
+     *   answer: {
+     *     entityName: "Entity Name",
+     *     fieldName: "Phone Number",
+     *     fieldApiName: "mainPhone",
+     *     value: "+11234567890",
+     *     fieldType: "phone" 
+     *   },
+     *   relatedItem: { 
+     *     verticalConfigId: 'people',
+     *     data: { ... }
+     *   }
+     * }
+     * The variables returned by setState can be used directly in your template.
+     * Below, we pass through a custom variable called directAnswerPrefix, in addition to the direct answer
+     * data, which can be acecssed in the template with {{directAnswerPrefix}}.
+     * @param {Object} data
+     * @returns {Object}
+     */ 
+    setState(data) {
+      return super.setState({
+        ...data,
+        directAnswerPrefix: data.answer.fieldApiName === 'mainPhone' ? 'Please Call: ' : 'Your Answer: '
+      });
+    }
+
+    /**
+     * The name of your custom direct answer card. This is the value you will use in any config when
+     * specifying this card.
+     * @returns {string}
+     */
+    static get type() {
+      return 'MyCustomDirectAnswerCard';
+    }
+  }
+
+  // Register your component class within the SDK. This is necessary for the SDK to recognize your custom card.
+  ANSWERS.registerComponentType(MyClassName);
 ```
 
 ## Universal Results Component

--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ ANSWERS.addComponent('DirectAnswer', {
   container: '.direct-answer-container',
   // Optional, a custom direct answer card to use, which is the default when there are no matching card overrides.
   // See the Custom Direct Answer Card section below.
-  defaultCard: 'MyDefaultDirectAnswer',
+  defaultCard: 'MyCustomDirectAnswerCard',
   // Optional, the selector for the form used for submitting the feedback
   formEl: '.js-directAnswer-feedback-form',
   // Optional, the selector to bind ui interaction to for reporting
@@ -471,9 +471,10 @@ ANSWERS.addComponent('DirectAnswer', {
 
 ## Custom Direct Answer Card
 
-If you need the full power of an SDK component, you can specificy a custom Direct Answers card.
-This component will be given the directAnswer data from the query, the same data the built-in component
-operates on. You can expect that object to look something like the below:
+You can customize the look and behavior of your DirectAnswer, you can create a custom Direct Answer card.
+
+A custom Direct Answer card is given the directAnswer data from the query, the same data the built-in component
+operates on. That object will look something like the below:
 
 ```js
 {
@@ -487,12 +488,23 @@ operates on. You can expect that object to look something like the below:
   },
   relatedItem: { 
     verticalConfigId: 'people',
-    data: { ... }
+    data: { 
+      id: "Employee-2116",
+      type: "ce_person",
+      fieldValues: {
+        description: "This is the description field.",
+        name: "First Last",
+        firstName: "First",
+        lastName: "Last",
+        mainPhone: "+1234567890",
+      }
+    }
   }
 }
 ```
 
-An SDK component needs a corresponding template. This can be added either inline by changing the constructor to
+A Direct Answer custom card needs a corresponding template. This can be added either inline by changing the component's constructor to:
+
 ```js
     constructor(config, systemConfig) {
       super(config, systemConfig);
@@ -500,7 +512,7 @@ An SDK component needs a corresponding template. This can be added either inline
     }
 ```
 
-Or by including a custom template bundle, and adding
+Or by including a custom template bundle, and adding:
 
 ```js
   static defaultTemplateName () {
@@ -510,7 +522,7 @@ Or by including a custom template bundle, and adding
 
 Where 'YourTemplateName' is the name of the template registered onto the Handlebars renderer.
 
-The example component will use the Handlebars template below.
+The example custom Direct Answer card will use the Handlebars template below.
 
 ```hbs
   <div class="customDirectAnswer">
@@ -537,11 +549,11 @@ The example component will use the Handlebars template below.
   {{/inline}}
 ```
 
-This is an example of a possible custom DirectAnswers card. It has custom rendering that depends on
+This is an example of a possible custom Direct Answer card. It has custom rendering that depends on
 the fieldType of the directAnswer, as well as a a custom analytics event.
 
 ```js
-  class MyClassName extends ANSWERS.Component {
+  class CustomDirectAnswerClassName extends ANSWERS.Component {
     constructor(config, systemConfig) {
       // If you need to override the constructor, make sure to call super(config, systemConfig) first.
       super(config, systemConfig);
@@ -608,8 +620,8 @@ the fieldType of the directAnswer, as well as a a custom analytics event.
     }
 
     /**
-     * The name of your custom direct answer card. This is the value you will use in any config when
-     * specifying this card.
+     * The name of your custom direct answer card. THIS is the value you will use in any config,
+     * such as defaultCard, when you want to specify this custom Direct Answer card.
      * @returns {string}
      */
     static get type() {
@@ -617,8 +629,8 @@ the fieldType of the directAnswer, as well as a a custom analytics event.
     }
   }
 
-  // Don't forget to register your component class within the SDK. Otherwise the SDK won't recognize your custom card!
-  ANSWERS.registerComponentType(MyClassName);
+  // Don't forget to register your Direct Answer card within the SDK. Otherwise the SDK won't recognize your card name!
+  ANSWERS.registerComponentType(CustomDirectAnswerClassName);
 ```
 
 ## Universal Results Component

--- a/README.md
+++ b/README.md
@@ -516,7 +516,7 @@ Or by including a custom template bundle, and adding:
 
 ```js
   static defaultTemplateName () {
-    return 'YourTemplateName';
+    return 'CustomDirectAnswerTemplateName';
   }
 ```
 
@@ -531,25 +531,25 @@ The example custom Direct Answer card will use the Handlebars template below.
     </div>
     <div class="customDirectAnswer-value">
       {{#each customValue}}
-        {{#if url}}
-          {{> valueLink }}
-        {{else}}
-          {{{this}}}
-        {{/if}}
+      {{#if url}}
+        {{> valueLink }}
+      {{else}}
+        {{{this}}}
+      {{/if}}
       {{/each}}
     </div>
     {{> feedback}}
   </div>
 
   {{#*inline 'feedback'}}
-    <span class="customDirectAnswer-thumbsUpIcon js-customDirectAnswer-thumbsUpIcon"
-      data-component="IconComponent"
-      data-opts='{"iconName": "thumb"}'
-    ></span>
-    <span class="customDirectAnswer-thumbsDownIcon js-customDirectAnswer-thumbsDownIcon"
-      data-component="IconComponent"
-      data-opts='{"iconName": "thumb"}'
-    ></span>
+  <span class="customDirectAnswer-thumbsUpIcon js-customDirectAnswer-thumbsUpIcon"
+    data-component="IconComponent"
+    data-opts='{"iconName": "thumb"}'
+  ></span>
+  <span class="customDirectAnswer-thumbsDownIcon js-customDirectAnswer-thumbsDownIcon"
+    data-component="IconComponent"
+    data-opts='{"iconName": "thumb"}'
+  ></span>
   {{/inline}}
 
   {{#*inline 'valueLink'}}
@@ -577,6 +577,45 @@ the fieldType of the directAnswer, as well as a custom analytics event.
     constructor(config, systemConfig) {
       // If you need to override the constructor, make sure to call super(config, systemConfig) first.
       super(config, systemConfig);
+
+      // For simplicity's sake, this custom Direct Answer card sets the template using setTemplate(), as opposed to
+      // a custom template bundle.
+      this.setTemplate(`
+        <div class="customDirectAnswer">
+          <div class="customDirectAnswer-type">
+            {{type}}
+          </div>
+          <div class="customDirectAnswer-value">
+            {{#each customValue}}
+            {{#if url}}
+              {{> valueLink }}
+            {{else}}
+              {{{this}}}
+            {{/if}}
+            {{/each}}
+          </div>
+          {{> feedback}}
+        </div>
+
+        {{#*inline 'feedback'}}
+        <span class="customDirectAnswer-thumbsUpIcon js-customDirectAnswer-thumbsUpIcon"
+          data-component="IconComponent"
+          data-opts='{"iconName": "thumb"}'
+        ></span>
+        <span class="customDirectAnswer-thumbsDownIcon js-customDirectAnswer-thumbsDownIcon"
+          data-component="IconComponent"
+          data-opts='{"iconName": "thumb"}'
+        ></span>
+        {{/inline}}
+
+        {{#*inline 'valueLink'}}
+        <a class="customDirectAnswer-fieldValueLink" href="{{{url}}}"
+          {{#if @root/eventType}}data-eventtype="{{@root/eventType}}"{{/if}}
+          {{#if @root/eventOptions}}data-eventoptions='{{{ json @root/eventOptions }}}'{{/if}}>
+          {{{displayText}}}
+        </a>
+        {{/inline}}
+      `);
     }
 
     /**
@@ -595,7 +634,7 @@ the fieldType of the directAnswer, as well as a custom analytics event.
         customValue: this.getCustomValue(answer),
         eventType: 'CUSTOM_EVENT',
         eventOptions: {
-          searcher: "UNIVERSAL",
+          searcher: 'UNIVERSAL',
           verticalConfigId: this.verticalConfigId,
           entityId: this.associatedEntityId,
         }
@@ -633,15 +672,15 @@ the fieldType of the directAnswer, as well as a custom analytics event.
     formatValue(answer) {
       const { fieldType, value } = answer;
       switch (fieldType) {
-        case "phone":
+        case 'phone':
           return {
               url: 'http://myCustomWebsite.com/?mainPhone=' + value,
               displayText: value,
             };
-        case "rich_text":
+        case 'rich_text':
           return ANSWERS.formatRichText(value);
-        case "single_line_text":
-        case "multi_line_text":
+        case 'single_line_text':
+        case 'multi_line_text':
         default:
           return value;
       }

--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ ANSWERS.addComponent('DirectAnswer', {
 
     /**
      * Here, data is the directAnswer data from the query. You can expect an object that looks something
-     * like.
+     * like:
      * {
      *   type: "FIELD_VALUE",
      *   answer: {

--- a/README.md
+++ b/README.md
@@ -518,26 +518,27 @@ The example component will use the Handlebars template below.
       {{type}}
     </div>
     <div class="customDirectAnswer-value">
-      {{#if customValue.url}}
-        {{> valueLink }}
-      {{else}}
-        {{{customValue}}}
-      {{/if}}
+      {{#each customValue}}
+        {{#if url}}
+          {{> valueLink }}
+        {{else}}
+          {{{this}}}
+        {{/if}}
+      {{/each}}
     </div>
   </div>
 
   {{#*inline 'valueLink'}}
-  <a class="customDirectAnswer-fieldValueLink"
-    href="{{{customValue.url}}}"
-    {{#if eventType}}data-eventtype="{{eventType}}"{{/if}}
-    {{#if eventOptions}}data-eventoptions='{{{ json eventOptions }}}'{{/if}}>
-    {{{customValue.displayText}}}
+  <a class="customDirectAnswer-fieldValueLink" href="{{{url}}}"
+    {{#if @root/eventType}}data-eventtype="{{@root/eventType}}"{{/if}}
+    {{#if @root/eventOptions}}data-eventoptions='{{{ json @root/eventOptions }}}'{{/if}}>
+    {{{displayText}}}
   </a>
   {{/inline}}
 ```
 
-This is an example of a possible custom DirectAnswers card. It has custom rendering, depending on
-the fieldType of the directAnswer, as well as custom analytics event logic.
+This is an example of a possible custom DirectAnswers card. It has custom rendering that depends on
+the fieldType of the directAnswer, as well as a a custom analytics event.
 
 ```js
   class MyClassName extends ANSWERS.Component {
@@ -596,13 +597,13 @@ the fieldType of the directAnswer, as well as custom analytics event logic.
      * formats every value in the array and returns it, otherwise it just formats the single
      * given value.
      * @param {Object} answer
-     * @returns {string}
+     * @returns {Array<string>}
      */ 
     getCustomValue(answer) {
       if (Array.isArray(answer.value)) {
         return answer.value.map(value => this.formatValue(answer))
       } else {
-        return this.formatValue(answer);
+        return [ this.formatValue(answer) ];
       }
     }
 

--- a/README.md
+++ b/README.md
@@ -538,7 +538,19 @@ The example custom Direct Answer card will use the Handlebars template below.
         {{/if}}
       {{/each}}
     </div>
+    {{> feedback}}
   </div>
+
+	{{#*inline 'feedback'}}
+		<span class="customDirectAnswer-thumbsUpIcon js-customDirectAnswer-thumbsUpIcon"
+				data-component="IconComponent"
+				data-opts='{"iconName": "thumb"}'
+		></span>
+		<span class="customDirectAnswer-thumbsDownIcon js-customDirectAnswer-thumbsDownIcon"
+				data-component="IconComponent"
+				data-opts='{"iconName": "thumb"}'
+		></span>
+  {{/inline}}
 
   {{#*inline 'valueLink'}}
   <a class="customDirectAnswer-fieldValueLink" href="{{{url}}}"
@@ -549,8 +561,16 @@ The example custom Direct Answer card will use the Handlebars template below.
   {{/inline}}
 ```
 
+Some css to flip the thumbs up icon the right way.
+
+```css
+  .customDirectAnswer-thumbsUpIcon svg {
+    transform: rotate(180deg);
+  }
+```
+
 This is an example of a possible custom Direct Answer card. It has custom rendering that depends on
-the fieldType of the directAnswer, as well as a a custom analytics event.
+the fieldType of the directAnswer, as well as a custom analytics event.
 
 ```js
   class CustomDirectAnswerClassName extends ANSWERS.Component {
@@ -580,6 +600,29 @@ the fieldType of the directAnswer, as well as a a custom analytics event.
           entityId: this.associatedEntityId,
         }
       });
+    }
+
+    /**
+     * onMount() lets you register event listeners. Here, we register the thumbs up and thumbs
+     * down buttons to fire an analytics event on click.
+     */ 
+    onMount() {
+      const thumbsUpIcon = this._container.querySelector('.js-customDirectAnswer-thumbsUpIcon');
+      const thumbsDownIcon = this._container.querySelector('.js-customDirectAnswer-thumbsDownIcon');
+      thumbsUpIcon.addEventListener('click', () => this.reportQuality(true));
+      thumbsDownIcon.addEventListener('click', () => this.reportQuality(false));
+    }
+
+    /**
+     * reportQuality will send the quality feedback to analytics
+     * @param {boolean} isGood true if the answer is what you were looking for
+     */
+    reportQuality(isGood) {
+      const eventType = isGood === true ? 'THUMBS_UP' : 'THUMBS_DOWN';
+      const event = new ANSWERS.AnalyticsEvent(eventType).addOptions({
+        directAnswer: true
+      });
+      this.analyticsReporter.report(event);
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -594,16 +594,16 @@ to the thumbs up/down icons, and passes custom event options into the template.
      */ 
     setState(data) {
       const { type, answer, relatedItem } = data;
-      this.associatedEntityId = data.relatedItem && data.relatedItem.data && data.relatedItem.data.id;
-      this.verticalConfigId = data.relatedItem && data.relatedItem.verticalConfigId;
+      const associatedEntityId = data.relatedItem && data.relatedItem.data && data.relatedItem.data.id;
+      const verticalConfigId = data.relatedItem && data.relatedItem.verticalConfigId;
       return super.setState({
         ...data,
         customValue: this.getCustomValue(answer),
         eventType: 'CUSTOM_EVENT',
         eventOptions: {
           searcher: 'UNIVERSAL',
-          verticalConfigId: this.verticalConfigId,
-          entityId: this.associatedEntityId,
+          verticalConfigId: verticalConfigId,
+          entityId: associatedEntityId,
         }
       });
     }

--- a/README.md
+++ b/README.md
@@ -541,15 +541,15 @@ The example custom Direct Answer card will use the Handlebars template below.
     {{> feedback}}
   </div>
 
-	{{#*inline 'feedback'}}
-		<span class="customDirectAnswer-thumbsUpIcon js-customDirectAnswer-thumbsUpIcon"
-				data-component="IconComponent"
-				data-opts='{"iconName": "thumb"}'
-		></span>
-		<span class="customDirectAnswer-thumbsDownIcon js-customDirectAnswer-thumbsDownIcon"
-				data-component="IconComponent"
-				data-opts='{"iconName": "thumb"}'
-		></span>
+  {{#*inline 'feedback'}}
+    <span class="customDirectAnswer-thumbsUpIcon js-customDirectAnswer-thumbsUpIcon"
+      data-component="IconComponent"
+      data-opts='{"iconName": "thumb"}'
+    ></span>
+    <span class="customDirectAnswer-thumbsDownIcon js-customDirectAnswer-thumbsDownIcon"
+      data-component="IconComponent"
+      data-opts='{"iconName": "thumb"}'
+    ></span>
   {{/inline}}
 
   {{#*inline 'valueLink'}}

--- a/src/ui/components/results/directanswercomponent.js
+++ b/src/ui/components/results/directanswercomponent.js
@@ -111,7 +111,7 @@ export default class DirectAnswerComponent extends Component {
     const directAnswerPropeties = {
       entityType: directAnswer.relatedItem.data.type,
       fieldName: directAnswer.answer.fieldName,
-      fieldType: directAnswer.fieldType
+      fieldType: directAnswer.answer.fieldType
     };
     for (let [propertyToMatch, propertyValue] of Object.entries(override)) {
       if (propertyToMatch === 'cardType') {


### PR DESCRIPTION
This commit adds a readme section for how to add a custom DA
card to the SDK. It also fixes the way fieldType is accessed when
calculating which cardOverride to use. One out of the 2 places
it is mentioned in the SDK spec is wrong and I only read the incorrect
one, and fieldType was not part of the query responses  at the time this
code was originally written.

J=SPR-2451
TEST=manual
test that I can specify a cardOverride for fieldType: 'phone',
that will be applied to 'amani farooque phone' but not
'amani farooque employee department'
test that custom card used in readme works