### PR TITLE
Ensure Filter Options are centered

### DIFF
--- a/src/ui/sass/modules/_FilterOptions.scss
+++ b/src/ui/sass/modules/_FilterOptions.scss
@@ -78,7 +78,7 @@
 
     &-option {
       display: flex;
-      align-items: flex-start;
+      align-items: center;
 
       &:not(:first-child) {
         margin-top: 8px;


### PR DESCRIPTION
Change align-items: flex-start to align-items: center in .yxt-FilterOptions-options. Previously, the text next to the filter options buttons were slightly too low. Now they are centered.

J=SPR-2561

TEST=manual

Tested on local test site.