### PR TITLE
Ensure Filter Options are centered

### DIFF
--- a/src/ui/sass/modules/_FilterOptions.scss
+++ b/src/ui/sass/modules/_FilterOptions.scss
@@ -33,7 +33,7 @@
 
     &-option {
       display: flex;
-      align-items: flex-start;
+      align-items: center;
       margin: 2px 0;
       @media (max-width: $breakpoint-mobile-max) {
         margin: 22px 0;


### PR DESCRIPTION
Change align-items: flex-start to align-items: center in .yxt-FilterOptions-options. Previously, the text next to the filter options buttons were slightly too low. Now they are centered.

J=SPR-2561

TEST=manual

Tested on local test site.