### PR TITLE
Remove default parameter in getTabUrl in navigation component

### DIFF
--- a/src/ui/components/navigation/navigationcomponent.js
+++ b/src/ui/components/navigation/navigationcomponent.js
@@ -457,7 +457,7 @@ export default class NavigationComponent extends Component {
     return tabOrder;
   }
 
-  generateTabUrl (baseUrl, params = new URLSearchParams()) {
+  generateTabUrl (baseUrl, params) {
     // We want to persist the params from the existing URL to the new
     // URLS we create.
     params.set('tabOrder', this._tabOrder);

--- a/tests/ui/components/navigation/navigationcomponent.js
+++ b/tests/ui/components/navigation/navigationcomponent.js
@@ -233,7 +233,7 @@ describe('navigation component configuration', () => {
       core: mockedCore(tabConfig)
     });
 
-    const url = navComponent.generateTabUrl(tabConfig[0].url);
+    const url = navComponent.generateTabUrl(tabConfig[0].url, navComponent.getUrlParams());
     expect(url).toEqual('/tab1/?tabOrder=tab1');
   });
 });


### PR DESCRIPTION
Remove default value for params parameter in getTabUrl in navigationcomponent.js and updated test that checks if tab url can be generated without params. The default value was added to fix a bug where the nav links had empty href's on the landing page, but got populated after submitting a query. We don't need the default value anymore as params in the calls to getTabUrl are given a value.

J=SPR-2518

TEST=manual

Tested on local site by making sure site can build and functions work properly.
