### PR TITLE
searchbar: re-allow redirectUrl without verticalKey

### DIFF
--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -413,7 +413,7 @@ export default class SearchComponent extends Component {
 
     // If we have a redirectUrl, we want the form to be
     // serialized and submitted.
-    if (typeof this.redirectUrl === 'string' && this._verticalKey) {
+    if (typeof this.redirectUrl === 'string') {
       if (this._allowEmptySearch || query) {
         if (params.has(StorageKeys.REFERRER_PAGE_URL)) {
           params.delete(StorageKeys.REFERRER_PAGE_URL);


### PR DESCRIPTION
If a user wants to add a redirectUrl without a verticalKey, it should
run a universal search with no vertical key. Before this change, we
would not allow this behavior.

J=none
TEST=manual

Tested that you can run a search on a searchbar with a redirect URL and
no vertical key and this runs a universal search on the redirect
experience.