### PR TITLE
query rules: fix history state problems when going back in history

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -150,10 +150,10 @@ export default class Core {
 
     if (setQueryParams) {
       if (context) {
-        this.persistentStorage.set(StorageKeys.API_CONTEXT, context, true);
+        this.persistentStorage.set(StorageKeys.API_CONTEXT, context);
       }
       if (referrerPageUrl !== null) {
-        this.persistentStorage.set(StorageKeys.REFERRER_PAGE_URL, referrerPageUrl, true);
+        this.persistentStorage.set(StorageKeys.REFERRER_PAGE_URL, referrerPageUrl);
       }
     }
 

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -214,6 +214,7 @@ export default class SearchComponent extends Component {
 
   onCreate () {
     if (this.query != null && !this.redirectUrl) {
+      this.core.persistentStorage.set(StorageKeys.REFERRER_PAGE_URL, this.core.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL), true);
       this.core.setQuery(this.query);
     }
   }

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -214,7 +214,11 @@ export default class SearchComponent extends Component {
 
   onCreate () {
     if (this.query != null && !this.redirectUrl) {
-      this.core.persistentStorage.set(StorageKeys.REFERRER_PAGE_URL, this.core.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL), true);
+      this.core.persistentStorage.set(
+        StorageKeys.REFERRER_PAGE_URL,
+        this.core.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL),
+        true
+      );
       this.core.setQuery(this.query);
     }
   }


### PR DESCRIPTION
* searchbar: set referrerPageUrl on pageload for non-redirectUrl searchbar

Imagine the following situation

1. Page A has a redirect URL searchbar to Page B
2. User types in a query on Page A and gets redirected to Page B w/ query
3. The page is updated to include referrerPageUrl
4. Going back in history takes you to Page B without referrerPageUrl
5. referrerPageUrl is added again

If you redirected to an answers experience through a redirectUrl
searchbar, you would not be able to go back in history. This is because
we run a search on load when we see a query is in the query parameters.
Every search from the search component will try to add referrerPageUrl
to the URL.

To fix this, we set the referrerPageUrl with replaceHistory true on
searchbar load when we make the initial query search. Persistent storage
will not update history after this because referrerPageUrl is already in
the URL.

J=SPR-2554
TEST=manual

Test on a local site that if you redirect to an answers experience from
redirectUrl searchbar and then try to go back in history, you are not
stuck.

Test on a local site that if you redirect to an answers experience with
a query from a link and then try to go back in history, you are not
stuck.

* core/search: dont replace history for vertical search query rules params

Make the vertical search match the universal search and do not replace
history when setting referrerPageUrl and context. We do this because
otherwise every search would replace history, when we do want to push to
history when there is a new query. This is a result of batching
history changes. The last replaceHistory boolean will be the setting for
all updates to history in the batch.

J=SPR-2554
TEST=manual

Make a few searches on a vertical page, make sure you can go back in
history to see previous queries