### PR TITLE
urlutils: refactor addParamsToUrl

### DIFF
--- a/src/core/utils/urlutils.js
+++ b/src/core/utils/urlutils.js
@@ -42,18 +42,15 @@ export function getAnalyticsUrl (env = PRODUCTION, conversionTrackingEnabled = f
 }
 
 /**
- * Returns the passed in url, with all url params from the current url, as well as any
- * pasased in params, appended to it.
+ * Returns the passed in url with the passed in params appended as query params
+ * Note: query parameters in the url are stripped, you should include those query parameters
+ * in `params` if you want to keep them
  * @param {string} url
- * @param {Object} params
+ * @param {SearchParams} params to add to the url
  * @returns {string}
  */
-export function addParamsToUrl (url, params = {}) {
-  const urlParams = new SearchParams(window.location.search.substring(1));
-  for (const paramKey in params) {
-    urlParams.set(paramKey, params[paramKey]);
-  }
-  return url.split('?')[0] + '?' + urlParams;
+export function addParamsToUrl (url, params = new SearchParams()) {
+  return url.split('?')[0] + '?' + params.toString();
 }
 
 export function urlWithoutQueryParamsAndHash (url) {

--- a/src/core/utils/urlutils.js
+++ b/src/core/utils/urlutils.js
@@ -49,7 +49,7 @@ export function getAnalyticsUrl (env = PRODUCTION, conversionTrackingEnabled = f
  * @param {SearchParams} params to add to the url
  * @returns {string}
  */
-export function addParamsToUrl (url, params = new SearchParams()) {
+export function replaceUrlParams (url, params = new SearchParams()) {
   return url.split('?')[0] + '?' + params.toString();
 }
 

--- a/src/ui/components/results/alternativeverticalscomponent.js
+++ b/src/ui/components/results/alternativeverticalscomponent.js
@@ -4,6 +4,7 @@ import AlternativeVertical from '../../../core/models/alternativevertical';
 import Component from '../component';
 import StorageKeys from '../../../core/storage/storagekeys';
 import { addParamsToUrl } from '../../../core/utils/urlutils';
+import SearchParams from '../../dom/searchparams';
 
 export default class AlternativeVerticalsComponent extends Component {
   constructor (opts = {}, systemOpts = {}) {
@@ -114,12 +115,12 @@ export default class AlternativeVerticalsComponent extends Component {
   static _buildVerticalSuggestions (alternativeVerticals, verticalsConfig, context, referrerPageUrl) {
     let verticals = [];
 
-    const params = {};
+    const params = new SearchParams(window.location.search.substring(1));
     if (context) {
-      params[StorageKeys.API_CONTEXT] = context;
+      params.set(StorageKeys.API_CONTEXT, context);
     }
     if (typeof referrerPageUrl === 'string') {
-      params[StorageKeys.REFERRER_PAGE_URL] = referrerPageUrl;
+      params.set(StorageKeys.REFERRER_PAGE_URL, referrerPageUrl);
     }
 
     for (let alternativeVertical of alternativeVerticals) {

--- a/src/ui/components/results/alternativeverticalscomponent.js
+++ b/src/ui/components/results/alternativeverticalscomponent.js
@@ -3,7 +3,7 @@
 import AlternativeVertical from '../../../core/models/alternativevertical';
 import Component from '../component';
 import StorageKeys from '../../../core/storage/storagekeys';
-import { addParamsToUrl } from '../../../core/utils/urlutils';
+import { replaceUrlParams } from '../../../core/utils/urlutils';
 import SearchParams from '../../dom/searchparams';
 
 export default class AlternativeVerticalsComponent extends Component {
@@ -136,7 +136,7 @@ export default class AlternativeVerticalsComponent extends Component {
 
       verticals.push(new AlternativeVertical({
         label: matchingVerticalConfig.label,
-        url: addParamsToUrl(matchingVerticalConfig.url, params),
+        url: replaceUrlParams(matchingVerticalConfig.url, params),
         iconName: matchingVerticalConfig.icon,
         iconUrl: matchingVerticalConfig.iconUrl,
         resultsCount: alternativeVertical.resultsCount

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -12,6 +12,7 @@ import ResultsHeaderComponent from './resultsheadercomponent';
 import { addParamsToUrl } from '../../../core/utils/urlutils';
 import Icons from '../../icons/index';
 import { defaultConfigOption } from '../../../core/utils/configutils';
+import SearchParams from '../../dom/searchparams';
 
 class VerticalResultsConfig {
   constructor (config = {}) {
@@ -229,14 +230,15 @@ export default class VerticalResultsComponent extends Component {
       return undefined;
     }
 
-    const params = { query: this.query };
+    const params = new SearchParams(window.location.search.substring(1));
+    params.set(StorageKeys.QUERY, this.query);
     const context = this.core.globalStorage.getState(StorageKeys.API_CONTEXT);
     if (context) {
-      params[StorageKeys.API_CONTEXT] = context;
+      params.set(StorageKeys.API_CONTEXT, context);
     }
     const referrerPageUrl = this.core.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL);
     if (referrerPageUrl !== null) {
-      params[StorageKeys.REFERRER_PAGE_URL] = referrerPageUrl;
+      params.set(StorageKeys.REFERRER_PAGE_URL, referrerPageUrl);
     }
 
     return addParamsToUrl(universalConfig.url, params);
@@ -246,13 +248,15 @@ export default class VerticalResultsComponent extends Component {
     const verticalConfig = this._verticalsConfig.find(config => config.verticalKey === this.verticalKey) || {};
     const verticalURL = this._config.verticalURL || verticalConfig.url || data.verticalURL || this.verticalKey + '.html';
 
-    const params = {
-      query: this.query,
-      referrerPageUrl: this.core.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL)
-    };
+    const params = new SearchParams(window.location.search.substring(1));
+    params.set(StorageKeys.QUERY, this.query);
+    params.set(
+      StorageKeys.REFERRER_PAGE_URL,
+      this.core.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL)
+    );
     const context = this.core.globalStorage.getState(StorageKeys.API_CONTEXT);
     if (context) {
-      params.context = context;
+      params.set(StorageKeys.API_CONTEXT, context);
     }
     return addParamsToUrl(verticalURL, params);
   }

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -9,7 +9,7 @@ import StorageKeys from '../../../core/storage/storagekeys';
 import SearchStates from '../../../core/storage/searchstates';
 import CardComponent from '../cards/cardcomponent';
 import ResultsHeaderComponent from './resultsheadercomponent';
-import { addParamsToUrl } from '../../../core/utils/urlutils';
+import { replaceUrlParams } from '../../../core/utils/urlutils';
 import Icons from '../../icons/index';
 import { defaultConfigOption } from '../../../core/utils/configutils';
 import SearchParams from '../../dom/searchparams';
@@ -241,7 +241,7 @@ export default class VerticalResultsComponent extends Component {
       params.set(StorageKeys.REFERRER_PAGE_URL, referrerPageUrl);
     }
 
-    return addParamsToUrl(universalConfig.url, params);
+    return replaceUrlParams(universalConfig.url, params);
   }
 
   getVerticalURL (data = {}) {
@@ -258,7 +258,7 @@ export default class VerticalResultsComponent extends Component {
     if (context) {
       params.set(StorageKeys.API_CONTEXT, context);
     }
-    return addParamsToUrl(verticalURL, params);
+    return replaceUrlParams(verticalURL, params);
   }
 
   setState (data = {}, val) {


### PR DESCRIPTION
We refactor the addParamsToUrl function for two reasons:

1. The function relies on window.location.search, a global variable
   usually in the browser. This is not available for change in our jest
   tests without extra work. To make the function easier to work with in
   unit tests, we factor out the global variable dependence.

2. In the cases we use addParamsToUrl, we would like to remove certain
   parameters in this generated URL. This makes it easier to pass in
   exactly what parameters should be generated with the url. SLAP-499

There should be no consumer-facing changes as a result of this refactor.
Because the function is not additive but rather replaces the search params,
we rename the function as well.

J=SLAP-182
TEST=manual

In a local Jambo repository, test all usages of addParamsToUrl
Change Filters in Universal
View All Link in Universal
Alternative Vericals in Vertical

Test that current parameters are being added to the links, correctly.
Test that new parameters are being added to the links, correctly.