### PR TITLE
urls: remove facets/pagination/filters from inter-experience links

### DIFF
--- a/src/core/utils/urlutils.js
+++ b/src/core/utils/urlutils.js
@@ -126,7 +126,7 @@ export function filterParamsForExperienceLink (
     ComponentTypes.DATE_RANGE_FILTER,
     ComponentTypes.SORT_OPTIONS
   ];
-  const queryPrefixComponentComponentTypes = [
+  const queryPrefixComponentTypes = [
     ComponentTypes.GEOLOCATION_FILTER,
     ComponentTypes.FILTER_SEARCH
   ];
@@ -135,7 +135,7 @@ export function filterParamsForExperienceLink (
   ];
   prefixes = prefixes.concat(getComponentNamesForComponentTypes(prefixComponentTypes));
   prefixes = prefixes.concat(
-    getComponentNamesForComponentTypes(queryPrefixComponentComponentTypes)
+    getComponentNamesForComponentTypes(queryPrefixComponentTypes)
       .map((name) => { return `${StorageKeys.QUERY}.${name}`; })
   );
 

--- a/src/core/utils/urlutils.js
+++ b/src/core/utils/urlutils.js
@@ -1,6 +1,7 @@
 import { PRODUCTION, SANDBOX } from '../constants';
 import SearchParams from '../../ui/dom/searchparams';
 import StorageKeys from '../storage/storagekeys';
+import ComponentTypes from '../../ui/components/componenttypes';
 
 /**
  * Returns the base url for the live api backend in the desired environment.
@@ -121,11 +122,23 @@ export function filterParamsForExperienceLink (
   params,
   getComponentNamesForComponentTypes
 ) {
-  let prefixes = getComponentNamesForComponentTypes([
-    'Facets', 'FilterBox', 'FilterOptions', 'RangeFilter', 'DateRangeFilter', 'SortOptions'
-  ]);
+  const prefixComponentTypes = [
+    'FACETS',
+    'FILTER_BOX',
+    'FILTER_OPTIONS',
+    'RANGE_FILTER',
+    'DATE_RANGE_FILTER',
+    'SORT_OPTIONS'
+  ].map((component) => {
+    return ComponentTypes[component];
+  });
+  const queryPrefixComponentComponentTypes = [
+    ComponentTypes['GEOLOCATION_FILTER'],
+    ComponentTypes['FILTER_SEARCH']
+  ];
+  let prefixes = getComponentNamesForComponentTypes(prefixComponentTypes);
   prefixes = prefixes.concat(
-    getComponentNamesForComponentTypes(['GeoLocationFilter', 'FilterSearch'])
+    getComponentNamesForComponentTypes(queryPrefixComponentComponentTypes)
       .map((name) => { return `${StorageKeys.QUERY}.${name}`; })
   );
   prefixes.push(StorageKeys.FILTER);

--- a/src/core/utils/urlutils.js
+++ b/src/core/utils/urlutils.js
@@ -118,28 +118,26 @@ export function filterParamsForExperienceLink (
   params,
   getComponentNamesForComponentTypes
 ) {
-  const prefixComponentTypes = [
+  const componentTypesToExclude = [
     ComponentTypes.FACETS,
     ComponentTypes.FILTER_BOX,
     ComponentTypes.FILTER_OPTIONS,
     ComponentTypes.RANGE_FILTER,
     ComponentTypes.DATE_RANGE_FILTER,
-    ComponentTypes.SORT_OPTIONS
-  ];
-  const queryPrefixComponentTypes = [
+    ComponentTypes.SORT_OPTIONS,
     ComponentTypes.GEOLOCATION_FILTER,
     ComponentTypes.FILTER_SEARCH
   ];
-  let prefixes = [
-    StorageKeys.FILTER
-  ];
-  prefixes = prefixes.concat(getComponentNamesForComponentTypes(prefixComponentTypes));
-  prefixes = prefixes.concat(
-    getComponentNamesForComponentTypes(queryPrefixComponentTypes)
-      .map((name) => { return `${StorageKeys.QUERY}.${name}`; })
-  );
+  let paramsToFilter = componentTypesToExclude.flatMap(type => {
+    let params = getComponentNamesForComponentTypes([type]);
+    if (type === ComponentTypes.GEOLOCATION_FILTER || type === ComponentTypes.FILTER_SEARCH) {
+      params = params.map(param => `${StorageKeys.QUERY}.${param}`);
+    }
+    return params;
+  });
+  paramsToFilter = paramsToFilter.concat([StorageKeys.FILTER]);
 
-  const newParams = removeParamsWithPrefixes(params, prefixes);
+  const newParams = removeParamsWithPrefixes(params, paramsToFilter);
   newParams.delete(StorageKeys.SEARCH_OFFSET);
   return newParams;
 }

--- a/src/core/utils/urlutils.js
+++ b/src/core/utils/urlutils.js
@@ -86,7 +86,8 @@ export function equivalentParams (params1, params2) {
 }
 
 /**
- * Creates a new params object without params that begin with the given prefixes
+ * Creates a copy of the provided {@link SearchParams}, with the specified
+ * attributes filtered out
  * @param {SearchParams} params The parameters to remove from
  * @param {string[]} prefixes The prefixes of parameters to remove
  * @return {SearchParams} A new instance of SearchParams without removed params
@@ -95,12 +96,7 @@ export function equivalentParams (params1, params2) {
 export function removeParamsWithPrefixes (params, prefixes) {
   const newParams = new SearchParams();
   for (const [key, val] of params.entries()) {
-    let includeEntry = true;
-    for (const prefix of prefixes) {
-      if (key.startsWith(prefix)) {
-        includeEntry = false;
-      }
-    }
+    const includeEntry = prefixes.every(prefix => !key.startsWith(prefix));
     if (includeEntry) {
       newParams.set(key, val);
     }
@@ -110,7 +106,7 @@ export function removeParamsWithPrefixes (params, prefixes) {
 
 /**
  * Removes parameters for filters, facets, sort options, and pagination
- * from the params provided. This is useful for constructing
+ * from the provided {@link SearchParams}. This is useful for constructing
  * inter-experience answers links.
  * @param {SearchParams} params The parameters to remove from
  * @param {function} getComponentNamesForComponentTypes Given string[]
@@ -123,25 +119,25 @@ export function filterParamsForExperienceLink (
   getComponentNamesForComponentTypes
 ) {
   const prefixComponentTypes = [
-    'FACETS',
-    'FILTER_BOX',
-    'FILTER_OPTIONS',
-    'RANGE_FILTER',
-    'DATE_RANGE_FILTER',
-    'SORT_OPTIONS'
-  ].map((component) => {
-    return ComponentTypes[component];
-  });
-  const queryPrefixComponentComponentTypes = [
-    ComponentTypes['GEOLOCATION_FILTER'],
-    ComponentTypes['FILTER_SEARCH']
+    ComponentTypes.FACETS,
+    ComponentTypes.FILTER_BOX,
+    ComponentTypes.FILTER_OPTIONS,
+    ComponentTypes.RANGE_FILTER,
+    ComponentTypes.DATE_RANGE_FILTER,
+    ComponentTypes.SORT_OPTIONS
   ];
-  let prefixes = getComponentNamesForComponentTypes(prefixComponentTypes);
+  const queryPrefixComponentComponentTypes = [
+    ComponentTypes.GEOLOCATION_FILTER,
+    ComponentTypes.FILTER_SEARCH
+  ];
+  let prefixes = [
+    StorageKeys.FILTER
+  ];
+  prefixes = prefixes.concat(getComponentNamesForComponentTypes(prefixComponentTypes));
   prefixes = prefixes.concat(
     getComponentNamesForComponentTypes(queryPrefixComponentComponentTypes)
       .map((name) => { return `${StorageKeys.QUERY}.${name}`; })
   );
-  prefixes.push(StorageKeys.FILTER);
 
   const newParams = removeParamsWithPrefixes(params, prefixes);
   newParams.delete(StorageKeys.SEARCH_OFFSET);

--- a/src/core/utils/urlutils.js
+++ b/src/core/utils/urlutils.js
@@ -82,3 +82,19 @@ export function equivalentParams (params1, params2) {
   }
   return true;
 }
+
+/**
+ * Removes params that begin with the given prefixes
+ * Note: modifies the params parameter
+ * @param {SearchParams} params The parameters to remove from
+ * @param {string[]} prefixes The prefixes of parameters to remove
+ */
+export function removeParamsWithPrefixes (params, prefixes) {
+  for (const [key] of Array.from(params.entries())) {
+    for (const prefix of prefixes) {
+      if (key.startsWith(prefix)) {
+        params.delete(key);
+      }
+    }
+  }
+}

--- a/src/ui/components/componentmanager.js
+++ b/src/ui/components/componentmanager.js
@@ -187,10 +187,20 @@ export default class ComponentManager {
     return this._activeComponents.find(c => c.constructor.type === type);
   }
 
+  /**
+   * Returns a list of all names associated with a given component type
+   * @param {string} type The type of the component
+   * @returns {string[]} The component names for the component type
+   */
   getComponentNamesForComponentType (type) {
     return this._componentTypeToComponentNames[type];
   }
 
+  /**
+   * Returns a concatenated list of all names associated with the given component types
+   * @param {string[]} type The types of the component
+   * @returns {string[]} The component names for the component types
+   */
   getComponentNamesForComponentTypes (types) {
     return types.reduce((names, type) => {
       return names.concat(this.getComponentNamesForComponentType(type) || []);

--- a/src/ui/components/componentmanager.js
+++ b/src/ui/components/componentmanager.js
@@ -41,6 +41,11 @@ export default class ComponentManager {
      * A local reference to the analytics reporter dependency
      */
     this._analyticsReporter = null;
+
+    /**
+     * A mapping from component types to component names, as these may be configured by a user
+     */
+    this._componentTypeToComponentNames = {};
   }
 
   static getInstance () {
@@ -134,6 +139,10 @@ export default class ComponentManager {
         .init(config);
 
     this._activeComponents.push(component);
+    if (!this._componentTypeToComponentNames[componentType]) {
+      this._componentTypeToComponentNames[componentType] = [];
+    }
+    this._componentTypeToComponentNames[componentType].push(component.name);
 
     // If there is a global storage to power state, apply the state
     // from the storage to the component, and then bind the component
@@ -176,5 +185,15 @@ export default class ComponentManager {
 
   getActiveComponent (type) {
     return this._activeComponents.find(c => c.constructor.type === type);
+  }
+
+  getComponentNamesForComponentType (type) {
+    return this._componentTypeToComponentNames[type];
+  }
+
+  getComponentNamesForComponentTypes (types) {
+    return types.reduce((names, type) => {
+      return names.concat(this.getComponentNamesForComponentType(type) || []);
+    }, []);
   }
 }

--- a/src/ui/components/componentmanager.js
+++ b/src/ui/components/componentmanager.js
@@ -188,22 +188,13 @@ export default class ComponentManager {
   }
 
   /**
-   * Returns a list of all names associated with a given component type
-   * @param {string} type The type of the component
-   * @returns {string[]} The component names for the component type
-   */
-  getComponentNamesForComponentType (type) {
-    return this._componentTypeToComponentNames[type];
-  }
-
-  /**
    * Returns a concatenated list of all names associated with the given component types
    * @param {string[]} type The types of the component
    * @returns {string[]} The component names for the component types
    */
   getComponentNamesForComponentTypes (types) {
     return types.reduce((names, type) => {
-      return names.concat(this.getComponentNamesForComponentType(type) || []);
+      return names.concat(this._componentTypeToComponentNames[type] || []);
     }, []);
   }
 }

--- a/src/ui/components/componenttypes.js
+++ b/src/ui/components/componenttypes.js
@@ -1,6 +1,11 @@
 /** @module */
 
-// TODO add all component types
+/**
+ * The component types is a map that contains the types for all components
+ * given some unique key.
+ * TODO: add all component types
+ * @type {Object.<string, string>}
+ */
 export default {
   FILTER_BOX: 'FilterBox',
   FILTER_OPTIONS: 'FilterOptions',

--- a/src/ui/components/componenttypes.js
+++ b/src/ui/components/componenttypes.js
@@ -1,0 +1,13 @@
+/** @module */
+
+// TODO add all component types
+export default {
+  FILTER_BOX: 'FilterBox',
+  FILTER_OPTIONS: 'FilterOptions',
+  RANGE_FILTER: 'RangeFilter',
+  DATE_RANGE_FILTER: 'DateRangeFilter',
+  FACETS: 'Facets',
+  GEOLOCATION_FILTER: 'GeoLocationFilter',
+  SORT_OPTIONS: 'SortOptions',
+  FILTER_SEARCH: 'FilterSearch'
+}

--- a/src/ui/components/componenttypes.js
+++ b/src/ui/components/componenttypes.js
@@ -1,8 +1,7 @@
 /** @module */
 
 /**
- * The component types is a map that contains the types for all components
- * given some unique key.
+ * An enum listing the different Component types supported in the SDK
  * TODO: add all component types
  * @type {Object.<string, string>}
  */

--- a/src/ui/components/componenttypes.js
+++ b/src/ui/components/componenttypes.js
@@ -10,4 +10,4 @@ export default {
   GEOLOCATION_FILTER: 'GeoLocationFilter',
   SORT_OPTIONS: 'SortOptions',
   FILTER_SEARCH: 'FilterSearch'
-}
+};

--- a/src/ui/components/filters/daterangefiltercomponent.js
+++ b/src/ui/components/filters/daterangefiltercomponent.js
@@ -5,6 +5,7 @@ import Filter from '../../../core/models/filter';
 import DOM from '../../dom/dom';
 import FilterNodeFactory from '../../../core/filters/filternodefactory';
 import FilterMetadata from '../../../core/filters/filtermetadata';
+import ComponentTypes from '../../components/componenttypes';
 
 /**
  * A filter for a range of dates
@@ -82,7 +83,7 @@ export default class DateRangeFilterComponent extends Component {
   }
 
   static get type () {
-    return 'DateRangeFilter';
+    return ComponentTypes.DATE_RANGE_FILTER;
   }
 
   setState (data) {

--- a/src/ui/components/filters/facetscomponent.js
+++ b/src/ui/components/filters/facetscomponent.js
@@ -3,6 +3,7 @@
 import Component from '../component';
 import StorageKeys from '../../../core/storage/storagekeys';
 import ResultsContext from '../../../core/storage/resultscontext';
+import ComponentTypes from '../../components/componenttypes';
 
 class FacetsConfig {
   constructor (config) {
@@ -178,7 +179,7 @@ export default class FacetsComponent extends Component {
   }
 
   static get type () {
-    return 'Facets';
+    return ComponentTypes.FACETS;
   }
 
   /**

--- a/src/ui/components/filters/filterboxcomponent.js
+++ b/src/ui/components/filters/filterboxcomponent.js
@@ -3,6 +3,7 @@
 import Component from '../component';
 import { AnswersComponentError } from '../../../core/errors/errors';
 import DOM from '../../dom/dom';
+import ComponentTypes from '../../components/componenttypes';
 
 class FilterBoxConfig {
   constructor (config) {
@@ -166,7 +167,7 @@ export default class FilterBoxComponent extends Component {
   }
 
   static get type () {
-    return 'FilterBox';
+    return ComponentTypes.FILTER_BOX;
   }
 
   static defaultTemplateName () {

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -12,6 +12,7 @@ import FilterNodeFactory from '../../../core/filters/filternodefactory';
 import FilterMetadata from '../../../core/filters/filtermetadata';
 import { groupArray } from '../../../core/utils/arrayutils';
 import FilterType from '../../../core/filters/filtertype';
+import ComponentTypes from '../../components/componenttypes';
 
 /**
  * The currently supported controls
@@ -275,7 +276,7 @@ export default class FilterOptionsComponent extends Component {
   }
 
   static get type () {
-    return 'FilterOptions';
+    return ComponentTypes.FILTER_OPTIONS;
   }
 
   /**

--- a/src/ui/components/filters/geolocationcomponent.js
+++ b/src/ui/components/filters/geolocationcomponent.js
@@ -6,6 +6,7 @@ import Filter from '../../../core/models/filter';
 import StorageKeys from '../../../core/storage/storagekeys';
 import buildSearchParameters from '../../tools/searchparamsparser';
 import FilterNodeFactory from '../../../core/filters/filternodefactory';
+import ComponentTypes from '../../components/componenttypes';
 
 const METERS_PER_MILE = 1609.344;
 
@@ -133,7 +134,7 @@ export default class GeoLocationComponent extends Component {
   }
 
   static get type () {
-    return 'GeoLocationFilter';
+    return ComponentTypes.GEOLOCATION_FILTER;
   }
 
   static defaultTemplateName () {

--- a/src/ui/components/filters/rangefiltercomponent.js
+++ b/src/ui/components/filters/rangefiltercomponent.js
@@ -5,6 +5,7 @@ import DOM from '../../dom/dom';
 import Component from '../component';
 import FilterNodeFactory from '../../../core/filters/filternodefactory';
 import FilterMetadata from '../../../core/filters/filtermetadata';
+import ComponentTypes from '../../components/componenttypes';
 
 const DEFAULT_CONFIG = {
   minPlaceholderText: 'Min',
@@ -90,7 +91,7 @@ export default class RangeFilterComponent extends Component {
   }
 
   static get type () {
-    return 'RangeFilter';
+    return ComponentTypes.RANGE_FILTER;
   }
 
   static defaultTemplateName () {

--- a/src/ui/components/filters/sortoptionscomponent.js
+++ b/src/ui/components/filters/sortoptionscomponent.js
@@ -6,6 +6,7 @@ import DOM from '../../dom/dom';
 import StorageKeys from '../../../core/storage/storagekeys';
 import ResultsContext from '../../../core/storage/resultscontext';
 import SearchStates from '../../../core/storage/searchstates';
+import ComponentTypes from '../../components/componenttypes';
 
 /**
  * Renders configuration options for sorting Vertical Results.
@@ -135,7 +136,7 @@ export default class SortOptionsComponent extends Component {
   }
 
   static get type () {
-    return 'SortOptions';
+    return ComponentTypes.SORT_OPTIONS;
   }
 
   static defaultTemplateName () {

--- a/src/ui/components/navigation/navigationcomponent.js
+++ b/src/ui/components/navigation/navigationcomponent.js
@@ -483,23 +483,17 @@ export default class NavigationComponent extends Component {
     // URLS we create, except for facets/filters/pagination
     params.set('tabOrder', this._tabOrder);
 
-    const prefixes = this.componentManager.getComponentNamesForComponentTypes([
-      'Facets',
-      'FilterBox',
-      'FilterOptions',
-      'RangeFilter',
-      'DateRangeFilter',
-      'SortOptions'
-    ]);
-    prefixes.concat(this.componentManager.getComponentNamesForComponentTypes(['GeoLocationFilter'])
-      .map((name) => { return `${StorageKeys.QUERY}.${name}`; })
-    );
-    prefixes.concat(this.componentManager.getComponentNamesForComponentTypes(['FilterSearch'])
-      .map((name) => { return `${StorageKeys.QUERY}.${name}`; })
-    );
-
     params.delete(StorageKeys.SEARCH_OFFSET);
-    params.delete(StorageKeys.FILTER);
+
+    let prefixes = this.componentManager.getComponentNamesForComponentTypes([
+      'Facets', 'FilterBox', 'FilterOptions', 'RangeFilter', 'DateRangeFilter', 'SortOptions'
+    ]);
+    prefixes = prefixes.concat(
+      this.componentManager
+        .getComponentNamesForComponentTypes(['GeoLocationFilter', 'FilterSearch'])
+        .map((name) => { return `${StorageKeys.QUERY}.${name}`; })
+    );
+    prefixes.push(StorageKeys.FILTER);
     removeParamsWithPrefixes(params, prefixes);
 
     return baseUrl + '?' + params.toString();

--- a/src/ui/components/navigation/navigationcomponent.js
+++ b/src/ui/components/navigation/navigationcomponent.js
@@ -484,7 +484,7 @@ export default class NavigationComponent extends Component {
     params.set('tabOrder', this._tabOrder);
     const filteredParams = filterParamsForExperienceLink(
       params,
-      this.componentManager.getComponentNamesForComponentTypes
+      this.componentManager.getComponentNamesForComponentTypes.bind(this.componentManager)
     );
 
     return baseUrl + '?' + filteredParams.toString();

--- a/src/ui/components/navigation/navigationcomponent.js
+++ b/src/ui/components/navigation/navigationcomponent.js
@@ -483,19 +483,24 @@ export default class NavigationComponent extends Component {
     // URLS we create, except for facets/filters/pagination
     params.set('tabOrder', this._tabOrder);
 
+    const prefixes = this.componentManager.getComponentNamesForComponentTypes([
+      'Facets',
+      'FilterBox',
+      'FilterOptions',
+      'RangeFilter',
+      'DateRangeFilter',
+      'SortOptions'
+    ]);
+    prefixes.concat(this.componentManager.getComponentNamesForComponentTypes(['GeoLocationFilter'])
+      .map((name) => { return `${StorageKeys.QUERY}.${name}`; })
+    );
+    prefixes.concat(this.componentManager.getComponentNamesForComponentTypes(['FilterSearch'])
+      .map((name) => { return `${StorageKeys.QUERY}.${name}`; })
+    );
+
     params.delete(StorageKeys.SEARCH_OFFSET);
     params.delete(StorageKeys.FILTER);
-    removeParamsWithPrefixes(
-      params,
-      this.componentManager.getComponentNamesForComponentTypes([
-        'Facets',
-        'FilterBox',
-        'FilterOptions',
-        'RangeFilter',
-        'DateRangeFilter',
-        'SortOptions'
-      ])
-    );
+    removeParamsWithPrefixes(params, prefixes);
 
     return baseUrl + '?' + params.toString();
   }

--- a/src/ui/components/navigation/navigationcomponent.js
+++ b/src/ui/components/navigation/navigationcomponent.js
@@ -7,7 +7,7 @@ import { AnswersComponentError } from '../../../core/errors/errors';
 import StorageKeys from '../../../core/storage/storagekeys';
 import SearchParams from '../../dom/searchparams';
 import DOM from '../../dom/dom';
-import { removeParamsWithPrefixes } from '../../../core/utils/urlutils.js';
+import { filterParamsForExperienceLink } from '../../../core/utils/urlutils.js';
 
 /**
  * The debounce duration for resize events
@@ -482,19 +482,11 @@ export default class NavigationComponent extends Component {
     // We want to persist the params from the existing URL to the new
     // URLS we create, except for facets/filters/pagination
     params.set('tabOrder', this._tabOrder);
-    params.delete(StorageKeys.SEARCH_OFFSET);
-
-    let prefixes = this.componentManager.getComponentNamesForComponentTypes([
-      'Facets', 'FilterBox', 'FilterOptions', 'RangeFilter', 'DateRangeFilter', 'SortOptions'
-    ]);
-    prefixes = prefixes.concat(
-      this.componentManager
-        .getComponentNamesForComponentTypes(['GeoLocationFilter', 'FilterSearch'])
-        .map((name) => { return `${StorageKeys.QUERY}.${name}`; })
+    const filteredParams = filterParamsForExperienceLink(
+      params,
+      this.componentManager.getComponentNamesForComponentTypes
     );
-    prefixes.push(StorageKeys.FILTER);
-    removeParamsWithPrefixes(params, prefixes);
 
-    return baseUrl + '?' + params.toString();
+    return baseUrl + '?' + filteredParams.toString();
   }
 }

--- a/src/ui/components/navigation/navigationcomponent.js
+++ b/src/ui/components/navigation/navigationcomponent.js
@@ -7,6 +7,7 @@ import { AnswersComponentError } from '../../../core/errors/errors';
 import StorageKeys from '../../../core/storage/storagekeys';
 import SearchParams from '../../dom/searchparams';
 import DOM from '../../dom/dom';
+import { removeParamsWithPrefixes } from '../../../core/utils/urlutils.js';
 
 /**
  * The debounce duration for resize events
@@ -479,8 +480,23 @@ export default class NavigationComponent extends Component {
     }
 
     // We want to persist the params from the existing URL to the new
-    // URLS we create.
+    // URLS we create, except for facets/filters/pagination
     params.set('tabOrder', this._tabOrder);
+
+    params.delete(StorageKeys.SEARCH_OFFSET);
+    params.delete(StorageKeys.FILTER);
+    removeParamsWithPrefixes(
+      params,
+      this.componentManager.getComponentNamesForComponentTypes([
+        'Facets',
+        'FilterBox',
+        'FilterOptions',
+        'RangeFilter',
+        'DateRangeFilter',
+        'SortOptions'
+      ])
+    );
+
     return baseUrl + '?' + params.toString();
   }
 }

--- a/src/ui/components/navigation/navigationcomponent.js
+++ b/src/ui/components/navigation/navigationcomponent.js
@@ -482,7 +482,6 @@ export default class NavigationComponent extends Component {
     // We want to persist the params from the existing URL to the new
     // URLS we create, except for facets/filters/pagination
     params.set('tabOrder', this._tabOrder);
-
     params.delete(StorageKeys.SEARCH_OFFSET);
 
     let prefixes = this.componentManager.getComponentNamesForComponentTypes([

--- a/src/ui/components/navigation/navigationcomponent.js
+++ b/src/ui/components/navigation/navigationcomponent.js
@@ -484,7 +484,7 @@ export default class NavigationComponent extends Component {
     params.set('tabOrder', this._tabOrder);
     const filteredParams = filterParamsForExperienceLink(
       params,
-      this.componentManager.getComponentNamesForComponentTypes.bind(this.componentManager)
+      types => this.componentManager.getComponentNamesForComponentTypes(types)
     );
 
     return baseUrl + '?' + filteredParams.toString();

--- a/src/ui/components/results/alternativeverticalscomponent.js
+++ b/src/ui/components/results/alternativeverticalscomponent.js
@@ -128,7 +128,7 @@ export default class AlternativeVerticalsComponent extends Component {
       this.componentManager.getComponentNamesForComponentTypes.bind(this.componentManager)
     );
 
-    for (let alternativeVertical of alternativeVerticals) {
+    for (const alternativeVertical of alternativeVerticals) {
       const verticalKey = alternativeVertical.verticalConfigId;
 
       const matchingVerticalConfig = verticalsConfig.find(config => {

--- a/src/ui/components/results/alternativeverticalscomponent.js
+++ b/src/ui/components/results/alternativeverticalscomponent.js
@@ -125,7 +125,7 @@ export default class AlternativeVerticalsComponent extends Component {
 
     const filteredParams = filterParamsForExperienceLink(
       params,
-      this.componentManager.getComponentNamesForComponentTypes.bind(this.componentManager)
+      types => this.componentManager.getComponentNamesForComponentTypes(types)
     );
 
     for (const alternativeVertical of alternativeVerticals) {

--- a/src/ui/components/results/alternativeverticalscomponent.js
+++ b/src/ui/components/results/alternativeverticalscomponent.js
@@ -125,7 +125,7 @@ export default class AlternativeVerticalsComponent extends Component {
 
     const filteredParams = filterParamsForExperienceLink(
       params,
-      this.componentManager.getComponentNamesForComponentTypes
+      this.componentManager.getComponentNamesForComponentTypes.bind(this.componentManager)
     );
 
     for (let alternativeVertical of alternativeVerticals) {

--- a/src/ui/components/results/alternativeverticalscomponent.js
+++ b/src/ui/components/results/alternativeverticalscomponent.js
@@ -3,7 +3,7 @@
 import AlternativeVertical from '../../../core/models/alternativevertical';
 import Component from '../component';
 import StorageKeys from '../../../core/storage/storagekeys';
-import { replaceUrlParams } from '../../../core/utils/urlutils';
+import { replaceUrlParams, removeParamsWithPrefixes } from '../../../core/utils/urlutils';
 import SearchParams from '../../dom/searchparams';
 
 export default class AlternativeVerticalsComponent extends Component {
@@ -123,7 +123,18 @@ export default class AlternativeVerticalsComponent extends Component {
       params[StorageKeys.SESSIONS_OPT_IN] = sessionsOptIn.value;
     }
 
-    for (const alternativeVertical of alternativeVerticals) {
+    let prefixes = this.componentManager.getComponentNamesForComponentTypes([
+      'Facets', 'FilterBox', 'FilterOptions', 'RangeFilter', 'DateRangeFilter', 'SortOptions'
+    ]);
+    prefixes = prefixes.concat(
+      this.componentManager
+        .getComponentNamesForComponentTypes(['GeoLocationFilter', 'FilterSearch'])
+        .map((name) => { return `${StorageKeys.QUERY}.${name}`; })
+    );
+    prefixes.push(StorageKeys.FILTER);
+    removeParamsWithPrefixes(params, prefixes);
+
+    for (let alternativeVertical of alternativeVerticals) {
       const verticalKey = alternativeVertical.verticalConfigId;
 
       const matchingVerticalConfig = verticalsConfig.find(config => {

--- a/src/ui/components/results/alternativeverticalscomponent.js
+++ b/src/ui/components/results/alternativeverticalscomponent.js
@@ -123,6 +123,7 @@ export default class AlternativeVerticalsComponent extends Component {
       params[StorageKeys.SESSIONS_OPT_IN] = sessionsOptIn.value;
     }
 
+    params.delete(StorageKeys.SEARCH_OFFSET);
     let prefixes = this.componentManager.getComponentNamesForComponentTypes([
       'Facets', 'FilterBox', 'FilterOptions', 'RangeFilter', 'DateRangeFilter', 'SortOptions'
     ]);

--- a/src/ui/components/results/alternativeverticalscomponent.js
+++ b/src/ui/components/results/alternativeverticalscomponent.js
@@ -3,7 +3,7 @@
 import AlternativeVertical from '../../../core/models/alternativevertical';
 import Component from '../component';
 import StorageKeys from '../../../core/storage/storagekeys';
-import { replaceUrlParams, removeParamsWithPrefixes } from '../../../core/utils/urlutils';
+import { replaceUrlParams, filterParamsForExperienceLink } from '../../../core/utils/urlutils';
 import SearchParams from '../../dom/searchparams';
 
 export default class AlternativeVerticalsComponent extends Component {
@@ -123,17 +123,10 @@ export default class AlternativeVerticalsComponent extends Component {
       params[StorageKeys.SESSIONS_OPT_IN] = sessionsOptIn.value;
     }
 
-    params.delete(StorageKeys.SEARCH_OFFSET);
-    let prefixes = this.componentManager.getComponentNamesForComponentTypes([
-      'Facets', 'FilterBox', 'FilterOptions', 'RangeFilter', 'DateRangeFilter', 'SortOptions'
-    ]);
-    prefixes = prefixes.concat(
-      this.componentManager
-        .getComponentNamesForComponentTypes(['GeoLocationFilter', 'FilterSearch'])
-        .map((name) => { return `${StorageKeys.QUERY}.${name}`; })
+    const filteredParams = filterParamsForExperienceLink(
+      params,
+      this.componentManager.getComponentNamesForComponentTypes
     );
-    prefixes.push(StorageKeys.FILTER);
-    removeParamsWithPrefixes(params, prefixes);
 
     for (let alternativeVertical of alternativeVerticals) {
       const verticalKey = alternativeVertical.verticalConfigId;
@@ -148,7 +141,7 @@ export default class AlternativeVerticalsComponent extends Component {
 
       verticals.push(new AlternativeVertical({
         label: matchingVerticalConfig.label,
-        url: replaceUrlParams(matchingVerticalConfig.url, params),
+        url: replaceUrlParams(matchingVerticalConfig.url, filteredParams),
         iconName: matchingVerticalConfig.icon,
         iconUrl: matchingVerticalConfig.iconUrl,
         resultsCount: alternativeVertical.resultsCount

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -276,7 +276,7 @@ export default class VerticalResultsComponent extends Component {
 
     const filteredParams = filterParamsForExperienceLink(
       params,
-      this.componentManager.getComponentNamesForComponentTypes.bind(this.componentManager)
+      types => this.componentManager.getComponentNamesForComponentTypes(types)
     );
 
     return replaceUrlParams(baseUrl, filteredParams);

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -9,7 +9,7 @@ import StorageKeys from '../../../core/storage/storagekeys';
 import SearchStates from '../../../core/storage/searchstates';
 import CardComponent from '../cards/cardcomponent';
 import ResultsHeaderComponent from './resultsheadercomponent';
-import { replaceUrlParams, removeParamsWithPrefixes } from '../../../core/utils/urlutils';
+import { replaceUrlParams, filterParamsForExperienceLink } from '../../../core/utils/urlutils';
 import Icons from '../../icons/index';
 import { defaultConfigOption } from '../../../core/utils/configutils';
 import SearchParams from '../../dom/searchparams';
@@ -271,19 +271,12 @@ export default class VerticalResultsComponent extends Component {
       params.set(StorageKeys.SESSIONS_OPT_IN, sessionsOptIn.value);
     }
 
-    params.delete(StorageKeys.SEARCH_OFFSET);
-    let prefixes = this.componentManager.getComponentNamesForComponentTypes([
-      'Facets', 'FilterBox', 'FilterOptions', 'RangeFilter', 'DateRangeFilter', 'SortOptions'
-    ]);
-    prefixes = prefixes.concat(
-      this.componentManager
-        .getComponentNamesForComponentTypes(['GeoLocationFilter', 'FilterSearch'])
-        .map((name) => { return `${StorageKeys.QUERY}.${name}`; })
+    const filteredParams = filterParamsForExperienceLink(
+      params,
+      this.componentManager.getComponentNamesForComponentTypes
     );
-    prefixes.push(StorageKeys.FILTER);
-    removeParamsWithPrefixes(params, prefixes);
 
-    return replaceUrlParams(baseUrl, params);
+    return replaceUrlParams(baseUrl, filteredParams);
   }
 
   setState (data = {}, val) {

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -271,6 +271,7 @@ export default class VerticalResultsComponent extends Component {
       params.set(StorageKeys.SESSIONS_OPT_IN, sessionsOptIn.value);
     }
 
+    params.delete(StorageKeys.SEARCH_OFFSET);
     let prefixes = this.componentManager.getComponentNamesForComponentTypes([
       'Facets', 'FilterBox', 'FilterOptions', 'RangeFilter', 'DateRangeFilter', 'SortOptions'
     ]);

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -241,8 +241,11 @@ export default class VerticalResultsComponent extends Component {
   }
 
   getVerticalURL (data = {}) {
-    const verticalConfig = this._verticalsConfig.find(config => config.verticalKey === this.verticalKey) || {};
-    const verticalURL = this._config.verticalURL || verticalConfig.url || data.verticalURL || this.verticalKey + '.html';
+    const verticalConfig = this._verticalsConfig.find(
+      config => config.verticalKey === this.verticalKey
+    ) || {};
+    const verticalURL = this._config.verticalURL || verticalConfig.url ||
+      data.verticalURL || this.verticalKey + '.html';
     return this._getExperienceURL(verticalURL);
   }
 

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -273,7 +273,7 @@ export default class VerticalResultsComponent extends Component {
 
     const filteredParams = filterParamsForExperienceLink(
       params,
-      this.componentManager.getComponentNamesForComponentTypes
+      this.componentManager.getComponentNamesForComponentTypes.bind(this.componentManager)
     );
 
     return replaceUrlParams(baseUrl, filteredParams);

--- a/src/ui/components/search/filtersearchcomponent.js
+++ b/src/ui/components/search/filtersearchcomponent.js
@@ -7,6 +7,7 @@ import Filter from '../../../core/models/filter';
 import SearchParams from '../../dom/searchparams';
 import buildSearchParameters from '../../tools/searchparamsparser';
 import FilterNodeFactory from '../../../core/filters/filternodefactory';
+import ComponentTypes from '../../components/componenttypes';
 
 /**
  * FilterSearchComponent is used for autocomplete using the FilterSearch backend.
@@ -117,7 +118,7 @@ export default class FilterSearchComponent extends Component {
   }
 
   static get type () {
-    return 'FilterSearch';
+    return ComponentTypes.FILTER_SEARCH;
   }
 
   /**

--- a/tests/acceptance/acceptancesuite.js
+++ b/tests/acceptance/acceptancesuite.js
@@ -175,7 +175,7 @@ test('Facets, pagination, and filters do not persist accross experience links', 
   await t.expect(changeFiltersLink).contains('referrerPageUrl');
   await verifyCleanLink(changeFiltersLink);
 
-  const viewAllLink = await Selector('.yxt-ResultsHeader-changeFilters')
+  const viewAllLink = await Selector('.yxt-Results-viewAllLink')
     .nth(0).getAttribute('href');
   await t.expect(viewAllLink).contains('referrerPageUrl');
   await verifyCleanLink(viewAllLink);

--- a/tests/acceptance/acceptancesuite.js
+++ b/tests/acceptance/acceptancesuite.js
@@ -158,13 +158,13 @@ test('Facets, pagination, and filters do not persist accross experience links', 
   await searchComponent.enterQuery('virginia');
   await searchComponent.submitQuery();
 
-  const changeFiltersLink = await
-    Selector('.yxt-ResultsHeader-changeFilters').nth(0).getAttribute('href');
+  const changeFiltersLink = await Selector('.yxt-ResultsHeader-changeFilters')
+    .nth(0).getAttribute('href');
   await t.expect(changeFiltersLink).contains('referrerPageUrl');
   await verifyCleanLink(changeFiltersLink);
 
-  const viewAllLink = await
-    Selector('.yxt-ResultsHeader-changeFilters').nth(0).getAttribute('href');
+  const viewAllLink = await Selector('.yxt-ResultsHeader-changeFilters')
+    .nth(0).getAttribute('href');
   await t.expect(viewAllLink).contains('referrerPageUrl');
   await verifyCleanLink(viewAllLink);
 });

--- a/tests/acceptance/acceptancesuite.js
+++ b/tests/acceptance/acceptancesuite.js
@@ -46,6 +46,15 @@ test('pagination flow', async t => {
   await t.expect(pageNum).eql('Page 2');
 });
 
+fixture`Experience links work as expected`
+  .before(setupServer)
+  .after(shutdownServer)
+  .page`http://localhost:9999/tests/acceptance/fixtures/html/facets`;
+
+test('Facets, pagination, and filters do not persist accross experience links', async t => {
+  // TODO
+});
+
 fixture`Facets page`
   .before(setupServer)
   .after(shutdownServer)

--- a/tests/acceptance/acceptancesuite.js
+++ b/tests/acceptance/acceptancesuite.js
@@ -139,6 +139,18 @@ test('Facets, pagination, and filters do not persist accross experience links', 
   await t.expect(universalUrl).contains('referrerPageUrl');
   await verifyCleanLink(universalUrl);
 
+  // When you apply sort options, nav links should be clean
+  await t.click(await Selector('.yxt-SortOptions-optionSelector').nth(2)); // Click search option
+  universalUrl = await Selector('.js-yxt-navItem').nth(0).getAttribute('href');
+  await t.expect(universalUrl).contains('referrerPageUrl');
+  await verifyCleanLink(universalUrl);
+
+  // When you apply static filters, nav links should be clean
+  await t.click(await Selector('.filterbox-container .js-yext-filter-option').nth(2)); // Click static filter
+  universalUrl = await Selector('.js-yxt-navItem').nth(0).getAttribute('href');
+  await t.expect(universalUrl).contains('referrerPageUrl');
+  await verifyCleanLink(universalUrl);
+
   // When you navigate with pagination, nav links should not have the
   // Facets/filter/pagination parameters
   await searchComponent.enterQuery('all');

--- a/tests/acceptance/acceptancesuite.js
+++ b/tests/acceptance/acceptancesuite.js
@@ -2,6 +2,7 @@ import UniversalPage from './pageobjects/universalpage';
 import VerticalPage from './pageobjects/verticalpage';
 import { setupServer, shutdownServer } from './server';
 import FacetsPage from './pageobjects/facetspage';
+import { Selector } from 'testcafe';
 
 /**
  * This file contains acceptance tests for a universal search page.
@@ -44,15 +45,6 @@ test('pagination flow', async t => {
   await paginationComponent.clickNextButton();
   const pageNum = await paginationComponent.getActivePageLabelAndNumber();
   await t.expect(pageNum).eql('Page 2');
-});
-
-fixture`Experience links work as expected`
-  .before(setupServer)
-  .after(shutdownServer)
-  .page`http://localhost:9999/tests/acceptance/fixtures/html/facets`;
-
-test('Facets, pagination, and filters do not persist accross experience links', async t => {
-  // TODO
 });
 
 fixture`Facets page`
@@ -113,4 +105,66 @@ test(`Facets load on the page, and can affect the search`, async t => {
   await filterBox.applyFilters();
   actualResultsCount = await verticalResultsComponent.getResultsCountTotal();
   await t.expect(actualResultsCount).eql(initialResultsCount);
+});
+
+fixture`Experience links work as expected`
+  .before(setupServer)
+  .after(shutdownServer)
+  .page`http://localhost:9999/tests/acceptance/fixtures/html/facets`;
+
+test('Facets, pagination, and filters do not persist accross experience links', async t => {
+  const verifyCleanLink = async (link) => {
+    await t.expect(universalUrl).notContains('Facets');
+    await t.expect(universalUrl).notContains('filter');
+    await t.expect(universalUrl).notContains('search-offset');
+  };
+
+  // When you land, nav links should not have the Facets/filter/pagination parameters
+  let universalUrl = await Selector('.js-yxt-navItem').nth(0).getAttribute('href');
+  await t.expect(universalUrl).contains('universal');
+  await t.expect(universalUrl).contains('referrerPageUrl');
+  await verifyCleanLink(universalUrl);
+
+  // When you search, nav links should not have the Facets/filter/pagination parameters
+  const searchComponent = FacetsPage.getSearchComponent();
+  await searchComponent.submitQuery();
+
+  const facets = FacetsPage.getFacetsComponent();
+  const filterBox = facets.getFilterBox();
+  const employeeDepartment = await filterBox.getFilterOptions('Employee Department');
+  await employeeDepartment.toggleOption('Client Delivery');
+  await filterBox.applyFilters();
+
+  universalUrl = await Selector('.js-yxt-navItem').nth(0).getAttribute('href');
+  await t.expect(universalUrl).contains('referrerPageUrl');
+  await verifyCleanLink(universalUrl);
+
+  // When you navigate with pagination, nav links should not have the
+  // Facets/filter/pagination parameters
+  await searchComponent.enterQuery('all');
+  await searchComponent.submitQuery();
+
+  await t.click(await Selector('.js-yxt-navItem').nth(2)); // Go to vertical page
+  await t.click(await Selector('.js-yxt-Pagination-next').nth(0)); // Page forward
+  universalUrl = await Selector('.js-yxt-navItem').nth(0).getAttribute('href');
+  await t.expect(universalUrl).contains('referrerPageUrl');
+  await verifyCleanLink(universalUrl);
+
+  // View All links AND Change Filters links should not have
+  // Facets/filter/pagination parameters (though those components are not
+  // allowed on universal currently)
+  await t.click(await Selector('.js-yxt-navItem').nth(0)); // Go to universal page
+  await searchComponent.clearQuery();
+  await searchComponent.enterQuery('virginia');
+  await searchComponent.submitQuery();
+
+  const changeFiltersLink = await
+    Selector('.yxt-ResultsHeader-changeFilters').nth(0).getAttribute('href');
+  await t.expect(changeFiltersLink).contains('referrerPageUrl');
+  await verifyCleanLink(changeFiltersLink);
+
+  const viewAllLink = await
+    Selector('.yxt-ResultsHeader-changeFilters').nth(0).getAttribute('href');
+  await t.expect(viewAllLink).contains('referrerPageUrl');
+  await verifyCleanLink(viewAllLink);
 });

--- a/tests/acceptance/fixtures/html/facets.html
+++ b/tests/acceptance/fixtures/html/facets.html
@@ -11,6 +11,7 @@
 <body>
   <div class="answers-container">
     <div class="search-bar-container"></div>
+    <div class="navigation-container"></div>
     <div class="facets-container"></div>
     <div class="filter-search-container"></div>
     <div class="results-container"></div>
@@ -33,6 +34,26 @@
           promptForLocation: true,
           verticalKey: 'people',
           allowEmptySearch: true
+        });
+
+        this.addComponent('Navigation', {
+          container: '.navigation-container',
+          verticalPages: [
+            {
+              label: 'Home',
+              url: './universal',
+              isFirst: true
+            },
+            {
+              label: 'Facets',
+              url: './links',
+              isActive: true
+            },
+            {
+              label: 'Vertical',
+              url: './vertical',
+            }
+          ],
         });
 
         this.addComponent('VerticalResults', {

--- a/tests/acceptance/fixtures/html/facets.html
+++ b/tests/acceptance/fixtures/html/facets.html
@@ -12,6 +12,8 @@
   <div class="answers-container">
     <div class="search-bar-container"></div>
     <div class="navigation-container"></div>
+    <div class="sort-options-container"></div>
+    <div class="filterbox-container"></div>
     <div class="facets-container"></div>
     <div class="filter-search-container"></div>
     <div class="results-container"></div>
@@ -54,6 +56,60 @@
               url: './vertical',
             }
           ],
+        });
+
+        this.addComponent('SortOptions', {
+          container: '.sort-options-container',
+          options: [
+            {
+              type: 'FIELD',
+                field: 'c_popularity',
+                direction: 'DESC',
+                label: 'Popularity'
+            },
+            {
+              type: "ENTITY_DISTANCE",
+              label: 'Recently Released'
+            },
+            {
+              type: 'RELEVANCE',
+              label: 'Price - Low to High'
+            },
+            {
+              type: 'RELEVANCE',
+              label: 'Price - High to Low'
+            }  
+          ],
+          verticalKey: 'people'
+        });
+
+        ANSWERS.addComponent('FilterBox', {
+          container: '.filterbox-container',
+          filters: [
+            {
+              type: "FilterOptions",
+              label: "DISTANCE",
+              optionType: "RADIUS_FILTER",
+              control: "singleoption",
+              options: [
+                {
+                  "label": "5 miles",
+                  "value": 8046.72, //NEW
+                },
+                {
+                  "label": "10 miles",
+                  "value": 16093.4, //NEW
+                },
+                {
+                  "label": "25 miles",
+                  "value": 40233.6, //NEW
+                },
+              ]
+            },
+          ],
+          verticalKey: 'people',
+          searchOnChange: true,
+          expand: false
         });
 
         this.addComponent('VerticalResults', {

--- a/tests/acceptance/fixtures/html/universal.html
+++ b/tests/acceptance/fixtures/html/universal.html
@@ -9,6 +9,7 @@
     <body>
         <div class="answers-container">
             <div class="search-bar-container"></div>
+            <div class="navigation-container"></div>
             <div class="results-container"></div>
         </div>
     
@@ -26,8 +27,31 @@
                         promptForLocation: true
                     });
 
+                    this.addComponent('Navigation', {
+                      container: '.navigation-container',
+                      verticalPages: [
+                        {
+                          label: 'Home',
+                          url: './universal',
+                          isFirst: true
+                        },
+                        {
+                          label: 'Facets',
+                          url: './links',
+                          isActive: true
+                        },
+                        {
+                          label: 'Vertical',
+                          url: './vertical',
+                        }
+                      ],
+                    });
+
                     this.addComponent('UniversalResults', {
                         container: '.results-container',
+                        appliedFilters: {
+                          showChangeFilters: true,
+                        },
                         config: {
                             "people": {
                                 includeMap: true,

--- a/tests/acceptance/fixtures/html/vertical.html
+++ b/tests/acceptance/fixtures/html/vertical.html
@@ -9,6 +9,7 @@
     <body>
         <div class="answers-container">
             <div class="search-bar-container"></div>
+            <div class="navigation-container"></div>
             <div class="results-container"></div>
             <div class="pagination-container"></div>
         </div>
@@ -30,6 +31,26 @@
                         verticalKey:'KM',
                         clearButton: true,
                         promptForLocation: true
+                    });
+
+                    this.addComponent('Navigation', {
+                      container: '.navigation-container',
+                      verticalPages: [
+                        {
+                          label: 'Home',
+                          url: './universal',
+                          isFirst: true
+                        },
+                        {
+                          label: 'Facets',
+                          url: './links',
+                          isActive: true
+                        },
+                        {
+                          label: 'Vertical',
+                          url: './vertical',
+                        }
+                      ],
                     });
 
                     this.addComponent('VerticalResults', {

--- a/tests/core/utils/urlutils.js
+++ b/tests/core/utils/urlutils.js
@@ -7,7 +7,8 @@ import {
   getAnalyticsUrl,
   replaceUrlParams,
   urlWithoutQueryParamsAndHash,
-  equivalentParams
+  equivalentParams,
+  removeParamsWithPrefixes
 } from '../../../src/core/utils/urlutils';
 
 const baseUrl = 'https://yext.com/';
@@ -101,5 +102,33 @@ describe('equivalentParams works', () => {
     const params3 = new SearchParams(paramsString);
     expect(equivalentParams(params2, params3)).toEqual(true);
     expect(equivalentParams(params3, params2)).toEqual(true);
+  });
+});
+
+describe('removeParamsWithPrefixes works', () => {
+  const baseParams = new SearchParams('?query=all&referrerPageUrl=&search-offset=10&Facets.filterbox.filter1=hello&Facets.filterbox.filter2=bye&FilterBox.filter1=what');
+
+  it('does not blow up on empty function parameters', () => {
+    const params2 = new SearchParams(baseParams.toString());
+    removeParamsWithPrefixes(params2, []);
+    expect(params2).toEqual(baseParams);
+
+    const params3 = new SearchParams();
+    removeParamsWithPrefixes(params3, ['query', 'Facets']);
+    expect(params3).toEqual(new SearchParams());
+
+    const params4 = new SearchParams();
+    removeParamsWithPrefixes(params4, []);
+    expect(params4).toEqual(new SearchParams());
+  });
+
+  it('removes params with multiple prefixes', () => {
+    const params2 = new SearchParams(baseParams.toString());
+    removeParamsWithPrefixes(params2, ['search', 'Facets', 'referrer']);
+    expect(params2).toEqual(new SearchParams('?query=all&FilterBox.filter1=what'));
+
+    const params3 = new SearchParams(baseParams.toString());
+    removeParamsWithPrefixes(params3, ['search', 'Facets', 'referrer', 'search']);
+    expect(params2).toEqual(new SearchParams('?query=all&FilterBox.filter1=what'));
   });
 });

--- a/tests/core/utils/urlutils.js
+++ b/tests/core/utils/urlutils.js
@@ -109,26 +109,21 @@ describe('removeParamsWithPrefixes works', () => {
   const baseParams = new SearchParams('?query=all&referrerPageUrl=&search-offset=10&Facets.filterbox.filter1=hello&Facets.filterbox.filter2=bye&FilterBox.filter1=what');
 
   it('does not blow up on empty function parameters', () => {
-    const params2 = new SearchParams(baseParams.toString());
-    removeParamsWithPrefixes(params2, []);
+    const params2 = removeParamsWithPrefixes(new SearchParams(baseParams.toString()), []);
     expect(params2).toEqual(baseParams);
 
-    const params3 = new SearchParams();
-    removeParamsWithPrefixes(params3, ['query', 'Facets']);
+    const params3 = removeParamsWithPrefixes(new SearchParams(), ['query', 'Facets']);
     expect(params3).toEqual(new SearchParams());
 
-    const params4 = new SearchParams();
-    removeParamsWithPrefixes(params4, []);
+    const params4 = removeParamsWithPrefixes(new SearchParams(), []);
     expect(params4).toEqual(new SearchParams());
   });
 
   it('removes params with multiple prefixes', () => {
-    const params2 = new SearchParams(baseParams.toString());
-    removeParamsWithPrefixes(params2, ['search', 'Facets', 'referrer']);
+    const params2 = removeParamsWithPrefixes(new SearchParams(baseParams.toString()), ['search', 'Facets', 'referrer']);
     expect(params2).toEqual(new SearchParams('?query=all&FilterBox.filter1=what'));
 
-    const params3 = new SearchParams(baseParams.toString());
-    removeParamsWithPrefixes(params3, ['search', 'Facets', 'referrer', 'search']);
-    expect(params2).toEqual(new SearchParams('?query=all&FilterBox.filter1=what'));
+    const params3 = removeParamsWithPrefixes(new SearchParams(baseParams.toString()), ['search', 'Facets', 'referrer', 'search']);
+    expect(params3).toEqual(new SearchParams('?query=all&FilterBox.filter1=what'));
   });
 });

--- a/tests/setup/mockcomponentmanager.js
+++ b/tests/setup/mockcomponentmanager.js
@@ -69,9 +69,6 @@ export default class MockComponentManager {
     throw new Error('getActiveComponent is not implemented');
   }
 
-  getComponentNamesForComponentType () {
-    throw new Error('getComponentNamesForComponentType is not implemented');
-  }
   getComponentNamesForComponentTypes () {
     throw new Error('getComponentNamesForComponentTypes is not implemented');
   }

--- a/tests/setup/mockcomponentmanager.js
+++ b/tests/setup/mockcomponentmanager.js
@@ -68,4 +68,11 @@ export default class MockComponentManager {
   getActiveComponent () {
     throw new Error('getActiveComponent is not implemented');
   }
+
+  getComponentNamesForComponentType () {
+    throw new Error('getComponentNamesForComponentType is not implemented');
+  }
+  getComponentNamesForComponentTypes () {
+    throw new Error('getComponentNamesForComponentTypes is not implemented');
+  }
 }

--- a/tests/ui/components/navigation/navigationcomponent.js
+++ b/tests/ui/components/navigation/navigationcomponent.js
@@ -125,9 +125,6 @@ describe('navigation component configuration', () => {
   };
   const mockedComponentManager = (config) => {
     const manager = mockManager(mockedCore(config));
-    manager.getComponentNamesForComponentType = () => {
-      return [];
-    };
     manager.getComponentNamesForComponentTypes = () => {
       return [];
     };

--- a/tests/ui/components/navigation/navigationcomponent.js
+++ b/tests/ui/components/navigation/navigationcomponent.js
@@ -2,6 +2,7 @@ import DOM from '../../../../src/ui/dom/dom';
 import NavigationComponent, { Tab } from '../../../../src/ui/components/navigation/navigationcomponent';
 import VerticalPagesConfig from '../../../../src/core/models/verticalpagesconfig';
 import StorageKeys from '../../../../src/core/storage/storagekeys';
+import mockManager from '../../../setup/managermocker';
 
 // The DOM doesn't exist within components in the JEST environment,
 // so we have to provide it to our DOM API properly.
@@ -122,6 +123,16 @@ describe('navigation component configuration', () => {
       }
     };
   };
+  const mockedComponentManager = (config) => {
+    const manager = mockManager(mockedCore(config));
+    manager.getComponentNamesForComponentType = () => {
+      return [];
+    };
+    manager.getComponentNamesForComponentTypes = () => {
+      return [];
+    };
+    return manager;
+  };
 
   it('component supports default tab ordering from config', () => {
     const tabConfig = [
@@ -142,7 +153,8 @@ describe('navigation component configuration', () => {
     let navComponent = new NavigationComponent({
       container: '.test-component'
     }, {
-      core: mockedCore(tabConfig)
+      core: mockedCore(tabConfig),
+      componentManager: mockedComponentManager(tabConfig)
     });
 
     const defaultOrder = navComponent.getDefaultTabOrder(tabConfig);
@@ -167,7 +179,8 @@ describe('navigation component configuration', () => {
     let navComponent = new NavigationComponent({
       container: '.test-component'
     }, {
-      core: mockedCore(tabConfig)
+      core: mockedCore(tabConfig),
+      componentManager: mockedComponentManager(tabConfig)
     });
 
     let params = new URLSearchParams('tabOrder=tab2,tab1');
@@ -193,7 +206,8 @@ describe('navigation component configuration', () => {
     let navComponent = new NavigationComponent({
       container: '.test-component'
     }, {
-      core: mockedCore(tabConfig)
+      core: mockedCore(tabConfig),
+      componentManager: mockedComponentManager(tabConfig)
     });
 
     const tabOrder1 = ['tab1', 'tab2'];
@@ -216,7 +230,8 @@ describe('navigation component configuration', () => {
     let navComponent = new NavigationComponent({
       container: '.test-component'
     }, {
-      core: mockedCore(tabConfig)
+      core: mockedCore(tabConfig),
+      componentManager: mockedComponentManager(tabConfig)
     });
 
     const params = new URLSearchParams('query=yes');
@@ -237,7 +252,8 @@ describe('navigation component configuration', () => {
     let navComponent = new NavigationComponent({
       container: '.test-component'
     }, {
-      core: mockedCore(tabConfig)
+      core: mockedCore(tabConfig),
+      componentManager: mockedComponentManager(tabConfig)
     });
 
     const url = navComponent.generateTabUrl(tabConfig[0].url, navComponent.getUrlParams());

--- a/tests/ui/components/results/verticalresultscomponent.js
+++ b/tests/ui/components/results/verticalresultscomponent.js
@@ -33,6 +33,12 @@ const COMPONENT_MANAGER = mockManager(
   mockCore,
   VerticalResultsComponent.defaultTemplateName()
 );
+COMPONENT_MANAGER.getComponentNamesForComponentType = () => {
+  return [];
+};
+COMPONENT_MANAGER.getComponentNamesForComponentTypes = () => {
+  return [];
+};
 
 describe('vertical results component', () => {
   let defaultConfig;

--- a/tests/ui/components/results/verticalresultscomponent.js
+++ b/tests/ui/components/results/verticalresultscomponent.js
@@ -33,9 +33,6 @@ const COMPONENT_MANAGER = mockManager(
   mockCore,
   VerticalResultsComponent.defaultTemplateName()
 );
-COMPONENT_MANAGER.getComponentNamesForComponentType = () => {
-  return [];
-};
 COMPONENT_MANAGER.getComponentNamesForComponentTypes = () => {
   return [];
 };


### PR DESCRIPTION
We remove query parameters dealing with facets, pagination, or filters
from the inter-experience links. This is because this encoded
information should not persist as we move throughout the experience
(ie to another vertical).

For example: if you land on a vertical page with facets, these facets are
automatically added to the URL. When you try to navigate to another
tab, these query parameters persist (encoded within the nav URL) and
can lead to confusion when another vertical also has facets with similar
facet names.

re Implementation: Because name is a configurable option for components, and because
facets/filters use this as a basis for the persistentStorage key, we
must account for the different types of possible names. Thus, we store
the componentNames mapped to a component type, for easier access.

To avoid a circular dependency (Component -> urlUtils -> Component.type),
we split out the types into a different ComponentTypes class that allow
one source of truth for the component type for both the new urlutils function
and the components themselves.

J=SLAP-499
TEST=manual

Test that navigation links on a page with filters, pagination, and
facets do not contain those query parameters.
  - filter search
  - geolocation
  - facets
  - filterbox with specific CF filter

Test that View More links, Change Filter links on universal do not
contain those query parameters.

Test that Alternative Verticals vertical and universal links do not
contain those query parameters.

Add acceptance test for going from page with facets to universal
and to vertical page and make sure those do not contain the
facet/filter/pagination params.