### PR TITLE
persistentstorage: Remove persistent storage history batch updates

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -150,10 +150,10 @@ export default class Core {
 
     if (setQueryParams) {
       if (context) {
-        this.persistentStorage.set(StorageKeys.API_CONTEXT, context);
+        this.persistentStorage.set(StorageKeys.API_CONTEXT, context, true);
       }
       if (referrerPageUrl !== null) {
-        this.persistentStorage.set(StorageKeys.REFERRER_PAGE_URL, referrerPageUrl);
+        this.persistentStorage.set(StorageKeys.REFERRER_PAGE_URL, referrerPageUrl, true);
       }
     }
 
@@ -245,10 +245,10 @@ export default class Core {
 
     if (setQueryParams) {
       if (context) {
-        this.persistentStorage.set(StorageKeys.API_CONTEXT, context);
+        this.persistentStorage.set(StorageKeys.API_CONTEXT, context, true);
       }
       if (referrerPageUrl !== null) {
-        this.persistentStorage.set(StorageKeys.REFERRER_PAGE_URL, referrerPageUrl);
+        this.persistentStorage.set(StorageKeys.REFERRER_PAGE_URL, referrerPageUrl, true);
       }
     }
 

--- a/src/core/utils/urlutils.js
+++ b/src/core/utils/urlutils.js
@@ -67,7 +67,10 @@ export function urlWithoutQueryParamsAndHash (url) {
  * @return {boolean} true if params1 and params2 have the same key,value entries, false otherwise
  */
 export function equivalentParams (params1, params2) {
-  if (params1.entries().length !== params2.entries().length) {
+  const entries1 = Array.from(params1.entries());
+  const entries2 = Array.from(params2.entries());
+
+  if (entries1.length !== entries2.length) {
     return false;
   }
   for (const [key, val] of params1.entries()) {

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -214,11 +214,6 @@ export default class SearchComponent extends Component {
 
   onCreate () {
     if (this.query != null && !this.redirectUrl) {
-      this.core.persistentStorage.set(
-        StorageKeys.REFERRER_PAGE_URL,
-        this.core.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL),
-        true
-      );
       this.core.setQuery(this.query);
     }
   }

--- a/src/ui/storage/persistentstorage.js
+++ b/src/ui/storage/persistentstorage.js
@@ -13,12 +13,6 @@ export default class PersistentStorage {
     this._params = new SearchParams(window.location.search.substring(1));
 
     /**
-     * The current history edit timer, if any
-     * @type {number}
-     */
-    this._historyTimer = null;
-
-    /**
      * The list of listeners to every storage update
      * @type {function[]}
      */
@@ -72,21 +66,12 @@ export default class PersistentStorage {
       return;
     }
 
-    if (this._historyTimer) {
-      clearTimeout(this._historyTimer);
+    if (replaceHistory) {
+      window.history.replaceState(null, null, `?${this._params.toString()}`);
+    } else {
+      window.history.pushState(null, null, `?${this._params.toString()}`);
     }
-
-    // batch update calls across components to avoid updating the url too much
-    this._historyTimer = setTimeout(
-      () => {
-        this._historyTimer = null;
-        if (replaceHistory) {
-          window.history.replaceState(null, null, `?${this._params.toString()}`);
-        } else {
-          window.history.pushState(null, null, `?${this._params.toString()}`);
-        }
-        this._callListener(this._updateListener);
-      });
+    this._callListener(this._updateListener);
   }
 
   /**

--- a/tests/core/storage/persistentstorage.js
+++ b/tests/core/storage/persistentstorage.js
@@ -7,10 +7,8 @@ describe('adding and removing data', () => {
 
   beforeEach(() => {
     delete global.window.location;
-    global.window = Object.create(global.window);
     global.window.location = {};
     global.window.location.search = '';
-    global.window.history = {};
 
     updateCb = jest.fn();
     storage = new PersistentStorage({ updateListener: updateCb });

--- a/tests/core/storage/persistentstorage.js
+++ b/tests/core/storage/persistentstorage.js
@@ -6,19 +6,19 @@ describe('adding and removing data', () => {
   let updateCb;
 
   beforeEach(() => {
-    delete window.location;
-    window = Object.create(window);
-    window.location = {};
-    window.location.search = '';
-    window.history = {};
+    delete global.window.location;
+    global.window = Object.create(global.window);
+    global.window.location = {};
+    global.window.location.search = '';
+    global.window.history = {};
 
     updateCb = jest.fn();
     storage = new PersistentStorage({ updateListener: updateCb });
     mockPushState = jest.fn((state, title, url) => {
-      window.location.search = url;
+      global.window.location.search = url;
     });
 
-    window.history.pushState = mockPushState;
+    global.window.history.pushState = mockPushState;
   });
 
   it('pushes history after set', () => {


### PR DESCRIPTION
* persistentstorage: Remove persistent storage history batch updates

The persistent storage batching has an interesting bug where you cannot
have updates to history with BOTH replaceHistory = false and
replaceHistory = true within a batch. That is, if you called

updateHistory(replaceHistory = true);
updateHistory(replaceHistory = true);
updateHistory(replaceHistory = false);

The batch would update the URL with replaceHistory = false (the last
value to be requested). This is a problem for query rules, where we
always want to replace the URL with the query params (and not add to the
history stack).

Updating the history stack was causing problems with going back in
history. Because we add query params on load with a search (like
referrerPageUrl), we get stuck on a page when we go back in history to a
page without a referrerPageUrl, it gets re-added on load, and if we go
back, we repeat the cycle.

This fix fixes the backspacing problem. There should be no changes
associated with history state.

J=SPR-2554
TEST=manual

Test that our sequential usage of URL params does not affect the normal
flow of searching.

On a local Jambo site,
Make a search A
Make a search B
In Chrome console ANSWERS.setContext({'state': 'hi'});
Make a search C
Go back in history
Go back in history
Make sure you can reach search A again and before search A.

From a redirectUrl searchbar pointing to answers page A
Make a search on the searchbar
Click search
Takes you to page A
Make sure you can go back in history to the redirectUrl searchbar.

Assert facets and pagination interactions (commonly add to the browser
history) work as intended with back and forward navigation.

* Fix equivalentParams to use correct length function

Before, equivalent params was trying to use the length function on an
iterator which will always return undefined. Update the params entries
to arrays to check for this length, instead of an undefined iterator
length.

J=SPR-2554
TEST=manual

Check that equivalentParams(params1, params2)
params1 = []
params2 = [{key1: val1}]

Will return false instead of true