### PR TITLE
Readme: update radius: 0 readme explanation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1175,6 +1175,7 @@ ANSWERS.addComponent('FilterOptions', {
 ```
 
 The options config varies depending on whether the optionType is 'STATIC_FILTER' or 'RADIUS_FILTER'.
+A STATIC_FILTER allows you to filter on a custom specified field, while a RADIUS_FILTER will add separate `locationRadius` parameter to your request, set to the currently selected value.
 
 ##### STATIC_FILTER
 
@@ -1213,7 +1214,7 @@ The options config varies depending on whether the optionType is 'STATIC_FILTER'
 {    
   options: [
     {
-      // Required, the value of the radius to apply (in meters). If this value is 0, will not filter by radius.
+      // Required, the value of the radius to apply (in meters). If this value is 0, no explicit locationRadius parameter will be applied to the request.
       value: 8046.72,
       // Optional, the label to show next to the filter option.
       label: '5 miles',

--- a/README.md
+++ b/README.md
@@ -1215,7 +1215,7 @@ results based on their distance from the user.
 {    
   options: [
     {
-      // Required, the value of the radius to apply (in meters). If this value is 0, the SDK will not add explicit radius filtering to the request.
+      // Required, the value of the radius to apply (in meters). If this value is 0, the SDK will not add explicit radius filtering to the request. The backend may still perform its own filtering depending on the query given.
       value: 8046.72,
       // Optional, the label to show next to the filter option.
       label: '5 miles',

--- a/README.md
+++ b/README.md
@@ -1175,7 +1175,8 @@ ANSWERS.addComponent('FilterOptions', {
 ```
 
 The options config varies depending on whether the optionType is 'STATIC_FILTER' or 'RADIUS_FILTER'.
-A STATIC_FILTER allows you to filter on a custom specified field, while a RADIUS_FILTER will add separate `locationRadius` parameter to your request, set to the currently selected value.
+A STATIC_FILTER allows you to filter on a specified field, while a RADIUS_FILTER allows you to filter
+results based on their distance from the user.
 
 ##### STATIC_FILTER
 
@@ -1214,7 +1215,7 @@ A STATIC_FILTER allows you to filter on a custom specified field, while a RADIUS
 {    
   options: [
     {
-      // Required, the value of the radius to apply (in meters). If this value is 0, no explicit locationRadius parameter will be applied to the request.
+      // Required, the value of the radius to apply (in meters). If this value is 0, the SDK will not add explicit radius filtering to the request.
       value: 8046.72,
       // Optional, the label to show next to the filter option.
       label: '5 miles',


### PR DESCRIPTION
Addresses https://github.com/yext/answers/issues/915.
The readme was not being entirely truthful with what happens
When a radius filter has a value of 0 selected.
In this case no locationRadius param is passed to the backend,
but the backend is still free to do whatever custom thing they want.

TEST=none