### PR TITLE
query rules: Set persistentStorage on search instead of on init or setContext

### DIFF
--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -177,9 +177,10 @@ class Answers {
     }
 
     if (globalStorage.getState(StorageKeys.REFERRER_PAGE_URL) === null) {
-      const referrer = urlWithoutQueryParamsAndHash(document.referrer);
-      persistentStorage.set(StorageKeys.REFERRER_PAGE_URL, referrer, true);
-      globalStorage.set(StorageKeys.REFERRER_PAGE_URL, referrer);
+      globalStorage.set(
+        StorageKeys.REFERRER_PAGE_URL,
+        urlWithoutQueryParamsAndHash(document.referrer)
+      );
     }
 
     this._masterSwitchApi = statusPage
@@ -476,7 +477,6 @@ class Answers {
       return;
     }
 
-    this.core.persistentStorage.set(StorageKeys.API_CONTEXT, contextString, true);
     this.core.globalStorage.set(StorageKeys.API_CONTEXT, contextString);
   }
 }

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -144,6 +144,19 @@ export default class Core {
       this.filterRegistry.setFacetFilterNodes([], []);
     }
 
+    const { setQueryParams } = options;
+    const context = this.globalStorage.getState(StorageKeys.API_CONTEXT);
+    const referrerPageUrl = this.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL);
+
+    if (setQueryParams) {
+      if (context) {
+        this.persistentStorage.set(StorageKeys.API_CONTEXT, context, true);
+      }
+      if (referrerPageUrl !== null) {
+        this.persistentStorage.set(StorageKeys.REFERRER_PAGE_URL, referrerPageUrl, true);
+      }
+    }
+
     const searchConfig = this.globalStorage.getState(StorageKeys.SEARCH_CONFIG) || {};
     if (!searchConfig.verticalKey) {
       this.globalStorage.set(StorageKeys.SEARCH_CONFIG, {
@@ -169,8 +182,8 @@ export default class Core {
         sessionTrackingEnabled: this.globalStorage.getState(StorageKeys.SESSIONS_OPT_IN),
         sortBys: this.globalStorage.getState(StorageKeys.SORT_BYS),
         locationRadius: locationRadiusFilterNode ? locationRadiusFilterNode.getFilter().value : null,
-        context: this.globalStorage.getState(StorageKeys.API_CONTEXT),
-        referrerPageUrl: this.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL)
+        context: context,
+        referrerPageUrl: referrerPageUrl
       })
       .then(response => SearchDataTransformer.transformVertical(response, this._fieldFormatters, verticalKey))
       .then(data => {
@@ -220,12 +233,25 @@ export default class Core {
    * @param {string} verticalKey The vertical key to use in the search
    */
   verticalPage (verticalKey) {
-    this.verticalSearch(verticalKey, { useFacets: true }, {
+    this.verticalSearch(verticalKey, { useFacets: true, setQueryParams: true }, {
       id: this.globalStorage.getState(StorageKeys.QUERY_ID)
     });
   }
 
-  search (queryString, urls) {
+  search (queryString, urls, options = {}) {
+    const { setQueryParams } = options;
+    const context = this.globalStorage.getState(StorageKeys.API_CONTEXT);
+    const referrerPageUrl = this.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL);
+
+    if (setQueryParams) {
+      if (context) {
+        this.persistentStorage.set(StorageKeys.API_CONTEXT, context);
+      }
+      if (referrerPageUrl !== null) {
+        this.persistentStorage.set(StorageKeys.REFERRER_PAGE_URL, referrerPageUrl);
+      }
+    }
+
     this.globalStorage.set(StorageKeys.DIRECT_ANSWER, {});
     this.globalStorage.set(StorageKeys.UNIVERSAL_RESULTS, UniversalResults.searchLoading());
     this.globalStorage.set(StorageKeys.QUESTION_SUBMISSION, {});
@@ -238,8 +264,8 @@ export default class Core {
         skipSpellCheck: this.globalStorage.getState('skipSpellCheck'),
         queryTrigger: this.globalStorage.getState('queryTrigger'),
         sessionTrackingEnabled: this.globalStorage.getState(StorageKeys.SESSIONS_OPT_IN),
-        context: this.globalStorage.getState(StorageKeys.API_CONTEXT),
-        referrerPageUrl: this.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL)
+        context: context,
+        referrerPageUrl: referrerPageUrl
       })
       .then(response => SearchDataTransformer.transform(response, urls, this._fieldFormatters))
       .then(data => {

--- a/src/core/utils/urlutils.js
+++ b/src/core/utils/urlutils.js
@@ -59,3 +59,21 @@ export function addParamsToUrl (url, params = {}) {
 export function urlWithoutQueryParamsAndHash (url) {
   return url.split('?')[0].split('#')[0];
 }
+
+/**
+ * returns if two SearchParams objects have the same key,value entries
+ * @param {SearchParams} params1
+ * @param {SearchParams} params2
+ * @return {boolean} true if params1 and params2 have the same key,value entries, false otherwise
+ */
+export function equivalentParams (params1, params2) {
+  if (params1.entries().length !== params2.entries().length) {
+    return false;
+  }
+  for (const [key, val] of params1.entries()) {
+    if (val !== params2.get(key)) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/src/ui/components/filters/filterboxcomponent.js
+++ b/src/ui/components/filters/filterboxcomponent.js
@@ -289,6 +289,7 @@ export default class FilterBoxComponent extends Component {
    */
   _search () {
     this.core.verticalSearch(this._config.verticalKey, {
+      setQueryParams: true,
       resetPagination: true,
       useFacets: true
     });

--- a/src/ui/components/filters/geolocationcomponent.js
+++ b/src/ui/components/filters/geolocationcomponent.js
@@ -288,6 +288,7 @@ export default class GeoLocationComponent extends Component {
 
     if (this._config.searchOnChange) {
       this.core.verticalSearch(this._config.verticalKey, {
+        setQueryParams: true,
         resetPagination: true,
         useFacets: true
       });

--- a/src/ui/components/filters/sortoptionscomponent.js
+++ b/src/ui/components/filters/sortoptionscomponent.js
@@ -128,6 +128,7 @@ export default class SortOptionsComponent extends Component {
    */
   _search () {
     this.core.verticalSearch(this._config.verticalKey, {
+      setQueryParams: true,
       resetPagination: true,
       useFacets: true
     });

--- a/src/ui/components/navigation/navigationcomponent.js
+++ b/src/ui/components/navigation/navigationcomponent.js
@@ -338,11 +338,7 @@ export default class NavigationComponent extends Component {
     for (let i = 0; i < this._tabOrder.length; i++) {
       let tab = this._tabs[this._tabOrder[i]];
       if (tab !== undefined) {
-        tab.url = this.generateTabUrl(
-          tab.baseUrl,
-          this.getUrlParams(),
-          this.core.globalStorage.getState(StorageKeys.API_CONTEXT)
-        );
+        tab.url = this.generateTabUrl(tab.baseUrl, this.getUrlParams());
         tabs.push(tab);
       }
     }
@@ -465,9 +461,14 @@ export default class NavigationComponent extends Component {
     return tabOrder;
   }
 
-  generateTabUrl (baseUrl, params, context) {
+  generateTabUrl (baseUrl, params) {
+    const context = this.core.globalStorage.getState(StorageKeys.API_CONTEXT);
     if (context) {
       params.set(StorageKeys.API_CONTEXT, context);
+    }
+    const referrerPageUrl = this.core.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL);
+    if (referrerPageUrl !== null) {
+      params.set(StorageKeys.REFERRER_PAGE_URL, referrerPageUrl);
     }
 
     // We want to persist the params from the existing URL to the new

--- a/src/ui/components/results/alternativeverticalscomponent.js
+++ b/src/ui/components/results/alternativeverticalscomponent.js
@@ -41,7 +41,8 @@ export default class AlternativeVerticalsComponent extends Component {
     this.verticalSuggestions = AlternativeVerticalsComponent._buildVerticalSuggestions(
       this._alternativeVerticals,
       this._verticalsConfig,
-      this.core.globalStorage.getState(StorageKeys.API_CONTEXT)
+      this.core.globalStorage.getState(StorageKeys.API_CONTEXT),
+      this.core.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL)
     );
 
     /**
@@ -60,7 +61,8 @@ export default class AlternativeVerticalsComponent extends Component {
       this.verticalSuggestions = AlternativeVerticalsComponent._buildVerticalSuggestions(
         this._alternativeVerticals,
         this._verticalsConfig,
-        this.core.globalStorage.getState(StorageKeys.API_CONTEXT)
+        this.core.globalStorage.getState(StorageKeys.API_CONTEXT),
+        this.core.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL)
       );
       this.setState(this.core.globalStorage.getState(StorageKeys.ALERNATIVE_VERTICALS));
     });
@@ -106,13 +108,18 @@ export default class AlternativeVerticalsComponent extends Component {
    * from alternative verticals and verticalPages configuration
    * @param {object} alternativeVerticals alternativeVerticals server response
    * @param {object} verticalsConfig the configuration to use
+   * @param {string} context the API context query parameter to add to the urls
+   * @param {string} referrerPageUrl the referrerPageUrl query parameter to add to the urls
    */
-  static _buildVerticalSuggestions (alternativeVerticals, verticalsConfig, context) {
+  static _buildVerticalSuggestions (alternativeVerticals, verticalsConfig, context, referrerPageUrl) {
     let verticals = [];
 
     const params = {};
     if (context) {
       params[StorageKeys.API_CONTEXT] = context;
+    }
+    if (typeof referrerPageUrl === 'string') {
+      params[StorageKeys.REFERRER_PAGE_URL] = referrerPageUrl;
     }
 
     for (let alternativeVertical of alternativeVerticals) {

--- a/src/ui/components/results/resultsheadercomponent.js
+++ b/src/ui/components/results/resultsheadercomponent.js
@@ -81,6 +81,7 @@ export default class ResultsHeaderComponent extends Component {
     const filterNode = this.appliedFilterNodes[filterId];
     filterNode.remove();
     this.core.verticalSearch(this._config.verticalKey, {
+      setQueryParams: true,
       resetPagination: true,
       useFacets: true
     });

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -232,8 +232,13 @@ export default class VerticalResultsComponent extends Component {
     const params = { query: this.query };
     const context = this.core.globalStorage.getState(StorageKeys.API_CONTEXT);
     if (context) {
-      params.context = context;
+      params[StorageKeys.API_CONTEXT] = context;
     }
+    const referrerPageUrl = this.core.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL);
+    if (referrerPageUrl !== null) {
+      params[StorageKeys.REFERRER_PAGE_URL] = referrerPageUrl;
+    }
+
     return addParamsToUrl(universalConfig.url, params);
   }
 

--- a/src/ui/components/search/filtersearchcomponent.js
+++ b/src/ui/components/search/filtersearchcomponent.js
@@ -220,6 +220,7 @@ export default class FilterSearchComponent extends Component {
     }
     window.setTimeout(() => {
       this.core.verticalSearch(this._config.verticalKey, {
+        setQueryParams: true,
         resetPagination: true,
         useFacets: true
       });

--- a/src/ui/components/search/locationbiascomponent.js
+++ b/src/ui/components/search/locationbiascomponent.js
@@ -142,6 +142,7 @@ export default class LocationBiasComponent extends Component {
   _doSearch () {
     if (this._verticalKey) {
       this.core.verticalSearch(this._config.verticalKey, {
+        setQueryParams: true,
         useFacets: true
       });
     } else {

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -411,13 +411,15 @@ export default class SearchComponent extends Component {
     const params = new SearchParams(window.location.search.substring(1));
     params.set('query', query);
 
+    const context = this.core.globalStorage.getState(StorageKeys.API_CONTEXT);
+    if (context) {
+      params.set(StorageKeys.API_CONTEXT, context);
+    }
+
     // If we have a redirectUrl, we want the form to be
     // serialized and submitted.
     if (typeof this.redirectUrl === 'string' && this._verticalKey) {
       if (this._allowEmptySearch || query) {
-        if (params.has(StorageKeys.REFERRER_PAGE_URL)) {
-          params.delete(StorageKeys.REFERRER_PAGE_URL);
-        }
         window.location.href = this.redirectUrl + '?' + params.toString();
         return false;
       }
@@ -544,7 +546,14 @@ export default class SearchComponent extends Component {
    */
   search (query) {
     if (this._verticalKey) {
-      this.core.verticalSearch(this._config.verticalKey, { resetPagination: true }, { input: query });
+      this.core.verticalSearch(
+        this._config.verticalKey,
+        {
+          resetPagination: true,
+          setQueryParams: true
+        },
+        { input: query }
+      );
     } else {
       // NOTE(billy) Temporary hack for DEMO
       // Remove me after the demo
@@ -567,10 +576,10 @@ export default class SearchComponent extends Component {
             urls[tabs[i].configId] = url;
           }
         }
-        return this.core.search(query, urls);
+        return this.core.search(query, urls, { setQueryParams: true });
       }
 
-      return this.core.search(query);
+      return this.core.search(query, undefined, { setQueryParams: true });
     }
   }
 

--- a/src/ui/storage/persistentstorage.js
+++ b/src/ui/storage/persistentstorage.js
@@ -1,5 +1,6 @@
 import SearchParams from '../dom/searchparams';
 import { AnswersStorageError } from '../../core/errors/errors';
+import { equivalentParams } from '../../core/utils/urlutils';
 
 /** @module PersistentStorage */
 
@@ -66,6 +67,11 @@ export default class PersistentStorage {
   }
 
   _updateHistory (replaceHistory = false) {
+    const currentParams = new SearchParams(window.location.search.substring(1));
+    if (equivalentParams(this._params, currentParams)) {
+      return;
+    }
+
     if (this._historyTimer) {
       clearTimeout(this._historyTimer);
     }

--- a/tests/ui/components/navigation/navigationcomponent.js
+++ b/tests/ui/components/navigation/navigationcomponent.js
@@ -109,8 +109,15 @@ describe('navigation component configuration', () => {
     return {
       globalStorage: {
         getState: (storageKey) => {
-          expect(storageKey).toEqual(StorageKeys.VERTICAL_PAGES_CONFIG);
-          return verticalsConfig;
+          switch (storageKey) {
+            case StorageKeys.REFERRER_PAGE_URL:
+              return null;
+            case StorageKeys.API_CONTEXT:
+              return null;
+            default:
+              expect(storageKey).toEqual(StorageKeys.VERTICAL_PAGES_CONFIG);
+              return verticalsConfig;
+          }
         },
         on: () => {}
       }

--- a/tests/ui/components/navigation/navigationcomponent.js
+++ b/tests/ui/components/navigation/navigationcomponent.js
@@ -110,13 +110,10 @@ describe('navigation component configuration', () => {
       globalStorage: {
         getState: (storageKey) => {
           switch (storageKey) {
-            case StorageKeys.REFERRER_PAGE_URL:
-              return null;
-            case StorageKeys.API_CONTEXT:
-              return null;
-            default:
-              expect(storageKey).toEqual(StorageKeys.VERTICAL_PAGES_CONFIG);
+            case StorageKeys.VERTICAL_PAGES_CONFIG:
               return verticalsConfig;
+            default:
+              return null;
           }
         },
         on: () => {}

--- a/tests/ui/components/results/resultsheadercomponent.js
+++ b/tests/ui/components/results/resultsheadercomponent.js
@@ -193,6 +193,7 @@ describe('ResultsHeaderComponent\'s applied filters', () => {
     expect(verticalSearchFn.mock.calls).toHaveLength(1);
     expect(verticalSearchFn.mock.calls[0][0]).toEqual('a vertical key');
     expect(verticalSearchFn.mock.calls[0][1]).toEqual({
+      setQueryParams: true,
       resetPagination: true,
       useFacets: true
     });


### PR DESCRIPTION
Similar to the query, we only set referrerPageUrl or context for the
first time in the URL after a search. This is to mitigate changes to
client subdomains. Before, referrerPageUrl would be added to the URL on
ANSWERS.init, even when the client only had a redirectUrl searchbar.

We change it so that after /any/ search to the API, we update the query
params. A search on universal, vertical, pagination, facets, will all
change the query parameters to any updated values. Note: they are still
available on globalStorage. We are moving the persistentStorage updates.

J=SPR-2554
TEST=manual

Test a searchbar with a redirectUrl. When searching, the referrerPageUrl
and the context do not show on the URL, only on the redirected URL.

Test that setContext context is not applied on a regular experience
until search or pagination or facet apply (essentially any re-search).

Test that referrerPageUrl is still added to links in navigation, view
more, alternative verticals, even if it is not currently in the URL.