### PR TITLE
Remove the hold stage for any commits merged into develop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,7 +139,6 @@ workflows:
             branches:
               only: 
                 - master
-                - develop
           requires:
             - unit_test
       - deploy_latest:


### PR DESCRIPTION
The canary branches are being pushed automatically, but an additional
(not doing anything) hold step is being added to develop after we push
to s3. Remove this unnecessary hold for all commits to the develop
branch.

J=SPR-2453
TEST=manual

circleci config validate