### PR TITLE
Fix null setState on setContext in navigation and universal results

### DIFF
--- a/src/ui/components/navigation/navigationcomponent.js
+++ b/src/ui/components/navigation/navigationcomponent.js
@@ -182,7 +182,7 @@ export default class NavigationComponent extends Component {
     this.checkMobileOverflowBehavior = this.checkMobileOverflowBehavior.bind(this);
 
     this.core.globalStorage.on('update', StorageKeys.API_CONTEXT, () => {
-      this.setState(this.core.globalStorage.getState(StorageKeys.NAVIGATION));
+      this.setState(this.core.globalStorage.getState(StorageKeys.NAVIGATION) || {});
     });
   }
 

--- a/src/ui/components/results/universalresultscomponent.js
+++ b/src/ui/components/results/universalresultscomponent.js
@@ -13,7 +13,7 @@ export default class UniversalResultsComponent extends Component {
     this.moduleId = StorageKeys.UNIVERSAL_RESULTS;
 
     this.core.globalStorage.on('update', StorageKeys.API_CONTEXT, () => {
-      this.setState(this.core.globalStorage.getState(StorageKeys.UNIVERSAL_RESULTS));
+      this.setState(this.core.globalStorage.getState(StorageKeys.UNIVERSAL_RESULTS) || {});
     });
   }
 


### PR DESCRIPTION
When on a universal results or any page with a navigation bar when there
is no query, if you ran ANSWERS.setContext, then you would get errors
like

```
Cannot read property 'tabOrder' of null
```

This is because universal results and navigation do not exist in
globalStorage until a search has been executed. Default to {} instead of
allowing null in setState.

Note: This update listener is also in AlternativeVerticals but we do not
need to worry about this because it is assumed global storage state will
be populated by a search. This affects Navigation and Universal Results
when there is no search.

J=SPR-2554
TEST=manual

Verify ANSWERS.setContext on a no-query Universal Results Page, Vertical
Results Page doesn't show an error

Verify ANSWERS.setContext on a queried Universal Results Page, Vertical
Results Page doesn't show an error

Verify context is still added to the URLs in Navigation, Alternative
Verticals, View More and included in subsequent API
calls.

Land on page with context in the URL. Verify all above.