### PR TITLE
Add referrerPageUrl to the query endpoint requests and persistentstorage

### DIFF
--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -32,6 +32,7 @@ import { SANDBOX, PRODUCTION } from './core/constants';
 import MasterSwitchApi from './core/utils/masterswitchapi';
 import RichTextFormatter from './core/utils/richtextformatter';
 import { isValidContext } from './core/utils/apicontext';
+import { urlWithoutQueryParamsAndHash } from './core/utils/urlutils';
 
 /** @typedef {import('./core/services/searchservice').default} SearchService */
 /** @typedef {import('./core/services/autocompleteservice').default} AutoCompleteService */
@@ -167,6 +168,12 @@ class Answers {
       persistentStorage.delete(StorageKeys.API_CONTEXT, true);
       globalStorage.delete(StorageKeys.API_CONTEXT);
       console.error(`Context parameter "${context}" is invalid, omitting from the search.`);
+    }
+
+    if (globalStorage.getState(StorageKeys.REFERRER_PAGE_URL) === null) {
+      const referrer = urlWithoutQueryParamsAndHash(document.referrer);
+      persistentStorage.set(StorageKeys.REFERRER_PAGE_URL, referrer, true);
+      globalStorage.set(StorageKeys.REFERRER_PAGE_URL, referrer);
     }
 
     this._masterSwitchApi = statusPage

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -169,7 +169,8 @@ export default class Core {
         sessionTrackingEnabled: this.globalStorage.getState(StorageKeys.SESSIONS_OPT_IN),
         sortBys: this.globalStorage.getState(StorageKeys.SORT_BYS),
         locationRadius: locationRadiusFilterNode ? locationRadiusFilterNode.getFilter().value : null,
-        context: this.globalStorage.getState(StorageKeys.API_CONTEXT)
+        context: this.globalStorage.getState(StorageKeys.API_CONTEXT),
+        referrerPageUrl: this.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL)
       })
       .then(response => SearchDataTransformer.transformVertical(response, this._fieldFormatters, verticalKey))
       .then(data => {
@@ -237,7 +238,8 @@ export default class Core {
         skipSpellCheck: this.globalStorage.getState('skipSpellCheck'),
         queryTrigger: this.globalStorage.getState('queryTrigger'),
         sessionTrackingEnabled: this.globalStorage.getState(StorageKeys.SESSIONS_OPT_IN),
-        context: this.globalStorage.getState(StorageKeys.API_CONTEXT)
+        context: this.globalStorage.getState(StorageKeys.API_CONTEXT),
+        referrerPageUrl: this.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL)
       })
       .then(response => SearchDataTransformer.transform(response, urls, this._fieldFormatters))
       .then(data => {

--- a/src/core/search/searchapi.js
+++ b/src/core/search/searchapi.js
@@ -66,7 +66,7 @@ export default class SearchApi {
   }
 
   /** @inheritdoc */
-  verticalSearch (verticalKey, { input, filter, facetFilter, limit, offset, id, geolocation, isDynamicFiltersEnabled, skipSpellCheck, queryTrigger, sessionTrackingEnabled, sortBys, locationRadius, context }) {
+  verticalSearch (verticalKey, { input, filter, facetFilter, limit, offset, id, geolocation, isDynamicFiltersEnabled, skipSpellCheck, queryTrigger, sessionTrackingEnabled, sortBys, locationRadius, context, referrerPageUrl }) {
     if (limit > 50) {
       throw new AnswersCoreError('Provided search limit unsupported', 'SearchApi');
     }
@@ -93,7 +93,8 @@ export default class SearchApi {
         'sessionTrackingEnabled': sessionTrackingEnabled,
         'sortBys': sortBys,
         'locationRadius': locationRadius,
-        'context': context
+        'context': context,
+        'referrerPageUrl': referrerPageUrl
       }
     };
     let request = new ApiRequest(requestConfig, { getState: () => sessionTrackingEnabled });
@@ -117,7 +118,8 @@ export default class SearchApi {
         'locale': this._locale,
         'skipSpellCheck': params.skipSpellCheck,
         'queryTrigger': params.queryTrigger,
-        'context': params.context
+        'context': params.context,
+        'referrerPageUrl': params.referrerPageUrl
       }
     };
     let request = new ApiRequest(requestConfig, { getState: () => params.sessionTrackingEnabled });

--- a/src/core/storage/storagekeys.js
+++ b/src/core/storage/storagekeys.js
@@ -34,5 +34,6 @@ export default {
   NO_RESULTS_CONFIG: 'no-results-config',
   LOCATION_RADIUS: 'location-radius',
   RESULTS_HEADER: 'results-header',
-  API_CONTEXT: 'context'
+  API_CONTEXT: 'context',
+  REFERRER_PAGE_URL: 'referrerPageUrl'
 };

--- a/src/core/utils/urlutils.js
+++ b/src/core/utils/urlutils.js
@@ -55,3 +55,7 @@ export function addParamsToUrl (url, params = {}) {
   }
   return url.split('?')[0] + '?' + urlParams;
 }
+
+export function urlWithoutQueryParamsAndHash (url) {
+  return url.split('?')[0].split('#')[0];
+}

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -241,7 +241,10 @@ export default class VerticalResultsComponent extends Component {
     const verticalConfig = this._verticalsConfig.find(config => config.verticalKey === this.verticalKey) || {};
     const verticalURL = this._config.verticalURL || verticalConfig.url || data.verticalURL || this.verticalKey + '.html';
 
-    const params = { query: this.query };
+    const params = {
+      query: this.query,
+      referrerPageUrl: this.core.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL)
+    };
     const context = this.core.globalStorage.getState(StorageKeys.API_CONTEXT);
     if (context) {
       params.context = context;

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -414,6 +414,9 @@ export default class SearchComponent extends Component {
     // If we have a redirectUrl, we want the form to be
     // serialized and submitted.
     if (typeof this.redirectUrl === 'string') {
+      if (params.has(StorageKeys.REFERRER_PAGE_URL)) {
+        params.delete(StorageKeys.REFERRER_PAGE_URL);
+      }
       window.location.href = this.redirectUrl + '?' + params.toString();
       return false;
     }

--- a/tests/ui/components/results/verticalresultscomponent.js
+++ b/tests/ui/components/results/verticalresultscomponent.js
@@ -15,6 +15,8 @@ const mockCore = {
         return {};
       } else if (storageKey === StorageKeys.API_CONTEXT) {
         return undefined;
+      } else if (storageKey === StorageKeys.REFERRER_PAGE_URL) {
+        return '';
       }
     }
   },
@@ -125,7 +127,7 @@ describe('vertical results component', () => {
     });
 
     it('if unset defaults to vertical key', () => {
-      expect(component.getVerticalURL()).toEqual('key.html?query=my-query&otherParam=123');
+      expect(component.getVerticalURL()).toEqual('key.html?query=my-query&otherParam=123&referrerPageUrl=');
     });
 
     it('if null defaults to vertical key', () => {
@@ -134,13 +136,13 @@ describe('vertical results component', () => {
       });
       component.query = 'my-query';
       component.verticalKey = 'key';
-      expect(component.getVerticalURL()).toEqual('key.html?query=my-query&otherParam=123');
+      expect(component.getVerticalURL()).toEqual('key.html?query=my-query&otherParam=123&referrerPageUrl=');
     });
 
     it('works with transformData', () => {
       expect(component.getVerticalURL({
         verticalURL: 'transform-data'
-      })).toEqual('transform-data?query=my-query&otherParam=123');
+      })).toEqual('transform-data?query=my-query&otherParam=123&referrerPageUrl=');
     });
 
     it('defaults to matching config in verticalPages', () => {
@@ -148,7 +150,7 @@ describe('vertical results component', () => {
         verticalKey: 'key',
         url: 'vertical-pages'
       }];
-      expect(component.getVerticalURL()).toEqual('vertical-pages?query=my-query&otherParam=123');
+      expect(component.getVerticalURL()).toEqual('vertical-pages?query=my-query&otherParam=123&referrerPageUrl=');
     });
 
     it('can be set', () => {
@@ -157,7 +159,7 @@ describe('vertical results component', () => {
       });
       component.query = 'my-query';
       component.verticalKey = 'key';
-      expect(component.getVerticalURL()).toEqual('vertical-url?query=my-query&otherParam=123');
+      expect(component.getVerticalURL()).toEqual('vertical-url?query=my-query&otherParam=123&referrerPageUrl=');
     });
   });
 });


### PR DESCRIPTION
We add the referrerPageUrl as part of the query endpoint requests to
support query rules in the Answers backend. The URL of the current page
is the source of truth for this parameter. We make three changes to
support this:

* On ANSWERS.init, look at the current URL in persistent storage to get
  the initial value of referrerPageUrl.
* If there is no referrerPageUrl query param already, source it from
  document.referrer of the current page.
* Change the view more link to include referrerPageUrl in the
  navigation.

Note: This makes it such that referrerPageUrl is a query parameter that
is always on the page. This is because referrerPageUrl is determined
when the page loads and is added as a query parameter to maintain the
parameter as you navigate within the experience.

When we redirect, we do not want to passthrough the referrerPageUrl
query param of the page with the redirectUrl search bar.

To ground in an example
Page X: initial page, navigate to Page Y
Page Y: contains a searchbar with redirectUrl, redirects to Page Z
Page Z: our answers experience

The referrerPageUrl of Z is currently X instead of Y because redirectUrl
passes all query params from page Y and page Y generates referrerPageUrl
on ANSWERS.init.

J=SPR-2452
TEST=manual

Test entry of page with URL param referrerPageUrl already set.

Test all search requests contain the referrerPageUrl in the request.

Test works when navigating to an answers page from a standalone page.
Add link to a standalone page to an answers root page. Click the link. Make sure
referrerPageUrl is the original standalone page.

Test as you navigate through the experience, the referrerPageUrl is
carried
 * Change filters
 * Navigation tabs
 * Alternative verticals
 * View more button

Test works in an iFrame, as you navigate within an iFrame, the
referrerPageUrl persists.

* Do not default document.referrer, check if exists before setting so we do not block ANSWERS.init

* semistandard, && at end of line

* Assume document.referrer always exists, error if it does not

Test on a QA site with a searchbar that redirects to a site. Make sure
the site has referrerPageUrl in the query params already. Make sure
that the referrerPageUrl of the resulting answers page has
referrerPageUrl as the QA site, not the value of the QA site's
referrerPageUrl.