### PR TITLE
SearchBar: add yxt-SearchBar-AnimatedIcon class w/display: flex

### DIFF
--- a/src/ui/sass/modules/_SearchBar.scss
+++ b/src/ui/sass/modules/_SearchBar.scss
@@ -174,6 +174,11 @@ $searchbar-button-text-color-active: var(--yxt-searchbar-button-text-color-base)
     }
   }
 
+  &-AnimatedIcon
+  {
+    display: flex;
+  }
+
   &-AnimatedIcon--inactive svg
   {
     display: none;

--- a/src/ui/templates/search/search.hbs
+++ b/src/ui/templates/search/search.hbs
@@ -49,12 +49,12 @@
           data-opts='{ "iconUrl": "{{_config.customIconUrl}}" }'
       ></div>
     {{else}}
-      <div class="js-yxt-AnimatedForward yxt-SearchBar-AnimatedIcon--paused
+      <div class="yxt-SearchBar-AnimatedIcon js-yxt-AnimatedForward yxt-SearchBar-AnimatedIcon--paused
         {{#if autoFocus}} yxt-SearchBar-AnimatedIcon--inactive{{/if}}"
         data-component="IconComponent"
         data-opts="{{json forwardIconOpts}}">
       </div>
-      <div class="js-yxt-AnimatedReverse yxt-SearchBar-AnimatedIcon--paused
+      <div class="yxt-SearchBar-AnimatedIcon js-yxt-AnimatedReverse yxt-SearchBar-AnimatedIcon--paused
         {{#unless autoFocus}} yxt-SearchBar-AnimatedIcon--inactive{{/unless}}"
         data-component="IconComponent"
         data-opts="{{json reverseIconOpts}}">

--- a/src/ui/templates/search/search.hbs
+++ b/src/ui/templates/search/search.hbs
@@ -49,12 +49,12 @@
           data-opts='{ "iconUrl": "{{_config.customIconUrl}}" }'
       ></div>
     {{else}}
-      <div class="yxt-SearchBar-AnimatedIcon js-yxt-AnimatedForward yxt-SearchBar-AnimatedIcon--paused
+      <div class="yxt-SearchBar-AnimatedIcon yxt-SearchBar-AnimatedIcon--paused js-yxt-AnimatedForward
         {{#if autoFocus}} yxt-SearchBar-AnimatedIcon--inactive{{/if}}"
         data-component="IconComponent"
         data-opts="{{json forwardIconOpts}}">
       </div>
-      <div class="yxt-SearchBar-AnimatedIcon js-yxt-AnimatedReverse yxt-SearchBar-AnimatedIcon--paused
+      <div class="yxt-SearchBar-AnimatedIcon yxt-SearchBar-AnimatedIcon--paused js-yxt-AnimatedReverse
         {{#unless autoFocus}} yxt-SearchBar-AnimatedIcon--inactive{{/unless}}"
         data-component="IconComponent"
         data-opts="{{json reverseIconOpts}}">


### PR DESCRIPTION
Below from the jira ticket:

> https://www.screencast.com/t/M340mRJKD0D.
Add a new class to the animated icon that can be used to target styling
(right now we just have js-yxt-AnimatedReverse component
Add display: flex; to this newly added class by default.
See here for further information and context (Chris came up with the original solution)
Note: The search bar icon appears centered when you use the SDK directly
– drives me truly nuts I can’t figure this out 😱  
I don’t think it hurts to have this styling in the SDK by default (doesn’t seem to impact anything)
but definitely let me know if not

J=SPR-2558
TEST=manual
test that animated icon has new css class, which has display: flex attached to it
check that the icon out of the box does not look different