### PR TITLE
VerticalResults: add resultsCountTemplate config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,8 +556,8 @@ ANSWERS.addComponent('VerticalResults', {
   maxNumberOfColumns: 1,
   // Optional, whether to display the total number of results, default true
   showResultCount: true,
-  // Optional, custom text for the results count. You can specify the variables resultsCountStart, resultsCountEnd, and resultsCount with the double bracket notation e.g. {{resultsCount}}.
-  resultsCountText: '{{resultsCountStart}} - {{resultsCountEnd}} of {{resultsCount}}',
+  // Optional, a custom template for the results count. You can specify the variables resultsCountStart, resultsCountEnd, and resultsCount.
+  resultsCountTemplate: '<div>{{resultsCountStart}} - {{resultsCountEnd}} of {{resultsCount}}</div>',
   // Optional, a modifier that will be appended to a class on the results list like this `yxt-Results--{modifier}`
   modifier: '',
   // Optional, the card used to display each individual result, see the Cards section for more details,

--- a/README.md
+++ b/README.md
@@ -556,8 +556,8 @@ ANSWERS.addComponent('VerticalResults', {
   maxNumberOfColumns: 1,
   // Optional, whether to display the total number of results, default true
   showResultCount: true,
-  // Optional, a custom template for the results count. You can specify the variables resultsCountStart, resultsCountEnd, and resultsCount with the double bracket notation e.g. {{resultsCount}}.
-  resultsCountTemplate: '{{resultsCountStart}} - {{resultsCountEnd}} of {{resultsCount}}',
+  // Optional, custom text for the results count. You can specify the variables resultsCountStart, resultsCountEnd, and resultsCount with the double bracket notation e.g. {{resultsCount}}.
+  resultsCountTemplateString: '{{resultsCountStart}} - {{resultsCountEnd}} of {{resultsCount}}',
   // Optional, a modifier that will be appended to a class on the results list like this `yxt-Results--{modifier}`
   modifier: '',
   // Optional, the card used to display each individual result, see the Cards section for more details,

--- a/README.md
+++ b/README.md
@@ -556,6 +556,8 @@ ANSWERS.addComponent('VerticalResults', {
   maxNumberOfColumns: 1,
   // Optional, whether to display the total number of results, default true
   showResultCount: true,
+  // Optional, a custom template for the results count. You can specify the variables resultsCountStart, resultsCountEnd, and resultsCount with the double bracket notation e.g. {{resultsCount}}.
+  resultsCountTemplate: '{{resultsCountStart}} - {{resultsCountEnd}} of {{resultsCount}}',
   // Optional, a modifier that will be appended to a class on the results list like this `yxt-Results--{modifier}`
   modifier: '',
   // Optional, the card used to display each individual result, see the Cards section for more details,

--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ ANSWERS.addComponent('VerticalResults', {
   // Optional, whether to display the total number of results, default true
   showResultCount: true,
   // Optional, custom text for the results count. You can specify the variables resultsCountStart, resultsCountEnd, and resultsCount with the double bracket notation e.g. {{resultsCount}}.
-  resultsCountTemplateString: '{{resultsCountStart}} - {{resultsCountEnd}} of {{resultsCount}}',
+  resultsCountText: '{{resultsCountStart}} - {{resultsCountEnd}} of {{resultsCount}}',
   // Optional, a modifier that will be appended to a class on the results list like this `yxt-Results--{modifier}`
   modifier: '',
   // Optional, the card used to display each individual result, see the Cards section for more details,

--- a/src/ui/components/results/resultsheadercomponent.js
+++ b/src/ui/components/results/resultsheadercomponent.js
@@ -22,7 +22,7 @@ const DEFAULT_CONFIG = {
   isUniversal: false,
   labelText: 'Filters applied to this search:',
   removableLabelText: 'Remove this filter',
-  resultsCountTemplate: '',
+  resultsCountTemplateString: '',
   hiddenFields: []
 };
 

--- a/src/ui/components/results/resultsheadercomponent.js
+++ b/src/ui/components/results/resultsheadercomponent.js
@@ -45,6 +45,11 @@ export default class ResultsHeaderComponent extends Component {
     this.resultsLength = data.resultsLength || 0;
 
     /**
+     * The compiled custom results count template, if the user specifies one.
+     */
+    this._compiledResultsCountTemplate = this._renderer.compile(this._config.resultsCountTemplate);
+
+    /**
      * Array of nlp filters in the search response.
      * @type {Array<AppliedQueryFilter>}
      */
@@ -156,14 +161,18 @@ export default class ResultsHeaderComponent extends Component {
     this.appliedFilterNodes = this._calculateAppliedFilterNodes();
     const appliedFiltersArray = this._createAppliedFiltersArray();
     const shouldShowFilters = appliedFiltersArray.length > 0 && this._config.showAppliedFilters;
-    return super.setState({
-      ...data,
+    const resultsCountData = {
       resultsCount: this.resultsCount,
       resultsCountStart: offset + 1,
-      resultsCountEnd: offset + this.resultsLength,
+      resultsCountEnd: offset + this.resultsLength
+    };
+    return super.setState({
+      ...data,
+      ...resultsCountData,
       showResultSeparator: this._config.resultsCountSeparator && this._config.showResultCount && shouldShowFilters,
       shouldShowFilters: shouldShowFilters,
-      appliedFiltersArray: appliedFiltersArray
+      appliedFiltersArray: appliedFiltersArray,
+      customResultsCount: this._compiledResultsCountTemplate(resultsCountData)
     });
   }
 

--- a/src/ui/components/results/resultsheadercomponent.js
+++ b/src/ui/components/results/resultsheadercomponent.js
@@ -46,6 +46,7 @@ export default class ResultsHeaderComponent extends Component {
 
     /**
      * The compiled custom results count template, if the user specifies one.
+     * @type {Function}
      */
     this._compiledResultsCountTemplate = this._renderer.compile(this._config.resultsCountTemplate);
 

--- a/src/ui/components/results/resultsheadercomponent.js
+++ b/src/ui/components/results/resultsheadercomponent.js
@@ -22,7 +22,7 @@ const DEFAULT_CONFIG = {
   isUniversal: false,
   labelText: 'Filters applied to this search:',
   removableLabelText: 'Remove this filter',
-  resultsCountText: '',
+  resultsCountTemplate: '',
   hiddenFields: []
 };
 

--- a/src/ui/components/results/resultsheadercomponent.js
+++ b/src/ui/components/results/resultsheadercomponent.js
@@ -22,7 +22,7 @@ const DEFAULT_CONFIG = {
   isUniversal: false,
   labelText: 'Filters applied to this search:',
   removableLabelText: 'Remove this filter',
-  resultsCountTemplateString: '',
+  resultsCountText: '',
   hiddenFields: []
 };
 

--- a/src/ui/components/results/resultsheadercomponent.js
+++ b/src/ui/components/results/resultsheadercomponent.js
@@ -22,6 +22,7 @@ const DEFAULT_CONFIG = {
   isUniversal: false,
   labelText: 'Filters applied to this search:',
   removableLabelText: 'Remove this filter',
+  resultsCountTemplate: '',
   hiddenFields: []
 };
 

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -209,7 +209,7 @@ export default class VerticalResultsComponent extends Component {
       labelText: this._config.appliedFilters.labelText,
       removableLabelText: this._config.appliedFilters.removableLabelText,
       hiddenFields: this._config.appliedFilters.hiddenFields,
-      resultsCountTemplateString: this._config.resultsCountTemplateString
+      resultsCountText: this._config.resultsCountText
     };
   }
 

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -209,7 +209,7 @@ export default class VerticalResultsComponent extends Component {
       labelText: this._config.appliedFilters.labelText,
       removableLabelText: this._config.appliedFilters.removableLabelText,
       hiddenFields: this._config.appliedFilters.hiddenFields,
-      resultsCountTemplate: this._config.resultsCountTemplate
+      resultsCountTemplateString: this._config.resultsCountTemplateString
     };
   }
 

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -52,6 +52,7 @@ class VerticalResultsConfig {
 
     /**
      * Vertical URL for view more link
+     * @type {string}
      */
     this.verticalURL = config.verticalURL;
 
@@ -60,6 +61,12 @@ class VerticalResultsConfig {
      * @type {boolean}
      */
     this.showResultCount = config.showResultCount === undefined ? true : config.showResultCount;
+
+    /**
+     * A custom results count template.
+     * @type {string}
+     */
+    this.resultsCountTemplate = config.resultsCountTemplate || '';
 
     /**
      * Config for the applied filters in the results header.

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -208,7 +208,8 @@ export default class VerticalResultsComponent extends Component {
       delimiter: this._config.appliedFilters.delimiter,
       labelText: this._config.appliedFilters.labelText,
       removableLabelText: this._config.appliedFilters.removableLabelText,
-      hiddenFields: this._config.appliedFilters.hiddenFields
+      hiddenFields: this._config.appliedFilters.hiddenFields,
+      resultsCountTemplate: this._config.resultsCountTemplate
     };
   }
 

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -209,7 +209,7 @@ export default class VerticalResultsComponent extends Component {
       labelText: this._config.appliedFilters.labelText,
       removableLabelText: this._config.appliedFilters.removableLabelText,
       hiddenFields: this._config.appliedFilters.hiddenFields,
-      resultsCountText: this._config.resultsCountText
+      resultsCountTemplate: this._config.resultsCountTemplate
     };
   }
 

--- a/src/ui/rendering/handlebarsrenderer.js
+++ b/src/ui/rendering/handlebarsrenderer.js
@@ -207,9 +207,5 @@ export default class HandlebarsRenderer extends Renderer {
       return getInverted ? self.SafeString(highlightedVal.getInverted())
         : self.SafeString(highlightedVal.get());
     });
-
-    self.registerHelper('renderTemplate', function (template) {
-      return self.SafeString(self.compile(template)(this));
-    });
   }
 }

--- a/src/ui/rendering/handlebarsrenderer.js
+++ b/src/ui/rendering/handlebarsrenderer.js
@@ -207,5 +207,9 @@ export default class HandlebarsRenderer extends Renderer {
       return getInverted ? self.SafeString(highlightedVal.getInverted())
         : self.SafeString(highlightedVal.get());
     });
+
+    self.registerHelper('renderTemplate', function (template) {
+      return self.SafeString(self.compile(template)(this));
+    });
   }
 }

--- a/src/ui/rendering/handlebarsrenderer.js
+++ b/src/ui/rendering/handlebarsrenderer.js
@@ -208,8 +208,8 @@ export default class HandlebarsRenderer extends Renderer {
         : self.SafeString(highlightedVal.get());
     });
 
-    self.registerHelper('hydrateString', function (templateString) {
-      return self.compile(templateString)(this);
+    self.registerHelper('renderTemplate', function (template) {
+      return self.SafeString(self.compile(template)(this));
     });
   }
 }

--- a/src/ui/rendering/handlebarsrenderer.js
+++ b/src/ui/rendering/handlebarsrenderer.js
@@ -208,8 +208,8 @@ export default class HandlebarsRenderer extends Renderer {
         : self.SafeString(highlightedVal.get());
     });
 
-    self.registerHelper('renderTemplate', function (template) {
-      return self.SafeString(self.compile(template)(this));
+    self.registerHelper('hydrateString', function (templateString) {
+      return self.compile(templateString)(this);
     });
   }
 }

--- a/src/ui/templates/results/resultsheader.hbs
+++ b/src/ui/templates/results/resultsheader.hbs
@@ -14,8 +14,10 @@
   {{#if (and _config.showResultCount resultsCount)}}
     <div class="yxt-ResultsHeader-resultsCount" aria-label="{{resultsCountStart}} through {{resultsCountEnd}} of {{resultsCount}}">
       <div aria-hidden="true">
-        {{#if _config.resultsCountTemplate}}
-          {{renderTemplate _config.resultsCountTemplate}}
+        {{#if _config.resultsCountTemplateString}}
+          <span class="yxt-ResultsHeader-resultsCountTemplateString">
+            {{hydrateString _config.resultsCountTemplateString}}
+          </span>
         {{else}}
           <span class="yxt-ResultsHeader-resultsCountStart">{{resultsCountStart}}</span>
           <span class="yxt-ResultsHeader-resultsCountDash">-</span>

--- a/src/ui/templates/results/resultsheader.hbs
+++ b/src/ui/templates/results/resultsheader.hbs
@@ -14,11 +14,15 @@
   {{#if (and _config.showResultCount resultsCount)}}
     <div class="yxt-ResultsHeader-resultsCount" aria-label="{{resultsCountStart}} through {{resultsCountEnd}} of {{resultsCount}}">
       <div aria-hidden="true">
-        <span class="yxt-ResultsHeader-resultsCountStart">{{resultsCountStart}}</span>
-        <span class="yxt-ResultsHeader-resultsCountDash">-</span>
-        <span class="yxt-ResultsHeader-resultsCountEnd">{{resultsCountEnd}}</span>
-        <span class="yxt-ResultsHeader-resultsCountOf">of</span>
-        <span class="yxt-ResultsHeader-resultsCountTotal">{{resultsCount}}</span>
+        {{#if _config.resultsCountTemplate}}
+          {{renderTemplate _config.resultsCountTemplate}}
+        {{else}}
+          <span class="yxt-ResultsHeader-resultsCountStart">{{resultsCountStart}}</span>
+          <span class="yxt-ResultsHeader-resultsCountDash">-</span>
+          <span class="yxt-ResultsHeader-resultsCountEnd">{{resultsCountEnd}}</span>
+          <span class="yxt-ResultsHeader-resultsCountOf">of</span>
+          <span class="yxt-ResultsHeader-resultsCountTotal">{{resultsCount}}</span>
+        {{/if}}
       </div>
     </div>
   {{/if}}

--- a/src/ui/templates/results/resultsheader.hbs
+++ b/src/ui/templates/results/resultsheader.hbs
@@ -12,19 +12,19 @@
 
 {{#*inline "resultscount"}}
   {{#if (and _config.showResultCount resultsCount)}}
-  {{#if _config.resultsCountTemplate}}
-    {{renderTemplate _config.resultsCountTemplate}}
-  {{else}}
-    <div class="yxt-ResultsHeader-resultsCount" aria-label="{{resultsCountStart}} through {{resultsCountEnd}} of {{resultsCount}}">
-      <div aria-hidden="true">
-        <span class="yxt-ResultsHeader-resultsCountStart">{{resultsCountStart}}</span>
-        <span class="yxt-ResultsHeader-resultsCountDash">-</span>
-        <span class="yxt-ResultsHeader-resultsCountEnd">{{resultsCountEnd}}</span>
-        <span class="yxt-ResultsHeader-resultsCountOf">of</span>
-        <span class="yxt-ResultsHeader-resultsCountTotal">{{resultsCount}}</span>
+    {{#if customResultsCount}}
+      {{{customResultsCount}}}
+    {{else}}
+      <div class="yxt-ResultsHeader-resultsCount" aria-label="{{resultsCountStart}} through {{resultsCountEnd}} of {{resultsCount}}">
+        <div aria-hidden="true">
+          <span class="yxt-ResultsHeader-resultsCountStart">{{resultsCountStart}}</span>
+          <span class="yxt-ResultsHeader-resultsCountDash">-</span>
+          <span class="yxt-ResultsHeader-resultsCountEnd">{{resultsCountEnd}}</span>
+          <span class="yxt-ResultsHeader-resultsCountOf">of</span>
+          <span class="yxt-ResultsHeader-resultsCountTotal">{{resultsCount}}</span>
+        </div>
       </div>
-    </div>
-  {{/if}}
+    {{/if}}
   {{/if}}
 {{/inline}}
 

--- a/src/ui/templates/results/resultsheader.hbs
+++ b/src/ui/templates/results/resultsheader.hbs
@@ -12,21 +12,19 @@
 
 {{#*inline "resultscount"}}
   {{#if (and _config.showResultCount resultsCount)}}
+  {{#if _config.resultsCountTemplate}}
+    {{renderTemplate _config.resultsCountTemplate}}
+  {{else}}
     <div class="yxt-ResultsHeader-resultsCount" aria-label="{{resultsCountStart}} through {{resultsCountEnd}} of {{resultsCount}}">
       <div aria-hidden="true">
-        {{#if _config.resultsCountText}}
-          <span class="yxt-ResultsHeader-resultsCountText">
-            {{hydrateString _config.resultsCountText}}
-          </span>
-        {{else}}
-          <span class="yxt-ResultsHeader-resultsCountStart">{{resultsCountStart}}</span>
-          <span class="yxt-ResultsHeader-resultsCountDash">-</span>
-          <span class="yxt-ResultsHeader-resultsCountEnd">{{resultsCountEnd}}</span>
-          <span class="yxt-ResultsHeader-resultsCountOf">of</span>
-          <span class="yxt-ResultsHeader-resultsCountTotal">{{resultsCount}}</span>
-        {{/if}}
+        <span class="yxt-ResultsHeader-resultsCountStart">{{resultsCountStart}}</span>
+        <span class="yxt-ResultsHeader-resultsCountDash">-</span>
+        <span class="yxt-ResultsHeader-resultsCountEnd">{{resultsCountEnd}}</span>
+        <span class="yxt-ResultsHeader-resultsCountOf">of</span>
+        <span class="yxt-ResultsHeader-resultsCountTotal">{{resultsCount}}</span>
       </div>
     </div>
+  {{/if}}
   {{/if}}
 {{/inline}}
 

--- a/src/ui/templates/results/resultsheader.hbs
+++ b/src/ui/templates/results/resultsheader.hbs
@@ -14,9 +14,9 @@
   {{#if (and _config.showResultCount resultsCount)}}
     <div class="yxt-ResultsHeader-resultsCount" aria-label="{{resultsCountStart}} through {{resultsCountEnd}} of {{resultsCount}}">
       <div aria-hidden="true">
-        {{#if _config.resultsCountTemplateString}}
-          <span class="yxt-ResultsHeader-resultsCountTemplateString">
-            {{hydrateString _config.resultsCountTemplateString}}
+        {{#if _config.resultsCountText}}
+          <span class="yxt-ResultsHeader-resultsCountText">
+            {{hydrateString _config.resultsCountText}}
           </span>
         {{else}}
           <span class="yxt-ResultsHeader-resultsCountStart">{{resultsCountStart}}</span>


### PR DESCRIPTION
This commit allows users to specify a resultsCountTemplate
in VerticalResults, which lets them specify a custom results count

J=SPR-2619
TEST=manual

test that I can specify a custom results count template, using variables 
passed to the main template, and with arbitrary html tags (I tested `<button>, <table>, and <div>`)