### PR TITLE
Version 1.4.3

### DIFF
--- a/src/ui/components/results/universalresultscomponent.js
+++ b/src/ui/components/results/universalresultscomponent.js
@@ -63,7 +63,7 @@ export default class UniversalResultsComponent extends Component {
       // Icon in the titlebar
       icon: config.sectionTitleIconName || config.sectionTitleIconUrl || 'star',
       // Url that links to the vertical search for this vertical.
-      verticalURL: 'url' in config ? config.url : verticalKey + '.html',
+      verticalURL: config.url,
       // Show a view more link by default, which also links to verticalURL.
       viewMore: true,
       // By default, the view more link has a label of 'View More'.

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -413,7 +413,7 @@ export default class SearchComponent extends Component {
 
     // If we have a redirectUrl, we want the form to be
     // serialized and submitted.
-    if (typeof this.redirectUrl === 'string' && this._verticalKey) {
+    if (typeof this.redirectUrl === 'string') {
       if (this._allowEmptySearch || query) {
         window.location.href = this.redirectUrl + '?' + params.toString();
         return false;

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -413,9 +413,11 @@ export default class SearchComponent extends Component {
 
     // If we have a redirectUrl, we want the form to be
     // serialized and submitted.
-    if (typeof this.redirectUrl === 'string') {
-      window.location.href = this.redirectUrl + '?' + params.toString();
-      return false;
+    if (typeof this.redirectUrl === 'string' && this._verticalKey) {
+      if (this._allowEmptySearch || query) {
+        window.location.href = this.redirectUrl + '?' + params.toString();
+        return false;
+      }
     }
 
     inputEl.blur();

--- a/src/ui/sass/modules/_FilterOptions.scss
+++ b/src/ui/sass/modules/_FilterOptions.scss
@@ -78,7 +78,7 @@
 
     &-option {
       display: flex;
-      align-items: flex-start;
+      align-items: center;
 
       &:not(:first-child) {
         margin-top: 8px;

--- a/src/ui/sass/modules/_SearchBar.scss
+++ b/src/ui/sass/modules/_SearchBar.scss
@@ -174,6 +174,11 @@ $searchbar-button-text-color-active: var(--yxt-searchbar-button-text-color-base)
     }
   }
 
+  &-AnimatedIcon
+  {
+    display: flex;
+  }
+
   &-AnimatedIcon--inactive svg
   {
     display: none;

--- a/src/ui/templates/search/search.hbs
+++ b/src/ui/templates/search/search.hbs
@@ -49,12 +49,12 @@
           data-opts='{ "iconUrl": "{{_config.customIconUrl}}" }'
       ></div>
     {{else}}
-      <div class="js-yxt-AnimatedForward yxt-SearchBar-AnimatedIcon--paused
+      <div class="yxt-SearchBar-AnimatedIcon yxt-SearchBar-AnimatedIcon--paused js-yxt-AnimatedForward
         {{#if autoFocus}} yxt-SearchBar-AnimatedIcon--inactive{{/if}}"
         data-component="IconComponent"
         data-opts="{{json forwardIconOpts}}">
       </div>
-      <div class="js-yxt-AnimatedReverse yxt-SearchBar-AnimatedIcon--paused
+      <div class="yxt-SearchBar-AnimatedIcon yxt-SearchBar-AnimatedIcon--paused js-yxt-AnimatedReverse
         {{#unless autoFocus}} yxt-SearchBar-AnimatedIcon--inactive{{/unless}}"
         data-component="IconComponent"
         data-opts="{{json reverseIconOpts}}">


### PR DESCRIPTION
# Version 1.4.3

## Fixes

* UniversalResults' view more url first defaults to a corresponding url specified in verticalPages, before defaulting to \<verticalKey\>.html.

* Added display: flex to the SearchBar's animated search icon. This fixes some interactions with external css that could misalign the icon.

* FilterOptions checkboxes and radio buttons were changed from align-items: flex-start to align-items: center for better alignment.

* SearchBars with a redirectUrl will now only redirect on empty searches if allowEmptySearch is true.