### PR TITLE
Update invokeOnReady so that onReady isn't called twice

### DIFF
--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -246,8 +246,7 @@ class Answers {
    */
   _invokeOnReady () {
     this._masterSwitchApi.isDisabled()
-      .then(isDisabled => !isDisabled && this._onReady())
-      .catch(() => this._onReady());
+      .then(isDisabled => !isDisabled && this._onReady(), () => this._onReady());
   }
 
   /**


### PR DESCRIPTION
Fixed the bug in invokeOnReady where onReady is fired twice if the first call results in an error. This bug caused certain components (e.g. the search bar) to render twice if there is an error in onReady. With this change the components before the error only render once as onReady is only called once.

J=SPR-2469
TEST=manual

Tested on local test site. Added console.log statement in onReady to check how many times it is called. Added 'throw new Error()' in onReady to make sure onReady is only called once, and also tested with errors in components. Added 'throw new Error()' in isDisabled() to make sure onReady is still called. Tested with isDisabled = true/false to make sure that when isDisabled is true, onReady is not called. Lastly, tested on IE11 to make sure the bug is fixed on IE11 as well.