### PR TITLE
Use pixels instead of rem/em for filter options caret sizing

### DIFF
--- a/src/ui/sass/modules/_FilterOptions.scss
+++ b/src/ui/sass/modules/_FilterOptions.scss
@@ -118,8 +118,8 @@
     margin-left: auto;
 
     >.Icon--chevron svg {
-      height: .75em;
-      width: .75rem;
+      height: 12px;
+      width: 12px;
     }
   }
 


### PR DESCRIPTION
TEST=manual

Use local test site with facets and filterbox. Confirm that caret sizes look the same before and after change.