### PR TITLE
UniversalResults: only default verticalURL inside VerticalResults

### DIFF
--- a/src/ui/components/results/universalresultscomponent.js
+++ b/src/ui/components/results/universalresultscomponent.js
@@ -63,7 +63,7 @@ export default class UniversalResultsComponent extends Component {
       // Icon in the titlebar
       icon: config.sectionTitleIconName || config.sectionTitleIconUrl || 'star',
       // Url that links to the vertical search for this vertical.
-      verticalURL: 'url' in config ? config.url : verticalKey + '.html',
+      verticalURL: config.url,
       // Show a view more link by default, which also links to verticalURL.
       viewMore: true,
       // By default, the view more link has a label of 'View More'.


### PR DESCRIPTION
Defaulting occurs in VerticalResults already, because this defaulting was occurring
before the defaulting in VerticalResults, none of the VerticalResults defaults were
being applied, preventing it from trying to default to a matching value in the global
VerticalPages config before <verticalKey>.html.

J=SPR-2559
TEST=manual

Test that the view more url will default to a matching entry in
verticalPages before defaulting to \<verticalKey\>.html