### PR TITLE
Version 1.4.1

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -1,7 +1,7 @@
 module.exports = [
   {
     path: 'dist/answers.min.js',
-    limit: '150 KB'
+    limit: '160 KB'
   },
   {
     path: 'dist/answers-modern.min.js',

--- a/README.md
+++ b/README.md
@@ -497,6 +497,8 @@ ANSWERS.addComponent('UniversalResults', {
         resultsCountSeparator: '|',
         // Whether to display the change filters link in universal results. Defaults to false.
         showChangeFilters: false,
+        // The text for the change filters link. Defaults to 'change filters'.
+        changeFiltersText: 'change filters',
         // The character that separates each field (and its associated filters) within the applied filter bar. Defaults to '|'
         delimiter: '|',
         // The aria-label given to the applied filters bar. Defaults to 'Filters applied to this search:'.

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -246,8 +246,7 @@ class Answers {
    */
   _invokeOnReady () {
     this._masterSwitchApi.isDisabled()
-      .then(isDisabled => !isDisabled && this._onReady())
-      .catch(() => this._onReady());
+      .then(isDisabled => !isDisabled && this._onReady(), () => this._onReady());
   }
 
   /**

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -6,7 +6,8 @@ import cssVars from 'css-vars-ponyfill';
 import {
   DefaultTemplatesLoader,
   Renderers,
-  DOM
+  DOM,
+  SearchParams
 } from './ui/index';
 import Component from './ui/components/component';
 
@@ -417,6 +418,10 @@ class Answers {
    * Updates the css styles with new current variables. This is useful when the css
    * variables are updated dynamically (e.g. through js) or if the css variables are
    * added after the ANSWERS.init
+   *
+   * To solve issues with non-zero max-age cache controls for link/script assets in IE11,
+   * we add a cache busting parameter so that XMLHttpRequests succeed.
+   *
    * @param {Object} config Additional config to pass to the ponyfill
    */
   ponyfillCssVariables (config = {}) {
@@ -424,7 +429,18 @@ class Answers {
       onlyLegacy: true,
       onError: config.onError || function () {},
       onSuccess: config.onSuccess || function () {},
-      onFinally: config.onFinally || function () {}
+      onFinally: config.onFinally || function () {},
+      onBeforeSend: (xhr, node, url) => {
+        try {
+          const uriWithCacheBust = new URL(url);
+          const params = new SearchParams(uriWithCacheBust.search);
+          params.set('_', new Date().getTime());
+          uriWithCacheBust.search = params.toString();
+          xhr.open('GET', uriWithCacheBust.toString());
+        } catch (e) {
+          // Catch the error and continue if the URL provided in the asset is not a valid URL
+        }
+      }
     });
   }
 }

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -187,6 +187,7 @@ export default class Core {
 
         if (data[StorageKeys.DYNAMIC_FILTERS]) {
           this.globalStorage.set(StorageKeys.DYNAMIC_FILTERS, data[StorageKeys.DYNAMIC_FILTERS]);
+          this.globalStorage.set(StorageKeys.RESULTS_HEADER, data[StorageKeys.DYNAMIC_FILTERS]);
         }
         if (data[StorageKeys.SPELL_CHECK]) {
           this.globalStorage.set(StorageKeys.SPELL_CHECK, data[StorageKeys.SPELL_CHECK]);

--- a/src/core/filters/combinedfilternode.js
+++ b/src/core/filters/combinedfilternode.js
@@ -65,8 +65,8 @@ export default class CombinedFilterNode extends FilterNode {
    * Recursively get all of the leaf SimpleFilterNodes.
    * @returns {Array<SimpleFilterNode>}
    */
-  getSimpleAncestors () {
-    return this.getChildren().flatMap(fn => fn.getSimpleAncestors());
+  getSimpleDescendants () {
+    return this.getChildren().flatMap(fn => fn.getSimpleDescendants());
   }
 
   /**

--- a/src/core/filters/filternode.js
+++ b/src/core/filters/filternode.js
@@ -31,7 +31,7 @@ export default class FilterNode {
    * Recursively get all of the leaf SimpleFilterNodes.
    * @returns {Array<SimpleFilterNode>}
    */
-  getSimpleAncestors () {}
+  getSimpleDescendants () {}
 
   /**
    * Remove this FilterNode from the FilterRegistry.

--- a/src/core/filters/filterregistry.js
+++ b/src/core/filters/filterregistry.js
@@ -26,6 +26,22 @@ export default class FilterRegistry {
   }
 
   /**
+   * Returns an array containing all of the filternodes stored in global storage.
+   * @returns {Array<FilterNode>}
+   */
+  getAllFilterNodes () {
+    const globalStorageFilterNodes = [
+      ...this.getStaticFilterNodes(),
+      ...this.getFacetFilterNodes()
+    ];
+    const locationRadiusFilterNode = this.getFilterNodeByKey(StorageKeys.LOCATION_RADIUS);
+    if (locationRadiusFilterNode) {
+      globalStorageFilterNodes.push(locationRadiusFilterNode);
+    }
+    return globalStorageFilterNodes;
+  }
+
+  /**
    * Get all of the {@link FilterNode}s for static filters.
    * @returns {Array<FilterNode>}
    */

--- a/src/core/filters/simplefilternode.js
+++ b/src/core/filters/simplefilternode.js
@@ -63,7 +63,7 @@ export default class SimpleFilterNode extends FilterNode {
    * Since SimpleFilterNodes have no children this just returns itself.
    * @returns {Array<SimpleFilterNode>}
    */
-  getSimpleAncestors () {
+  getSimpleDescendants () {
     return this;
   }
 
@@ -72,5 +72,31 @@ export default class SimpleFilterNode extends FilterNode {
    */
   remove () {
     this._remove();
+  }
+
+  /**
+   * Returns whether this SimpleFilterNode's filter is equal to another SimpleFilterNode's
+   * @param {SimpleFilterNode} node
+   * @returns {boolean}
+   */
+  hasSameFilterAs (otherNode) {
+    const thisFilter = this.getFilter();
+    const otherFilter = otherNode.getFilter();
+    const thisFieldId = thisFilter.getFilterKey();
+    const otherFieldId = otherFilter.getFilterKey();
+    if (thisFieldId !== otherFieldId) {
+      return false;
+    }
+    const thisMatchersToValues = thisFilter[thisFieldId];
+    const otherMatchersToValues = otherFilter[otherFieldId];
+    const thisMatchers = Object.keys(thisMatchersToValues);
+    const otherMatchers = Object.keys(otherMatchersToValues);
+    if (thisMatchers.length !== otherMatchers.length) {
+      return false;
+    }
+    return thisMatchers.every(m =>
+      otherMatchersToValues.hasOwnProperty(m) &&
+      otherMatchersToValues[m] === thisMatchersToValues[m]
+    );
   }
 }

--- a/src/core/storage/storagekeys.js
+++ b/src/core/storage/storagekeys.js
@@ -32,5 +32,6 @@ export default {
   LOCALE: 'locale',
   SORT_BYS: 'sort-bys',
   NO_RESULTS_CONFIG: 'no-results-config',
-  LOCATION_RADIUS: 'location-radius'
+  LOCATION_RADIUS: 'location-radius',
+  RESULTS_HEADER: 'results-header'
 };

--- a/src/core/utils/filternodeutils.js
+++ b/src/core/utils/filternodeutils.js
@@ -1,0 +1,47 @@
+import FilterNodeFactory from '../filters/filternodefactory';
+import Filter from '../models/filter';
+import FilterMetadata from '../filters/filtermetadata';
+
+/**
+ * Converts an array of {@link AppliedQueryFilter}s into equivalent {@link SimpleFilterNode}s.
+ * @param {Array<AppliedQueryFilter>} nlpFilters
+ * @returns {Array<SimpleFilterNode>}
+ */
+export function convertNlpFiltersToFilterNodes (nlpFilters) {
+  return nlpFilters.map(nlpFilter => FilterNodeFactory.from({
+    filter: Filter.from(nlpFilter.filter),
+    metadata: new FilterMetadata({
+      fieldName: nlpFilter.key,
+      displayValue: nlpFilter.value
+    })
+  }));
+}
+
+/**
+ * Flattens an array of {@link FilterNode}s into an array
+ * of their constituent leaf {@link SimpleFilterNode}s.
+ * @param {Array<FilterNode>} filterNodes
+ * @returns {Array<SimpleFilterNode>}
+ */
+export function flattenFilterNodes (filterNodes) {
+  return filterNodes.flatMap(fn => fn.getSimpleDescendants());
+}
+
+/**
+ * Returns the given array of {@link FilterNode}s,
+ * removing FilterNodes that are empty or have a field id listed as a hidden.
+ * @param {Array<FilterNode>} filterNodes
+ * @param {Array<string>} hiddenFields
+ * @returns {Array<FilterNode>}
+ */
+export function pruneFilterNodes (filterNodes, hiddenFields) {
+  return filterNodes
+    .filter(fn => {
+      const { fieldName, displayValue } = fn.getMetadata();
+      if (!fieldName || !displayValue) {
+        return false;
+      }
+      const fieldId = fn.getFilter().getFilterKey();
+      return !hiddenFields.includes(fieldId);
+    });
+}

--- a/src/ui/components/results/paginationcomponent.js
+++ b/src/ui/components/results/paginationcomponent.js
@@ -249,6 +249,12 @@ export default class PaginationComponent extends Component {
       const num = { number: i };
       if (i === pageNumber) {
         num.active = true;
+        if (this._maxVisiblePagesDesktop > 1) {
+          num.activeDesktop = true;
+        }
+        if (this._maxVisiblePagesMobile > 1) {
+          num.activeMobile = true;
+        }
       } else {
         if (i <= mobileBackLimit || i > mobileFrontLimit) {
           num.mobileHidden = true;

--- a/src/ui/components/results/resultsheadercomponent.js
+++ b/src/ui/components/results/resultsheadercomponent.js
@@ -4,6 +4,11 @@ import Component from '../component';
 import StorageKeys from '../../../core/storage/storagekeys';
 import DOM from '../../dom/dom';
 import { groupArray } from '../../../core/utils/arrayutils';
+import {
+  convertNlpFiltersToFilterNodes,
+  flattenFilterNodes,
+  pruneFilterNodes
+} from '../../../core/utils/filternodeutils';
 
 const DEFAULT_CONFIG = {
   showResultCount: true,
@@ -16,7 +21,8 @@ const DEFAULT_CONFIG = {
   delimiter: '|',
   isUniversal: false,
   labelText: 'Filters applied to this search:',
-  removableLabelText: 'Remove this filter'
+  removableLabelText: 'Remove this filter',
+  hiddenFields: []
 };
 
 export default class ResultsHeaderComponent extends Component {
@@ -38,18 +44,19 @@ export default class ResultsHeaderComponent extends Component {
     this.resultsLength = data.resultsLength || 0;
 
     /**
-     * Array of applied filterNodes. These are allowed to be removable, but
-     * if config.removable is set as false these will not render as removable.
-     * @type {Array<FilterNode>}
+     * Array of nlp filters in the search response.
+     * @type {Array<AppliedQueryFilter>}
      */
-    this.appliedFilterNodes = data.appliedFilterNodes || [];
+    this.nlpFilterNodes = convertNlpFiltersToFilterNodes(data.nlpFilters || []);
 
     /**
-     * Array of nlp filterNodes to display.
-     * These will not render as removable even if config.removable is true.
-     * @type {Array<FilterNode>}
+     * TODO (SPR-2455): Ideally, we would be able to set moduleId to DYNAMIC_FILTERS, the actual data
+     * we are listening to changes to, instead of this bespoke RESULTS_HEADER storage key.
+     * The issue is that when two components share a moduleId, if that moduleId listener is ever
+     * unregistered with the off() method, all listeners to that moduleId are unregistered.
+     * With child components, this is something that happens whenever the parent component rerenders.
      */
-    this.nlpFilterNodes = data.nlpFilterNodes || [];
+    this.moduleId = StorageKeys.RESULTS_HEADER;
   }
 
   static areDuplicateNamesAllowed () {
@@ -80,6 +87,20 @@ export default class ResultsHeaderComponent extends Component {
   }
 
   /**
+   * Returns the currently applied nlp filter nodes, with nlp filter nodes that
+   * are duplicates of other filter nodes removed.
+   * @returns {Array<FilterNode>}
+   */
+  _pruneDuplicateNlpFilterNodes () {
+    return this.nlpFilterNodes.filter(nlpNode => {
+      const isDuplicate = this.appliedFilterNodes.find(appliedNode =>
+        appliedNode.hasSameFilterAs(nlpNode)
+      );
+      return !isDuplicate;
+    });
+  }
+
+  /**
    * Combine all of the applied filters into a format the handlebars
    * template can work with.
    * Keys are the fieldName of the filter. Values are an array of objects with a
@@ -89,17 +110,18 @@ export default class ResultsHeaderComponent extends Component {
    * @returns {Array<Object>}
    */
   _groupAppliedFilters () {
-    const keyFunc = filterNode => filterNode.getMetadata().fieldName;
-    const irremovableValueFunc = filterNode => ({
+    const getFieldName = filterNode => filterNode.getMetadata().fieldName;
+    const parseNlpFilterDisplay = filterNode => ({
       displayValue: filterNode.getMetadata().displayValue
     });
-    const irremovableGrouped = groupArray(this.nlpFilterNodes, keyFunc, irremovableValueFunc);
-    const removableValueFunc = (filterNode, index) => ({
+    const parseRemovableFilterDisplay = (filterNode, index) => ({
       displayValue: filterNode.getMetadata().displayValue,
       dataFilterId: index,
       removable: this._config.removable
     });
-    return groupArray(this.appliedFilterNodes, keyFunc, removableValueFunc, irremovableGrouped);
+    const removableNodes = groupArray(this.appliedFilterNodes, getFieldName, parseRemovableFilterDisplay);
+    const prunedNlpFilterNodes = this._pruneDuplicateNlpFilterNodes();
+    return groupArray(prunedNlpFilterNodes, getFieldName, parseNlpFilterDisplay, removableNodes);
   }
 
   /**
@@ -108,7 +130,7 @@ export default class ResultsHeaderComponent extends Component {
    * not objects, so we need to reformat the grouped applied filters.
    * @returns {Array<Object>}
    */
-  _getAppliedFiltersArray () {
+  _createAppliedFiltersArray () {
     const groupedFilters = this._groupAppliedFilters();
     return Object.keys(groupedFilters).map(label => ({
       label: label,
@@ -116,9 +138,21 @@ export default class ResultsHeaderComponent extends Component {
     }));
   }
 
+  /**
+   * Pulls applied filter nodes from {@link FilterRegistry}, then retrives an array of
+   * the leaf nodes, and then removes hidden or empty {@link FilterNode}s. Then appends
+   * the currently applied nlp filters.
+   */
+  _calculateAppliedFilterNodes () {
+    const filterNodes = this.core.filterRegistry.getAllFilterNodes();
+    const simpleFilterNodes = flattenFilterNodes(filterNodes);
+    return pruneFilterNodes(simpleFilterNodes, this._config.hiddenFields);
+  }
+
   setState (data) {
     const offset = this.core.globalStorage.getState(StorageKeys.SEARCH_OFFSET);
-    const appliedFiltersArray = this._getAppliedFiltersArray();
+    this.appliedFilterNodes = this._calculateAppliedFilterNodes();
+    const appliedFiltersArray = this._createAppliedFiltersArray();
     const shouldShowFilters = appliedFiltersArray.length > 0 && this._config.showAppliedFilters;
     return super.setState({
       ...data,

--- a/src/ui/components/results/universalresultscomponent.js
+++ b/src/ui/components/results/universalresultscomponent.js
@@ -85,6 +85,8 @@ export default class UniversalResultsComponent extends Component {
         resultsCountSeparator: defaultConfigOption(config, ['appliedFilters.resultsCountSeparator', 'resultsCountSeparator'], '|'),
         // Whether to show a 'change filters' link, linking back to verticalURL.
         showChangeFilters: defaultConfigOption(config, ['appliedFilters.showChangeFilters', 'showChangeFilters'], false),
+        // The text for the change filters link.
+        changeFiltersText: defaultConfigOption(config, ['appliedFilters.changeFiltersText', 'changeFiltersText']),
         // The symbol placed between different filters with the same fieldName. e.g. Location: Virginia | New York | Miami.
         delimiter: defaultConfigOption(config, ['appliedFilters.delimiter'], '|'),
         // The aria-label given to the applied filters bar.

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -113,6 +113,12 @@ class VerticalResultsConfig {
       showChangeFilters: defaultConfigOption(config, ['appliedFilters.showChangeFilters', 'showChangeFilters'], false),
 
       /**
+       * The text for the change filters link.
+       * @type {string}
+       */
+      changeFiltersText: defaultConfigOption(config, ['appliedFilters.changeFiltersText', 'changeFiltersText']),
+
+      /**
        * The aria-label given to the applied filters bar. Defaults to 'Filters applied to this search:'.
        * @type {string}
        **/
@@ -199,6 +205,7 @@ export default class VerticalResultsComponent extends Component {
       resultsCountSeparator: this._config.appliedFilters.resultsCountSeparator,
       showAppliedFilters: this._config.appliedFilters.show,
       showChangeFilters: this._config.appliedFilters.showChangeFilters,
+      changeFiltersText: this._config.appliedFilters.changeFiltersText,
       showResultCount: this._config.showResultCount,
       removable: this._config.appliedFilters.removable,
       delimiter: this._config.appliedFilters.delimiter,

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -12,9 +12,6 @@ import ResultsHeaderComponent from './resultsheadercomponent';
 import { addParamsToUrl } from '../../../core/utils/urlutils';
 import Icons from '../../icons/index';
 import { defaultConfigOption } from '../../../core/utils/configutils';
-import FilterNodeFactory from '../../../core/filters/filternodefactory';
-import Filter from '../../../core/models/filter';
-import FilterMetadata from '../../../core/filters/filtermetadata';
 
 class VerticalResultsConfig {
   constructor (config = {}) {
@@ -210,7 +207,8 @@ export default class VerticalResultsComponent extends Component {
       removable: this._config.appliedFilters.removable,
       delimiter: this._config.appliedFilters.delimiter,
       labelText: this._config.appliedFilters.labelText,
-      removableLabelText: this._config.appliedFilters.removableLabelText
+      removableLabelText: this._config.appliedFilters.removableLabelText,
+      hiddenFields: this._config.appliedFilters.hiddenFields
     };
   }
 
@@ -246,16 +244,10 @@ export default class VerticalResultsComponent extends Component {
     this.resultsCount = data.resultsCount;
     this.verticalKey = data.verticalConfigId;
     this.resultsContext = data.resultsContext;
-    const nlpFilters = data.appliedQueryFilters || [];
     const searchState = data.searchState || SearchStates.PRE_SEARCH;
     const displayResultsIfExist = this._config.isUniversal ||
       this._displayAllResults ||
       data.resultsContext === ResultsContext.NORMAL;
-    this.appliedFilterNodes = this._processFilterNodes(this._getAppliedFilterNodes());
-    this.nlpFilterNodes = this._processFilterNodes(this._convertNlpFiltersToFilterNodes(nlpFilters));
-    const hasAppliedFilters = this.appliedFilterNodes.length || this.nlpFilterNodes.length;
-    const showResultsHeader = this.resultsHeaderOpts.showResultCount ||
-      (this.resultsHeaderOpts.showAppliedFilters && hasAppliedFilters);
     this.query = this.core.globalStorage.getState(StorageKeys.QUERY);
     return super.setState(Object.assign({ results: [] }, data, {
       isPreSearch: searchState === SearchStates.PRE_SEARCH,
@@ -270,9 +262,9 @@ export default class VerticalResultsComponent extends Component {
       showNoResults: this.resultsContext === ResultsContext.NO_RESULTS,
       placeholders: new Array(this._config.maxNumberOfColumns - 1),
       numColumns: Math.min(this._config.maxNumberOfColumns, this.results.length),
-      showResultsHeader: showResultsHeader,
       useLegacyNoResults: this._useLegacyNoResults,
-      iconIsBuiltIn: Icons[this._config.icon]
+      iconIsBuiltIn: Icons[this._config.icon],
+      nlpFilters: data.appliedQueryFilters || []
     }), val);
   }
 
@@ -297,59 +289,6 @@ export default class VerticalResultsComponent extends Component {
    */
   static defaultTemplateName (config) {
     return 'results/verticalresults';
-  }
-
-  /**
-   * Given an array of nlp filters from the backend turn them into an array of SimpleFilterNodes
-   * @param {Array<AppliedQueryFilter>} nlpFilters
-   * @returns {Array<SimpleFilterNode>}
-   */
-  _convertNlpFiltersToFilterNodes (nlpFilters) {
-    return nlpFilters.map(nlpFilter => FilterNodeFactory.from({
-      filter: Filter.from(nlpFilter.filter),
-      metadata: new FilterMetadata({
-        fieldName: nlpFilter.key,
-        displayValue: nlpFilter.value
-      })
-    }));
-  }
-
-  /**
-   * Gets all applied {@link FilterNode}s stored in the {@link FilterRegistry}, which
-   * uses manages FilterNodes in globalStorage.
-   * @returns {Array<FilterNode>}
-   */
-  _getAppliedFilterNodes () {
-    const globalStorageFilterNodes = [
-      ...this.core.getStaticFilterNodes(),
-      ...this.core.getFacetFilterNodes()
-    ];
-    const locationRadiusFilterNode = this.core.getLocationRadiusFilterNode();
-    if (locationRadiusFilterNode) {
-      globalStorageFilterNodes.push(locationRadiusFilterNode);
-    }
-    return globalStorageFilterNodes;
-  }
-
-  /**
-   * Returns an array of all filter nodes currently being applied to the search.
-   * Filters out filterNodes without fieldName or displayValue, or that have a
-   * fieldId listed in this._config.hiddenFields. Any AppliedQueryFilters are first
-   * converted into a FilterNode.
-   * @param {Array<FilterNode>} filterNodes
-   * @returns {Array<FilterNode>}
-   */
-  _processFilterNodes (filterNodes) {
-    return filterNodes
-      .flatMap(fn => fn.getSimpleAncestors())
-      .filter(fn => {
-        const { fieldName, displayValue } = fn.getMetadata();
-        if (!fieldName || !displayValue) {
-          return false;
-        }
-        const fieldId = fn.getFilter().getFilterKey();
-        return !this._config.appliedFilters.hiddenFields.includes(fieldId);
-      });
   }
 
   addChild (data, type, opts) {
@@ -394,8 +333,7 @@ export default class VerticalResultsComponent extends Component {
       const resultsHeaderData = {
         resultsLength: this.results.length,
         resultsCount: this.resultsCount,
-        appliedFilterNodes: this.appliedFilterNodes,
-        nlpFilterNodes: this.nlpFilterNodes,
+        nlpFilters: this.getState('nlpFilters'),
         ...data
       };
       const _opts = { ...opts };

--- a/src/ui/sass/modules/_FilterOptions.scss
+++ b/src/ui/sass/modules/_FilterOptions.scss
@@ -264,8 +264,8 @@
     margin-left: auto;
 
     >.Icon--chevron svg {
-      height: .75em;
-      width: .75rem;
+      height: 12px;
+      width: 12px;
     }
   }
 

--- a/src/ui/sass/modules/_FilterOptions.scss
+++ b/src/ui/sass/modules/_FilterOptions.scss
@@ -262,6 +262,11 @@
 
   &-expand {
     margin-left: auto;
+
+    >.Icon--chevron svg {
+      height: .75em;
+      width: .75rem;
+    }
   }
 
   &--collapsed {

--- a/src/ui/sass/modules/_FilterOptions.scss
+++ b/src/ui/sass/modules/_FilterOptions.scss
@@ -42,6 +42,12 @@
       &:focus {
         border: var(--yxt-border-hover);
       }
+
+      &::-ms-clear {
+        display: none;
+        height: 0;
+        width: 0;
+      }
     }
 
     &-fieldSet {
@@ -101,6 +107,7 @@
     position: absolute;
     right: 0;
     top: 50%;
+    max-height: 100%;
     transform: translateY(-50%);
     border: none;
     background: none;

--- a/src/ui/sass/modules/_Pagination.scss
+++ b/src/ui/sass/modules/_Pagination.scss
@@ -55,8 +55,16 @@ $pagination-color-hover: var(--yxt-color-text-secondary) !default;
     }
   }
 
-  #active-page {
-    background-color: var(--yxt-pagination-color-active-page);
+  &--activeMobile{
+    @media (max-width: $breakpoint-mobile-max) {
+      background-color: var(--yxt-pagination-color-active-page);
+    }
+  }
+
+  &--activeDesktop {
+    @media (min-width: $breakpoint-mobile-min) {
+      background-color: var(--yxt-pagination-color-active-page);
+    }
   }
 
   &-link:hover, &-link:focus {

--- a/src/ui/sass/modules/_QuestionSubmission.scss
+++ b/src/ui/sass/modules/_QuestionSubmission.scss
@@ -80,6 +80,7 @@ $question-submission-acknowledgement-bar-bg: var(--yxt-color-background-highligh
   display: flex;
   flex-direction: column;
   border: var(--yxt-question-submission-border);
+  background-color: var(--yxt-color-brand-white);
   margin-top: var(--yxt-base-spacing);
 
   &-titleBar

--- a/src/ui/sass/modules/_Results.scss
+++ b/src/ui/sass/modules/_Results.scss
@@ -198,7 +198,7 @@ $results-cards-margin: calc(var(--yxt-base-spacing) / 2) !default;
     display: flex;
     padding: calc(var(--yxt-base-spacing) / 2) var(--yxt-base-spacing);
     align-items: center;
-    background-color:  var(--yxt-color-background-highlight);
+    background-color:  var(--yxt-results-title-bar-background);
   }
 
   &-title
@@ -206,10 +206,10 @@ $results-cards-margin: calc(var(--yxt-base-spacing) / 2) !default;
     margin: 0;
     text-transform: uppercase;
     @include Text(
-      $color: var(--yxt-color-text-primary),
-      $weight: var(--yxt-font-weight-semibold),
-      $line-height: var(--yxt-line-height-lg),
-      $size: var(--yxt-font-size-md-lg),
+      var(--yxt-results-title-bar-text-font-size),
+      var(--yxt-results-title-bar-text-line-height),
+      var(--yxt-font-weight-semibold),
+      $color: var(--yxt-results-title-bar-text-color)
     );
   }
 }

--- a/src/ui/sass/modules/_ResultsHeader.scss
+++ b/src/ui/sass/modules/_ResultsHeader.scss
@@ -134,7 +134,8 @@ $results-header-universal-background: var(--yxt-color-brand-white) !default;
       $color: var(--yxt-color-brand-primary)
     );
     @include Link(
-      $base-color: var(--yxt-color-brand-primary)
+      $base-color: var(--yxt-color-brand-primary),
+      $base-decoration: underline
     );
   }
 

--- a/src/ui/templates/results/pagination.hbs
+++ b/src/ui/templates/results/pagination.hbs
@@ -56,7 +56,8 @@
 
     {{#each pageNumbers}}
       {{#if this.active}}
-        <span id="active-page" class="yxt-Pagination-page" aria-label="Currently on page {{../pageNumber}}">{{../pageLabel}} {{../pageNumber}}</span>
+        <span id="active-page" class="yxt-Pagination-page{{#if this.activeMobile}} yxt-Pagination--activeMobile{{/if}}{{#if this.activeDesktop}} yxt-Pagination--activeDesktop{{/if}}" 
+        aria-label="Currently on page {{../pageNumber}}">{{../pageLabel}} {{../pageNumber}}</span>
       {{else}}
         <a 
           class="yxt-Pagination-link js-yxt-Pagination-link{{#if this.desktopHidden}} desktop-hidden{{/if}}{{#if this.mobileHidden}} mobile-hidden{{/if}}"

--- a/src/ui/templates/results/resultsheader.hbs
+++ b/src/ui/templates/results/resultsheader.hbs
@@ -1,15 +1,17 @@
-<div class="yxt-ResultsHeader
-  {{~#if _config.isUniversal}} yxt-ResultsHeader--universal yxt-Results-filters{{/if}}
-  {{~#if _config.removable}} yxt-ResultsHeader--removable{{/if}}">
-  {{> resultscount}}
-  {{#if showResultSeparator}}
-    <div class="yxt-ResultsHeader-resultsCountSeparator">{{_config.resultsCountSeparator}}</div>
-  {{/if}}
-  {{> filters}}
-</div>
+{{#if (or shouldShowFilters (and _config.showResultCount resultsCount))}}
+  <div class="yxt-ResultsHeader
+    {{~#if _config.isUniversal}} yxt-ResultsHeader--universal yxt-Results-filters{{/if}}
+    {{~#if _config.removable}} yxt-ResultsHeader--removable{{/if}}">
+    {{> resultscount}}
+    {{#if showResultSeparator}}
+      <div class="yxt-ResultsHeader-resultsCountSeparator">{{_config.resultsCountSeparator}}</div>
+    {{/if}}
+    {{> filters}}
+  </div>
+{{/if}}
 
 {{#*inline "resultscount"}}
-  {{#every _config.showResultCount resultsCount}}
+  {{#if (and _config.showResultCount resultsCount)}}
     <div class="yxt-ResultsHeader-resultsCount" aria-label="{{resultsCountStart}} through {{resultsCountEnd}} of {{resultsCount}}">
       <div aria-hidden="true">
         <span class="yxt-ResultsHeader-resultsCountStart">{{resultsCountStart}}</span>
@@ -19,7 +21,7 @@
         <span class="yxt-ResultsHeader-resultsCountTotal">{{resultsCount}}</span>
       </div>
     </div>
-  {{/every}}
+  {{/if}}
 {{/inline}}
 
 {{#*inline "filters"}}

--- a/src/ui/templates/results/resultsheader.hbs
+++ b/src/ui/templates/results/resultsheader.hbs
@@ -56,7 +56,11 @@
         data-eventtype="FILTERING_WITHIN_SECTION"
         data-eventoptions='{{eventOptions}}'
       >
-        change filters
+        {{#if _config.changeFiltersText}}
+          {{_config.changeFiltersText}}
+        {{else}}
+          change filters
+        {{/if}}
       </a>
     {{/every}}
     </div>

--- a/src/ui/templates/results/verticalresults.hbs
+++ b/src/ui/templates/results/verticalresults.hbs
@@ -41,9 +41,7 @@
 {{/inline}}
 
 {{#*inline 'resultsHeader'}}
-  {{#if showResultsHeader}}
-    <div data-component="ResultsHeader"></div>
-  {{/if}}
+  <div data-component="ResultsHeader"></div>
 {{/inline}}
 
 {{#*inline "results"}}

--- a/tests/core/filters/combinedfilternode.js
+++ b/tests/core/filters/combinedfilternode.js
@@ -36,7 +36,7 @@ describe('CombinedFilterNode', () => {
       FilterNodeFactory.and(node_f0_v0, node_f0_v1),
       FilterNodeFactory.or(node_f1_v0, node_f1_v1)
     );
-    const simpleFilterNodes = combinedNode.getSimpleAncestors();
+    const simpleFilterNodes = combinedNode.getSimpleDescendants();
     expect(simpleFilterNodes).toHaveLength(4);
     expect(simpleFilterNodes).toContainEqual(node_f0_v0);
     expect(simpleFilterNodes).toContainEqual(node_f1_v0);

--- a/tests/core/filters/simplefilternode.js
+++ b/tests/core/filters/simplefilternode.js
@@ -1,0 +1,86 @@
+/* eslint no-dupe-keys: 0 */
+import FilterNodeFactory from '../../../src/core/filters/filternodefactory';
+
+describe('haveEqualSimpleFilters helper', () => {
+  const joeFilterNode = FilterNodeFactory.from({
+    filter: { name: { '$eq': 'joe' } }
+  });
+  const bobFilterNode = FilterNodeFactory.from({
+    filter: { name: { '$eq': 'bob' } }
+  });
+
+  it('works for equivalent simple filters', () => {
+    const joeClone = FilterNodeFactory.from(joeFilterNode);
+    expect(joeFilterNode.hasSameFilterAs(joeClone)).toBeTruthy();
+    expect(joeClone.hasSameFilterAs(joeFilterNode)).toBeTruthy();
+  });
+
+  it('returns false for different simple filters', () => {
+    expect(bobFilterNode.hasSameFilterAs(joeFilterNode)).toBeFalsy();
+  });
+
+  it('does not care about order within filter object', () => {
+    const rangeFilterNode = FilterNodeFactory.from({
+      filter: {
+        fieldId: {
+          '$ge': 5,
+          '$le': 7
+        }
+      }
+    });
+
+    const rangeFilterNodeReverse = FilterNodeFactory.from({
+      filter: {
+        fieldId: {
+          '$le': 7,
+          '$ge': 5
+        }
+      }
+    });
+    expect(rangeFilterNode.hasSameFilterAs(rangeFilterNodeReverse)).toBeTruthy();
+  });
+
+  it('returns false for different fieldId', () => {
+    const rangeFilterNode = FilterNodeFactory.from({
+      filter: {
+        iamDifferent: {
+          '$ge': 5,
+          '$le': 7
+        }
+      }
+    });
+
+    const rangeFilterNodeReverse = FilterNodeFactory.from({
+      filter: {
+        thanBefore: {
+          '$le': 7,
+          '$ge': 5
+        }
+      }
+    });
+    expect(rangeFilterNode.hasSameFilterAs(rangeFilterNodeReverse)).toBeFalsy();
+  });
+
+  it('works with duplicate matchers', () => {
+    const rangeFilterNode = FilterNodeFactory.from({
+      filter: {
+        aFieldId: {
+          '$eq': 5,
+          '$eq': 5,
+          '$le': 7
+        }
+      }
+    });
+
+    const rangeFilterNodeReverse = FilterNodeFactory.from({
+      filter: {
+        aFieldId: {
+          '$eq': 5,
+          '$le': 7,
+          '$le': 7
+        }
+      }
+    });
+    expect(rangeFilterNode.hasSameFilterAs(rangeFilterNodeReverse)).toBeTruthy();
+  });
+});

--- a/tests/ui/components/results/resultsheadercomponent.js
+++ b/tests/ui/components/results/resultsheadercomponent.js
@@ -13,9 +13,9 @@ describe('ResultsHeaderComponent\'s applied filters', () => {
   let remove_f0_v0_fn, remove_f0_v1_fn, remove_f1_v0_fn, remove_f1_v1_fn;
   let COMPONENT_MANAGER = mockManager(
     {
-      getStaticFilterNodes: () => [],
-      getFacetFilterNodes: () => [],
-      getLocationRadiusFilterNode: () => null
+      filterRegistry: {
+        getAllFilterNodes: () => []
+      }
     },
     ResultsHeaderComponent.defaultTemplateName()
   );
@@ -99,7 +99,7 @@ describe('ResultsHeaderComponent\'s applied filters', () => {
     expect(groupedFilters['name1']).toHaveLength(2);
   });
 
-  it('irremovable filter nodes come first, and removable: false by default', () => {
+  it('nlp filter nodes that are duplicates are removed', () => {
     const appliedFilterNodes = [ node_f0_v0, node_f1_v0 ];
     const nlpFilterNodes = [ node_f0_v0, node_f0_v1, node_f1_v0 ];
     resultsHeaderComponent.appliedFilterNodes = appliedFilterNodes;
@@ -108,21 +108,15 @@ describe('ResultsHeaderComponent\'s applied filters', () => {
     expect(Object.keys(groupedFilters)).toHaveLength(2);
     expect(groupedFilters['name0']).toEqual([
       {
-        displayValue: 'display0'
-      },
-      {
-        displayValue: 'display1'
-      },
-      {
         displayValue: 'display0',
         dataFilterId: 0,
         removable: false
+      },
+      {
+        displayValue: 'display1'
       }
     ]);
     expect(groupedFilters['name1']).toEqual([
-      {
-        displayValue: 'display0'
-      },
       {
         displayValue: 'display0',
         dataFilterId: 1,
@@ -169,23 +163,21 @@ describe('ResultsHeaderComponent\'s applied filters', () => {
     const verticalSearchFn = jest.fn();
     COMPONENT_MANAGER = mockManager(
       {
-        getStaticFilterNodes: () => [],
-        getFacetFilterNodes: () => [],
-        getLocationRadiusFilterNode: () => null,
-        verticalSearch: verticalSearchFn
+        verticalSearch: verticalSearchFn,
+        filterRegistry: {
+          getAllFilterNodes: () => [ node_f0_v0, node_f0_v1, node_f1_v0 ]
+        }
       },
       ResultsHeaderComponent.defaultTemplateName()
     );
 
     // Initialize and mount component
-    const simpleFilterNodes = [ node_f0_v0, node_f0_v1, node_f1_v0 ];
     resultsHeaderComponent = COMPONENT_MANAGER.create('ResultsHeader', {
       container: '#test-component',
       removable: true,
       verticalKey: 'a vertical key',
       data: {
-        appliedFilterNodes: simpleFilterNodes,
-        nlpFilterNodes: []
+        nlpFilters: []
       }
     });
     const wrapper = mount(resultsHeaderComponent);


### PR DESCRIPTION
# Version 1.4.1

## Fixes

* Css variables are now correctly ponyfilled on IE11 when using the SDK through a CDN link pinned to a patch version, like v1.4.0. This was not an issue for experiences pinned to a major or minor version of the SDK (e.g. v1 or v1.4).

* ANSWERS.init()'s onReady() function will no longer fire twice if it fails the first time.

* VerticalResults header now hides NLP filters that are duplicates of another applied filter.

* UniversalResults now supports the legacy changeFiltersText configuration option.

## Styling Fixes

* Facets with searchable: true were displaying two close buttons on IE11, one being the built-in IE11 close button for <input> elements and the other being our custom close button. We think ours is much prettier, so we've disabled the IE11 one.

* FilterOptions' caret icon for expanding and collapsing FilterOptions is now set to 12px by 12px instead of 1em by 1em.

* QASubmission's background-color is now set to white instead of being unset.

* Pagination will no longer apply a special background-color to the active page button when there is only one visible page button. It will now inherit its background-color from its parent element.

* yxt-Results-title now uses the preexisting --yxt-results-title-bar-* css variables for better backwards compatibility.