### PR TITLE
Add top, left and right border to map on universal page

### DIFF
--- a/src/ui/sass/modules/_Results.scss
+++ b/src/ui/sass/modules/_Results.scss
@@ -162,7 +162,9 @@ $results-cards-margin: calc(var(--yxt-base-spacing) / 2) !default;
   &-map
   {
     height: 300px;
-    border-bottom: var(--yxt-results-border);
+    border-top: var(--yxt-results-border);
+    border-left: var(--yxt-results-border);
+    border-right: var(--yxt-results-border);
   }
 
   &-items {


### PR DESCRIPTION
Add top, left and right border to map on universal page. border-left and border-right are set to var(--yxt-results-border).

J=SPR-2622

TEST=manual

Tested on local site to ensure left and right border were added. Tested on IE11 to make sure changes apply in IE11 as well.