### PR TITLE
Fix empty search behavior when searchbar is initialized with redirectURL

### DIFF
--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -414,9 +414,11 @@ export default class SearchComponent extends Component {
 
     // If we have a redirectUrl, we want the form to be
     // serialized and submitted.
-    if (typeof this.redirectUrl === 'string') {
-      window.location.href = this.redirectUrl + '?' + params.toString();
-      return false;
+    if (typeof this.redirectUrl === 'string' && this._verticalKey) {
+      if (this._allowEmptySearch || query) {
+        window.location.href = this.redirectUrl + '?' + params.toString();
+        return false;
+      }
     }
 
     inputEl.blur();


### PR DESCRIPTION
Fix behavior of empty search when redirect url is provided. Previously, when a searchBar is initialized with a redirectUrl param, it's possible to submit an empty search. Now, if it's a search bar for a vertical search (verticalKey has been included), we use the allowEmptySearch boolean to control empty search behavior. If it's a search bar for a universal search, an empty search is not be allowed.

J=SPR-2470

TEST=manual

Tested on local site. Tested behavior when search is empty/not empty, verticalKey is included/not included and when allowEmptySearch is true/false.