### PR TITLE
FilterOptions: fix clearSearch button's vertical alignment

### DIFF
--- a/src/ui/sass/modules/_FilterOptions.scss
+++ b/src/ui/sass/modules/_FilterOptions.scss
@@ -101,6 +101,7 @@
     position: absolute;
     right: 0;
     top: 50%;
+    height: 100%;
     transform: translateY(-50%);
     border: none;
     background: none;

--- a/src/ui/sass/modules/_FilterOptions.scss
+++ b/src/ui/sass/modules/_FilterOptions.scss
@@ -101,7 +101,7 @@
     position: absolute;
     right: 0;
     top: 50%;
-    height: 100%;
+    max-height: 100%;
     transform: translateY(-50%);
     border: none;
     background: none;

--- a/src/ui/sass/modules/_FilterOptions.scss
+++ b/src/ui/sass/modules/_FilterOptions.scss
@@ -42,6 +42,12 @@
       &:focus {
         border: var(--yxt-border-hover);
       }
+
+      &::-ms-clear {
+        display: none;
+        height: 0;
+        width: 0;
+      }
     }
 
     &-fieldSet {


### PR DESCRIPTION
J=SPR-2506
TEST=manual
Tested that on page
https://synergic-health_yextdemos_com.yextpages.net/providers.html
adding this line of css correctly vertically aligns the clear button

Also tested that locally, I can manually set the text input to arbitrary
heights and the clear button will still be aligned

test that extra space above and below clear button is not clickable