### PR TITLE
Fix back-button for query rules by only updating url when different

### DIFF
--- a/src/core/utils/urlutils.js
+++ b/src/core/utils/urlutils.js
@@ -59,3 +59,24 @@ export function addParamsToUrl (url, params = {}) {
 export function urlWithoutQueryParamsAndHash (url) {
   return url.split('?')[0].split('#')[0];
 }
+
+/**
+ * returns if two SearchParams objects have the same key,value entries
+ * @param {SearchParams} params1
+ * @param {SearchParams} params2
+ * @return {boolean} true if params1 and params2 have the same key,value entries, false otherwise
+ */
+export function equivalentParams (params1, params2) {
+  if (params1.entries().length !== params2.entries().length) {
+    return false;
+  }
+  for (let entry of params1.entries()) {
+    if (!params2.has(entry[0])) {
+      return false;
+    }
+    if (entry[1] !== params2.get(entry[0])) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/src/core/utils/urlutils.js
+++ b/src/core/utils/urlutils.js
@@ -70,11 +70,8 @@ export function equivalentParams (params1, params2) {
   if (params1.entries().length !== params2.entries().length) {
     return false;
   }
-  for (let entry of params1.entries()) {
-    if (!params2.has(entry[0])) {
-      return false;
-    }
-    if (entry[1] !== params2.get(entry[0])) {
+  for (const [key, val] of params1.entries()) {
+    if (val !== params2.get(key)) {
       return false;
     }
   }

--- a/src/ui/storage/persistentstorage.js
+++ b/src/ui/storage/persistentstorage.js
@@ -1,5 +1,6 @@
 import SearchParams from '../dom/searchparams';
 import { AnswersStorageError } from '../../core/errors/errors';
+import { equivalentParams } from '../../core/utils/urlutils';
 
 /** @module PersistentStorage */
 
@@ -66,6 +67,11 @@ export default class PersistentStorage {
   }
 
   _updateHistory (replaceHistory = false) {
+    const currentParams = new SearchParams(window.location.search.substring(1));
+    if (equivalentParams(this._params, currentParams)) {
+      return;
+    }
+
     if (this._historyTimer) {
       clearTimeout(this._historyTimer);
     }


### PR DESCRIPTION
Our persistent storage updates history in batches. Imagine the following
scenario:

```
persistentStorage.set(QUERY, ..., replaceHistory = false);
persistentStorage.set(REFERRER_PAGE_URL, ..., replaceHistory = false);
persistentStorage.set(CONTEXT, ..., replaceHistory = true);
```

Because of our implementation oof batched updates, all three will be set
at the same time with replaceHistory = true (Even if the first two were
applied with false).

Our implementation of query rules applies the query params to
the url right before a search. This is at the same time query is
applied. Thus, we should keep replaceHistory to match what query is
doing (replaceHistory = false).

This puts in a problem when we land on an experience with a `query`
query param. Because replaceHistory must be false and because we set
context/referrerPageUrl before any search, we push another state
when we land on this page. This makes it so you cannot go backwards in
browser history from this page. (See test example below).

By only updating the URL when query params are different, we do not push
that extra state on page land. This is also useful for avoiding pushing
extra unnecessary state.

J=SPR-2554
TEST=manual

Test that you can make three queries in succession and you are not stuck
in the second query. For example.

Land on empty universal.
Search for virginia
Search for all
Search for christian

If you go back in your browser history twice, you should be back on the
`virginia` search. Not the `all` search.