### PR TITLE
Add activeMobile and activeDesktop classes to style pagination background color

### DIFF
--- a/src/ui/components/results/paginationcomponent.js
+++ b/src/ui/components/results/paginationcomponent.js
@@ -255,15 +255,6 @@ export default class PaginationComponent extends Component {
         if (this._maxVisiblePagesMobile > 1) {
           num.activeMobile = true;
         }
-        // if (this._maxVisiblePagesDesktop === 1 && this._maxVisiblePagesMobile === 1) {
-        //   num.onePageAll = true;
-        // } else if (this._maxVisiblePagesMobile === 1) {
-        //   num.activeDesktop = true;
-        // } else if (this._maxVisiblePagesDesktop === 1) {
-        //   num.activeMobile = true;
-        // } else {
-        //   num.activeAll = true;
-        // }
       } else {
         if (i <= mobileBackLimit || i > mobileFrontLimit) {
           num.mobileHidden = true;

--- a/src/ui/components/results/paginationcomponent.js
+++ b/src/ui/components/results/paginationcomponent.js
@@ -249,10 +249,10 @@ export default class PaginationComponent extends Component {
       const num = { number: i };
       if (i === pageNumber) {
         num.active = true;
-        if (this._maxVisiblePagesMobile == 1) {
+        if (this._maxVisiblePagesMobile === 1) {
           num.onePageMobile = '-onepage-mobile';
         }
-        if (this._maxVisiblePagesDesktop == 1) {
+        if (this._maxVisiblePagesDesktop === 1) {
           num.onePageDesktop = '-onepage-desktop';
         }
       } else {

--- a/src/ui/components/results/paginationcomponent.js
+++ b/src/ui/components/results/paginationcomponent.js
@@ -249,6 +249,12 @@ export default class PaginationComponent extends Component {
       const num = { number: i };
       if (i === pageNumber) {
         num.active = true;
+        if (this._maxVisiblePagesMobile == 1) {
+          num.onePageMobile = '-onepage-mobile';
+        }
+        if (this._maxVisiblePagesDesktop == 1) {
+          num.onePageDesktop = '-onepage-desktop';
+        }
       } else {
         if (i <= mobileBackLimit || i > mobileFrontLimit) {
           num.mobileHidden = true;

--- a/src/ui/components/results/paginationcomponent.js
+++ b/src/ui/components/results/paginationcomponent.js
@@ -249,15 +249,21 @@ export default class PaginationComponent extends Component {
       const num = { number: i };
       if (i === pageNumber) {
         num.active = true;
-        if (this._maxVisiblePagesDesktop === 1 && this._maxVisiblePagesMobile === 1) {
-          num.onePageAll = true;
-        } else if (this._maxVisiblePagesMobile === 1) {
+        if (this._maxVisiblePagesDesktop > 1) {
           num.activeDesktop = true;
-        } else if (this._maxVisiblePagesDesktop === 1) {
-          num.activeMobile = true;
-        } else {
-          num.activeAll = true;
         }
+        if (this._maxVisiblePagesMobile > 1) {
+          num.activeMobile = true;
+        }
+        // if (this._maxVisiblePagesDesktop === 1 && this._maxVisiblePagesMobile === 1) {
+        //   num.onePageAll = true;
+        // } else if (this._maxVisiblePagesMobile === 1) {
+        //   num.activeDesktop = true;
+        // } else if (this._maxVisiblePagesDesktop === 1) {
+        //   num.activeMobile = true;
+        // } else {
+        //   num.activeAll = true;
+        // }
       } else {
         if (i <= mobileBackLimit || i > mobileFrontLimit) {
           num.mobileHidden = true;

--- a/src/ui/components/results/paginationcomponent.js
+++ b/src/ui/components/results/paginationcomponent.js
@@ -249,11 +249,14 @@ export default class PaginationComponent extends Component {
       const num = { number: i };
       if (i === pageNumber) {
         num.active = true;
-        if (this._maxVisiblePagesMobile === 1) {
-          num.onePageMobile = '-onepage-mobile';
-        }
-        if (this._maxVisiblePagesDesktop === 1) {
-          num.onePageDesktop = '-onepage-desktop';
+        if (this._maxVisiblePagesDesktop === 1 && this._maxVisiblePagesMobile === 1) {
+          num.onePageAll = true;
+        } else if (this._maxVisiblePagesMobile === 1) {
+          num.activeDesktop = true;
+        } else if (this._maxVisiblePagesDesktop === 1) {
+          num.activeMobile = true;
+        } else {
+          num.activeAll = true;
         }
       } else {
         if (i <= mobileBackLimit || i > mobileFrontLimit) {

--- a/src/ui/sass/modules/_Pagination.scss
+++ b/src/ui/sass/modules/_Pagination.scss
@@ -55,25 +55,25 @@ $pagination-color-hover: var(--yxt-color-text-secondary) !default;
     }
   }
 
-  #active-page {
+  &-active {
     background-color: var(--yxt-pagination-color-active-page);
   }
 
-  #active-page-onepage-desktop {
+  &-active-onepage-desktop {
     background-color: inherit;
     @media (max-width: $breakpoint-mobile-max) {
       background-color: var(--yxt-pagination-color-active-page);
     }
   }
 
-  #active-page-onepage-mobile {
+  &-active-onepage-mobile {
     background-color: var(--yxt-pagination-color-active-page);
     @media (max-width: $breakpoint-mobile-max) {
       background-color: inherit;
     }
   }
 
-  #active-page-onepage-desktop-onepage-mobile {
+  &-active-onepage-mobile-onepage-desktop {
     background-color: inherit;
   }
 

--- a/src/ui/sass/modules/_Pagination.scss
+++ b/src/ui/sass/modules/_Pagination.scss
@@ -59,6 +59,24 @@ $pagination-color-hover: var(--yxt-color-text-secondary) !default;
     background-color: var(--yxt-pagination-color-active-page);
   }
 
+  #active-page-onepage-desktop {
+    background-color: inherit;
+    @media (max-width: $breakpoint-mobile-max) {
+      background-color: var(--yxt-pagination-color-active-page);
+    }
+  }
+
+  #active-page-onepage-mobile {
+    background-color: var(--yxt-pagination-color-active-page);
+    @media (max-width: $breakpoint-mobile-max) {
+      background-color: inherit;
+    }
+  }
+
+  #active-page-onepage-desktop-onepage-mobile {
+    background-color: inherit;
+  }
+
   &-link:hover, &-link:focus {
     cursor: pointer;
     color: var(--yxt-pagination-text-color-hover);

--- a/src/ui/sass/modules/_Pagination.scss
+++ b/src/ui/sass/modules/_Pagination.scss
@@ -55,25 +55,25 @@ $pagination-color-hover: var(--yxt-color-text-secondary) !default;
     }
   }
 
-  &--active-all {
+  &--activeAll {
     background-color: var(--yxt-pagination-color-active-page);
   }
 
-  &--active-mobile {
+  &--activeMobile{
     background-color: inherit;
     @media (max-width: $breakpoint-mobile-max) {
       background-color: var(--yxt-pagination-color-active-page);
     }
   }
 
-  &--active-desktop {
+  &--activeDesktop {
     background-color: var(--yxt-pagination-color-active-page);
     @media (max-width: $breakpoint-mobile-max) {
       background-color: inherit;
     }
   }
 
-  &--onepage-all {
+  &--onepageAll {
     background-color: inherit;
   }
 

--- a/src/ui/sass/modules/_Pagination.scss
+++ b/src/ui/sass/modules/_Pagination.scss
@@ -55,25 +55,25 @@ $pagination-color-hover: var(--yxt-color-text-secondary) !default;
     }
   }
 
-  &-active {
+  &--active-all {
     background-color: var(--yxt-pagination-color-active-page);
   }
 
-  &-active-onepage-desktop {
+  &--active-mobile {
     background-color: inherit;
     @media (max-width: $breakpoint-mobile-max) {
       background-color: var(--yxt-pagination-color-active-page);
     }
   }
 
-  &-active-onepage-mobile {
+  &--active-desktop {
     background-color: var(--yxt-pagination-color-active-page);
     @media (max-width: $breakpoint-mobile-max) {
       background-color: inherit;
     }
   }
 
-  &-active-onepage-mobile-onepage-desktop {
+  &--onepage-all {
     background-color: inherit;
   }
 

--- a/src/ui/sass/modules/_Pagination.scss
+++ b/src/ui/sass/modules/_Pagination.scss
@@ -55,26 +55,16 @@ $pagination-color-hover: var(--yxt-color-text-secondary) !default;
     }
   }
 
-  &--activeAll {
-    background-color: var(--yxt-pagination-color-active-page);
-  }
-
   &--activeMobile{
-    background-color: inherit;
     @media (max-width: $breakpoint-mobile-max) {
       background-color: var(--yxt-pagination-color-active-page);
     }
   }
 
   &--activeDesktop {
-    background-color: var(--yxt-pagination-color-active-page);
-    @media (max-width: $breakpoint-mobile-max) {
-      background-color: inherit;
+    @media (min-width: $breakpoint-mobile-min) {
+      background-color: var(--yxt-pagination-color-active-page);
     }
-  }
-
-  &--onepageAll {
-    background-color: inherit;
   }
 
   &-link:hover, &-link:focus {

--- a/src/ui/templates/results/pagination.hbs
+++ b/src/ui/templates/results/pagination.hbs
@@ -56,7 +56,8 @@
 
     {{#each pageNumbers}}
       {{#if this.active}}
-        <span id="active-page{{this.onePageDesktop}}{{this.onePageMobile}}" class="yxt-Pagination-page" aria-label="Currently on page {{../pageNumber}}">{{../pageLabel}} {{../pageNumber}}</span>
+        <span id="active-page" class="yxt-Pagination-page yxt-Pagination-active{{this.onePageDesktop}}{{this.onePageMobile}}" aria-label="Currently on page {{../pageNumber}}">{{../pageLabel}} {{../pageNumber}}</span>
+        {{!-- <span id="active-page" class="yxt-Pagination-page{{this.onePage}}" aria-label="Currently on page {{../pageNumber}}">{{../pageLabel}} {{../pageNumber}}</span> --}}
       {{else}}
         <a 
           class="yxt-Pagination-link js-yxt-Pagination-link{{#if this.desktopHidden}} desktop-hidden{{/if}}{{#if this.mobileHidden}} mobile-hidden{{/if}}"

--- a/src/ui/templates/results/pagination.hbs
+++ b/src/ui/templates/results/pagination.hbs
@@ -56,7 +56,7 @@
 
     {{#each pageNumbers}}
       {{#if this.active}}
-        <span id="active-page" class="yxt-Pagination-page" aria-label="Currently on page {{../pageNumber}}">{{../pageLabel}} {{../pageNumber}}</span>
+        <span id="active-page{{this.onePageDesktop}}{{this.onePageMobile}}" class="yxt-Pagination-page" aria-label="Currently on page {{../pageNumber}}">{{../pageLabel}} {{../pageNumber}}</span>
       {{else}}
         <a 
           class="yxt-Pagination-link js-yxt-Pagination-link{{#if this.desktopHidden}} desktop-hidden{{/if}}{{#if this.mobileHidden}} mobile-hidden{{/if}}"

--- a/src/ui/templates/results/pagination.hbs
+++ b/src/ui/templates/results/pagination.hbs
@@ -56,8 +56,8 @@
 
     {{#each pageNumbers}}
       {{#if this.active}}
-        <span id="active-page" class="yxt-Pagination-page {{#if this.activeAll}}yxt-Pagination-active-all{{/if}} {{#if this.onePageAll}}yxt-Pagination--onepage-all{{/if}}
-        {{#if this.activeMobile}}yxt-Pagination--active-mobile{{/if}}{{#if this.activeDesktop}}yxt-Pagination--active-desktop{{/if}}" 
+        <span id="active-page" class="yxt-Pagination-page{{#if this.activeAll}} yxt-Pagination-activeAll{{/if}}{{#if this.onePageAll}} yxt-Pagination--onepageAll{{/if}}
+        {{#if this.activeMobile}} yxt-Pagination--activeMobile{{/if}}{{#if this.activeDesktop}} yxt-Pagination--activeDesktop{{/if}}" 
         aria-label="Currently on page {{../pageNumber}}">{{../pageLabel}} {{../pageNumber}}</span>
       {{else}}
         <a 

--- a/src/ui/templates/results/pagination.hbs
+++ b/src/ui/templates/results/pagination.hbs
@@ -56,8 +56,7 @@
 
     {{#each pageNumbers}}
       {{#if this.active}}
-        <span id="active-page" class="yxt-Pagination-page{{#if this.activeAll}} yxt-Pagination-activeAll{{/if}}{{#if this.onePageAll}} yxt-Pagination--onepageAll{{/if}}
-        {{#if this.activeMobile}} yxt-Pagination--activeMobile{{/if}}{{#if this.activeDesktop}} yxt-Pagination--activeDesktop{{/if}}" 
+        <span id="active-page" class="yxt-Pagination-page{{#if this.activeMobile}} yxt-Pagination--activeMobile{{/if}}{{#if this.activeDesktop}} yxt-Pagination--activeDesktop{{/if}}" 
         aria-label="Currently on page {{../pageNumber}}">{{../pageLabel}} {{../pageNumber}}</span>
       {{else}}
         <a 

--- a/src/ui/templates/results/pagination.hbs
+++ b/src/ui/templates/results/pagination.hbs
@@ -56,8 +56,9 @@
 
     {{#each pageNumbers}}
       {{#if this.active}}
-        <span id="active-page" class="yxt-Pagination-page yxt-Pagination-active{{this.onePageDesktop}}{{this.onePageMobile}}" aria-label="Currently on page {{../pageNumber}}">{{../pageLabel}} {{../pageNumber}}</span>
-        {{!-- <span id="active-page" class="yxt-Pagination-page{{this.onePage}}" aria-label="Currently on page {{../pageNumber}}">{{../pageLabel}} {{../pageNumber}}</span> --}}
+        <span id="active-page" class="yxt-Pagination-page {{#if this.activeAll}}yxt-Pagination-active-all{{/if}} {{#if this.onePageAll}}yxt-Pagination--onepage-all{{/if}}
+        {{#if this.activeMobile}}yxt-Pagination--active-mobile{{/if}}{{#if this.activeDesktop}}yxt-Pagination--active-desktop{{/if}}" 
+        aria-label="Currently on page {{../pageNumber}}">{{../pageLabel}} {{../pageNumber}}</span>
       {{else}}
         <a 
           class="yxt-Pagination-link js-yxt-Pagination-link{{#if this.desktopHidden}} desktop-hidden{{/if}}{{#if this.mobileHidden}} mobile-hidden{{/if}}"


### PR DESCRIPTION
Changed active state styling when there is only one page in the pagination. Previously, the active page in the pagination would have a different background color. Now, if the pagination only has 1 visible page, the active page inherits its background color.

TEST=manual

Tested on local test site. Checked that when maxVisiblePagesDesktop/maxVisiblePagesMobile is 1, the active page in the pagination has no background color. Changed size of window to test behavior on desktop/mobile.