### PR TITLE
Remove the hold stage for canary builds push to s3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,4 +169,4 @@ workflows:
             branches:
               only: develop
           requires:
-            - hold
+            - unit_test


### PR DESCRIPTION
We should not be holding the builds for every commit merged into
develop. Instead, we should push to s3 with the associated canary
version as soon as it passes unit tests and builds correctly.

J=SPR-2453
TEST=manual

circleci config validate