### PR TITLE
Add word-break to yxt-FilterOptions-optionLabel

### DIFF
--- a/src/ui/sass/modules/_FilterOptions.scss
+++ b/src/ui/sass/modules/_FilterOptions.scss
@@ -123,6 +123,8 @@
 
   &-radioButtonLabel {
     cursor: pointer;
+    word-break: break-word;
+    hyphens: auto;
   }
 
   &-optionLabel {

--- a/src/ui/sass/modules/_FilterOptions.scss
+++ b/src/ui/sass/modules/_FilterOptions.scss
@@ -132,6 +132,8 @@
     align-items: center;
     margin-left: 22px;
     cursor: pointer;
+    word-break: break-word;
+    hyphens: auto;
 
     /* Checkmark outer box */
     &::before {


### PR DESCRIPTION
Add word-break: break-word; and hyphens: auto; to yxt-FilterOptions-optionLabel. Previously, some Facets/Filter options with long words were not getting wrapped. Now, long words will continue on the next line with a hyphen.

J=SLAP-100

TEST=manual

Tested on local test site by ensuring that long words in facets/filter options didn't overflow and got wrapped.