### PR TITLE
searchcomponent: Remove referrerPageUrl from redirectUrl

### DIFF
--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -414,6 +414,9 @@ export default class SearchComponent extends Component {
     // If we have a redirectUrl, we want the form to be
     // serialized and submitted.
     if (typeof this.redirectUrl === 'string') {
+      if (params.has(StorageKeys.REFERRER_PAGE_URL)) {
+        params.delete(StorageKeys.REFERRER_PAGE_URL);
+      }
       window.location.href = this.redirectUrl + '?' + params.toString();
       return false;
     }


### PR DESCRIPTION
When we redirect, we do not want to passthrough the referrerPageUrl
query param of the page with the redirectUrl search bar.

To ground in an example
Page X: initial page, navigate to Page Y
Page Y: contains a searchbar with redirectUrl, redirects to Page Z
Page Z: our answers experience

The referrerPageUrl of Z is currently X instead of Y because redirectUrl
passes all query params from page Y and page Y generates referrerPageUrl
on ANSWERS.init.

J=SPR-2452
TEST=manual

Test on a QA site with a searchbar that redirects to a site. Make sure
the site has referrerPageUrl in the query params already. Make sure
that the referrerPageUrl of the resulting answers page has
referrerPageUrl as the QA site, not the value of the QA site's
referrerPageUrl.