### PR TITLE
Facets/FilterOptions: match old behavior with persistent storage

### DIFF
--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -159,46 +159,41 @@ class FilterOptionsConfig {
       }
     }
     // previousOptions will be null if there were no previousOptions in persistentStorage
-    const previousOptions = config.previousOptions;
-    this.options = this.setSelectedOptions(this.options, previousOptions);
+    this.previousOptions = config.previousOptions;
+    this.options = this.setSelectedOptions(this.options);
   }
 
   /**
-   * Sets selected options on load based on options stored in persistent storage and options with selected: true.
-   * If no previous options were stored in persistentStorage, default to options marked
-   * as selected. If multiple options are marked as selected for 'singleoption', only the
-   * first should be selected.
+   * Marks selected options as selected: true.
    * @param {Array<Object>} options
    * @param {Array<string>} previousOptions
    * @returns {Array<Object>}
    */
-  setSelectedOptions (options, previousOptions) {
-    if (previousOptions && this.control === 'singleoption') {
-      let hasSeenSelectedOption = false;
-      return options.map(o => {
-        if (previousOptions.includes(o.label) && !hasSeenSelectedOption) {
-          hasSeenSelectedOption = true;
-          return { ...o, selected: true };
-        }
-        return { ...o, selected: false };
-      });
-    } else if (previousOptions && this.control === 'multioption') {
-      return options.map(o => ({
-        ...o,
-        selected: previousOptions.includes(o.label)
-      }));
-    } else if (this.control === 'singleoption') {
-      let hasSeenSelectedOption = false;
-      return options.map(o => {
-        if (hasSeenSelectedOption) {
-          return { ...o, selected: false };
-        } else if (o.selected) {
-          hasSeenSelectedOption = true;
-        }
-        return { ...o };
-      });
+  setSelectedOptions (options) {
+    let alreadySelected = false;
+    return options.map(o => {
+      o = { ...o, selected: this.optionIsSelected(o, alreadySelected) };
+      alreadySelected = alreadySelected || o.selected;
+      return o;
+    });
+  }
+
+  /**
+   * Whether a given option should be set to selected: true.
+   * @param {Object} o the given option
+   * @param {boolean} alreadySelected whether there is already a selected option
+   * @return {boolean}
+   */
+  optionIsSelected (o, alreadySelected) {
+    if (this.control === 'singleoption' && alreadySelected) {
+      return false;
     }
-    return options;
+    if (this.previousOptions) {
+      const isPreviousOption = this.previousOptions.includes(o.label);
+      const isDynamicallySelected = this.isDynamic && o.selected;
+      return isPreviousOption || isDynamicallySelected;
+    }
+    return o.selected;
   }
 
   getInitialSelectedCount () {


### PR DESCRIPTION
pre v1.4.0 version of the SDK had Facets behavior where FilterOptions
would store checked off options in the url, and on page load these
previously stored options would be used to check off options, but
would not prohibit any options marked as selected from the backend
from being checked.

The Facets component marks options as selected using a selected flag
within FilterOptions' config. As part of v1.4.0 this config was turned
into a public interface, with specification that it would be used to
check off options ONLY if none were stored in the url. This is different
from the previous Facets behavior.

This was fixed by adding additional isDynamic logic to FilterOptions
when setting previously selected options that matches the old logic in https://github.com/yext/answers/blob/v0.12.2/src/ui/components/filters/filteroptionscomponent.js.

note: since the this.name of a FilterOptions used in a Facets depends on
it's index in the Facets, and since this order depends on the query
(e.g. a query with "Consulting" might only show 4 Facets, and have the Awards Facet
as the 4th one, while a blank search might have it as the 11th one). This causes
behavior where if you select a facet, run a search that changes the order/length
of facets, then select another facet, since refreshing the page uses the first
set of facets not the second, the previously selected facets will not be
selected on page refresh. This is consistent with pre v1.4.0 and is a separate issue.

TEST=manual
test that reported bug is fixed
- search for 'Consulting', see that facet is checked off and removable filter tag
is displayed. Uncheck 'Consulting' facet, refresh the page. Previously, the 'Consulting'
facet would no longer be checked, now it is. The removable filter tag is also displayed.

test that we match 0.12.2 behavior
- In a filterbox filtering on c_awards, select 'Roses Friend', apply filters. Select filterbox's
'Pres Club', apply filters. See that Roses Friend and Presidents Club facets are checked off
Refresh page, only see Roses Friend facet is checked off. (See note above)
- Select 'Pres Club' in filterbox, apply filters. Select 'Roses Friend' in filterbox, apply filters.
See that both Roses Friend and Presidents Club facets are checked off.
Refresh page, see that both Roses Friend and Presidents Club facets are checked off.