### PR TITLE
UniversalResults: add top level appliedFilters config

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,9 +697,30 @@ across all configured verticals, with one section per vertical.
 ANSWERS.addComponent('UniversalResults', {
   // Required, the selector for the container element where the component will be injected
   container: '.universal-results-container',
+  // Settings for the applied filters bar in the results header. These settings can be overriden in the
+  // "config" option below on a per-vertical basis.
+  appliedFilters: {
+    // If true, show any applied filters that were applied to the universal search. Defaults to true
+    show: true,
+    // If appliedFilters.show is true, whether to display the field name of an applied filter, e.g. "Location: Virginia" vs just "Virginia". Defaults to false.
+    showFieldNames: false,
+    // If appliedFilters.show is true, this is list of filters that should not be displayed.
+    // By default, builtin.entityType will be hidden
+    hiddenFields: ['builtin.entityType'],
+    // The character that separates the count of results (e.g. “1-6”) from the applied filter bar. Defaults to '|'
+    resultsCountSeparator: '|',
+    // Whether to display the change filters link in universal results. Defaults to false.
+    showChangeFilters: false,
+    // The text for the change filters link. Defaults to 'change filters'.
+    changeFiltersText: 'change filters',
+    // The character that separates each field (and its associated filters) within the applied filter bar. Defaults to '|'
+    delimiter: '|',
+    // The aria-label given to the applied filters bar. Defaults to 'Filters applied to this search:'.
+    labelText: 'Filters applied to this search:',
+  },
   // Optional, configuration for each vertical's results
   config: {
-    'people': { // The verticalKey
+    people: { // The verticalKey
       card: {
         // Configuration for the cards in this vertical, see Cards
       },
@@ -719,23 +740,7 @@ ANSWERS.addComponent('UniversalResults', {
       viewMoreLabel: 'View More!',
       // Config for the applied filters bar in the results header.
       appliedFilters: {
-        // If true, show any applied filters that were applied to the universal search. Defaults to true
-        show: true,
-        // If appliedFilters.show is true, whether to display the field name of an applied filter, e.g. "Location: Virginia" vs just "Virginia". Defaults to false.
-        showFieldNames: false,
-        // If appliedFilters.show is true, this is list of filters that should not be displayed.
-        // By default, builtin.entityType will be hidden
-        hiddenFields: ['builtin.entityType'],
-        // The character that separates the count of results (e.g. “1-6”) from the applied filter bar. Defaults to '|'
-        resultsCountSeparator: '|',
-        // Whether to display the change filters link in universal results. Defaults to false.
-        showChangeFilters: false,
-        // The text for the change filters link. Defaults to 'change filters'.
-        changeFiltersText: 'change filters',
-        // The character that separates each field (and its associated filters) within the applied filter bar. Defaults to '|'
-        delimiter: '|',
-        // The aria-label given to the applied filters bar. Defaults to 'Filters applied to this search:'.
-        labelText: 'Filters applied to this search:',
+        // Same as appliedFilters settings above. Settings specified here will override any top level settings.
       },
       // If true, display the count of results at the very top of the results. Defaults to false.
       showResultCount: true,

--- a/src/ui/components/results/universalresultscomponent.js
+++ b/src/ui/components/results/universalresultscomponent.js
@@ -11,6 +11,16 @@ export default class UniversalResultsComponent extends Component {
   constructor (config = {}, systemConfig = {}) {
     super(config, systemConfig);
     this.moduleId = StorageKeys.UNIVERSAL_RESULTS;
+    this._appliedFilters = {
+      show: true,
+      showFieldNames: false,
+      hiddenFields: ['builtin.entityType'],
+      resultsCountSeparator: '|',
+      showChangeFilters: false,
+      delimiter: '|',
+      labelText: 'Filters applied to this search:',
+      ...config.appliedFilters
+    };
 
     this.core.globalStorage.on('update', StorageKeys.API_CONTEXT, () => {
       this.setState(this.core.globalStorage.getState(StorageKeys.UNIVERSAL_RESULTS));
@@ -47,7 +57,8 @@ export default class UniversalResultsComponent extends Component {
     const verticalKey = data.verticalConfigId;
     const childOpts = {
       ...opts,
-      ...UniversalResultsComponent.getChildConfig(verticalKey, verticals[verticalKey] || {})
+      ...UniversalResultsComponent.getChildConfig(
+        verticalKey, verticals[verticalKey] || {}, this._appliedFilters)
     };
     const childType = childOpts.useAccordion ? AccordionResultsComponent.type : type;
     return super.addChild(data, childType, childOpts);
@@ -57,8 +68,10 @@ export default class UniversalResultsComponent extends Component {
    * Applies synonyms and default config for a vertical in universal results.
    * @param {string} verticalKey
    * @param {Object} config
+   * @param {Object} topLevelAppliedFilters
+   * @returns {Object}
    */
-  static getChildConfig (verticalKey, config) {
+  static getChildConfig (verticalKey, config, topLevelAppliedFilters) {
     return {
       // Tells vertical results it is in a universal results page.
       isUniversal: true,
@@ -76,25 +89,31 @@ export default class UniversalResultsComponent extends Component {
       showResultCount: false,
       // Whether to use AccordionResults (DEPRECATED)
       useAccordion: false,
+      // Override vertical config defaults with user given config.
       ...config,
       // Config for the applied filters bar. Must be placed after ...config to not override defaults.
       appliedFilters: {
         // Whether to display applied filters.
-        show: defaultConfigOption(config, ['appliedFilters.show', 'showAppliedFilters'], true),
+        show: defaultConfigOption(config, ['appliedFilters.show', 'showAppliedFilters'], topLevelAppliedFilters.show),
         // Whether to show field names, e.g. Location in Location: Virginia.
-        showFieldNames: defaultConfigOption(config, ['appliedFilters.showFieldNames', 'showFieldNames'], false),
+        showFieldNames: defaultConfigOption(config,
+          ['appliedFilters.showFieldNames', 'showFieldNames'], topLevelAppliedFilters.showFieldNames),
         // Hide filters with these field ids.
-        hiddenFields: defaultConfigOption(config, ['appliedFilters.hiddenFields', 'hiddenFields'], ['builtin.entityType']),
+        hiddenFields: defaultConfigOption(config,
+          ['appliedFilters.hiddenFields', 'hiddenFields'], topLevelAppliedFilters.hiddenFields),
         // Symbol placed between the result count and the applied filters.
-        resultsCountSeparator: defaultConfigOption(config, ['appliedFilters.resultsCountSeparator', 'resultsCountSeparator'], '|'),
+        resultsCountSeparator: defaultConfigOption(config,
+          ['appliedFilters.resultsCountSeparator', 'resultsCountSeparator'], topLevelAppliedFilters.resultsCountSeparator),
         // Whether to show a 'change filters' link, linking back to verticalURL.
-        showChangeFilters: defaultConfigOption(config, ['appliedFilters.showChangeFilters', 'showChangeFilters'], false),
+        showChangeFilters: defaultConfigOption(config,
+          ['appliedFilters.showChangeFilters', 'showChangeFilters'], topLevelAppliedFilters.showChangeFilters),
         // The text for the change filters link.
-        changeFiltersText: defaultConfigOption(config, ['appliedFilters.changeFiltersText', 'changeFiltersText']),
+        changeFiltersText: defaultConfigOption(config,
+          ['appliedFilters.changeFiltersText', 'changeFiltersText'], topLevelAppliedFilters.changeFiltersText),
         // The symbol placed between different filters with the same fieldName. e.g. Location: Virginia | New York | Miami.
-        delimiter: defaultConfigOption(config, ['appliedFilters.delimiter'], '|'),
+        delimiter: defaultConfigOption(config, ['appliedFilters.delimiter'], topLevelAppliedFilters.delimiter),
         // The aria-label given to the applied filters bar.
-        labelText: defaultConfigOption(config, ['appliedFilters.labelText'], 'Filters applied to this search:')
+        labelText: defaultConfigOption(config, ['appliedFilters.labelText'], topLevelAppliedFilters.labelText)
       }
     };
   }


### PR DESCRIPTION
This commit adds a top level appliedFilters config
to UniversalResults. This allows users to easily specify
shared config for appliedFilters, and override it
per vertical.

J=SPR-2540
TEST=manual

Tested that each config option specified in
getChildConfig can be set in the global config,
as well as overridden for a specific vertical.