### PR TITLE
circleci: Remove max-age cache for canary/latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ jobs:
           cache-control: 'max-age=31536000'
       - deploy-to-aws:
           subdirectory: '/canary/latest'
-          cache-control: 'max-age=31536000'
+          cache-control: 'no-cache'
   # deploys assets to a long-lived-cache folder in the S3 bucket named by release tag
   deploy_version:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,6 @@ jobs:
           cache-control: 'max-age=31536000'
       - deploy-to-aws:
           subdirectory: '/canary/latest'
-          cache-control: 'no-cache'
   # deploys assets to a long-lived-cache folder in the S3 bucket named by release tag
   deploy_version:
     docker:


### PR DESCRIPTION
When we make a change to develop, we want the changes to reflect
immediately, even if we had already loaded canary/latest on a page.

Change to no-cache instead of a large max-age so that a page must
re-validate the context before using a cached version.

J=SPR-2549
TEST=manual

circleci config validate