### PR TITLE
Increase package size limit for legacy bundle

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -1,7 +1,7 @@
 module.exports = [
   {
     path: 'dist/answers.min.js',
-    limit: '150 KB'
+    limit: '160 KB'
   },
   {
     path: 'dist/answers-modern.min.js',


### PR DESCRIPTION
TEST=auto

Run npm run build locally, see package size is under limit. That is not the same limit used in CircleCI, so wait for the "build" step to finish there as well, see it was successful.