### PR TITLE
Version v1.4.3

### DIFF
--- a/src/ui/components/results/universalresultscomponent.js
+++ b/src/ui/components/results/universalresultscomponent.js
@@ -63,7 +63,7 @@ export default class UniversalResultsComponent extends Component {
       // Icon in the titlebar
       icon: config.sectionTitleIconName || config.sectionTitleIconUrl || 'star',
       // Url that links to the vertical search for this vertical.
-      verticalURL: 'url' in config ? config.url : verticalKey + '.html',
+      verticalURL: config.url,
       // Show a view more link by default, which also links to verticalURL.
       viewMore: true,
       // By default, the view more link has a label of 'View More'.


### PR DESCRIPTION
# Version 1.4.3

## Fixes

* UniversalResults' "view more" and "change filters" links, for a specific verticalKey, now correctly default to the verticalPages url for that verticalKey, if one was specified (#958).