### PR TITLE
urlutils: refactor addParamsToUrl, add unit tests

### DIFF
--- a/src/core/utils/urlutils.js
+++ b/src/core/utils/urlutils.js
@@ -42,18 +42,15 @@ export function getAnalyticsUrl (env = PRODUCTION, conversionTrackingEnabled = f
 }
 
 /**
- * Returns the passed in url, with all url params from the current url, as well as any
- * pasased in params, appended to it.
+ * Returns the passed in url with the passed in params appended as query params
+ * Note: query parameters in the url are stripped, you should include those query parameters
+ * in `params` if you want to keep them
  * @param {string} url
- * @param {Object} params
+ * @param {SearchParams} params to add to the url
  * @returns {string}
  */
-export function addParamsToUrl (url, params = {}) {
-  const urlParams = new SearchParams(window.location.search.substring(1));
-  for (const paramKey in params) {
-    urlParams.set(paramKey, params[paramKey]);
-  }
-  return url.split('?')[0] + '?' + urlParams;
+export function replaceUrlParams (url, params = new SearchParams()) {
+  return url.split('?')[0] + '?' + params.toString();
 }
 
 export function urlWithoutQueryParamsAndHash (url) {

--- a/src/core/utils/urlutils.js
+++ b/src/core/utils/urlutils.js
@@ -53,6 +53,11 @@ export function replaceUrlParams (url, params = new SearchParams()) {
   return url.split('?')[0] + '?' + params.toString();
 }
 
+/**
+ * Returns the given url without query params and hashes
+ * @param {string} url Full url e.g. https://yext.com/?query=hello#Footer
+ * @returns {string} Url without query params and hashes e.g. https://yext.com/
+ */
 export function urlWithoutQueryParamsAndHash (url) {
   return url.split('?')[0].split('#')[0];
 }

--- a/src/ui/components/results/alternativeverticalscomponent.js
+++ b/src/ui/components/results/alternativeverticalscomponent.js
@@ -3,7 +3,8 @@
 import AlternativeVertical from '../../../core/models/alternativevertical';
 import Component from '../component';
 import StorageKeys from '../../../core/storage/storagekeys';
-import { addParamsToUrl } from '../../../core/utils/urlutils';
+import { replaceUrlParams } from '../../../core/utils/urlutils';
+import SearchParams from '../../dom/searchparams';
 
 export default class AlternativeVerticalsComponent extends Component {
   constructor (opts = {}, systemOpts = {}) {
@@ -114,12 +115,12 @@ export default class AlternativeVerticalsComponent extends Component {
   static _buildVerticalSuggestions (alternativeVerticals, verticalsConfig, context, referrerPageUrl) {
     let verticals = [];
 
-    const params = {};
+    const params = new SearchParams(window.location.search.substring(1));
     if (context) {
-      params[StorageKeys.API_CONTEXT] = context;
+      params.set(StorageKeys.API_CONTEXT, context);
     }
     if (typeof referrerPageUrl === 'string') {
-      params[StorageKeys.REFERRER_PAGE_URL] = referrerPageUrl;
+      params.set(StorageKeys.REFERRER_PAGE_URL, referrerPageUrl);
     }
 
     for (let alternativeVertical of alternativeVerticals) {
@@ -135,7 +136,7 @@ export default class AlternativeVerticalsComponent extends Component {
 
       verticals.push(new AlternativeVertical({
         label: matchingVerticalConfig.label,
-        url: addParamsToUrl(matchingVerticalConfig.url, params),
+        url: replaceUrlParams(matchingVerticalConfig.url, params),
         iconName: matchingVerticalConfig.icon,
         iconUrl: matchingVerticalConfig.iconUrl,
         resultsCount: alternativeVertical.resultsCount

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -9,9 +9,10 @@ import StorageKeys from '../../../core/storage/storagekeys';
 import SearchStates from '../../../core/storage/searchstates';
 import CardComponent from '../cards/cardcomponent';
 import ResultsHeaderComponent from './resultsheadercomponent';
-import { addParamsToUrl } from '../../../core/utils/urlutils';
+import { replaceUrlParams } from '../../../core/utils/urlutils';
 import Icons from '../../icons/index';
 import { defaultConfigOption } from '../../../core/utils/configutils';
+import SearchParams from '../../dom/searchparams';
 
 class VerticalResultsConfig {
   constructor (config = {}) {
@@ -229,32 +230,35 @@ export default class VerticalResultsComponent extends Component {
       return undefined;
     }
 
-    const params = { query: this.query };
+    const params = new SearchParams(window.location.search.substring(1));
+    params.set(StorageKeys.QUERY, this.query);
     const context = this.core.globalStorage.getState(StorageKeys.API_CONTEXT);
     if (context) {
-      params[StorageKeys.API_CONTEXT] = context;
+      params.set(StorageKeys.API_CONTEXT, context);
     }
     const referrerPageUrl = this.core.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL);
     if (referrerPageUrl !== null) {
-      params[StorageKeys.REFERRER_PAGE_URL] = referrerPageUrl;
+      params.set(StorageKeys.REFERRER_PAGE_URL, referrerPageUrl);
     }
 
-    return addParamsToUrl(universalConfig.url, params);
+    return replaceUrlParams(universalConfig.url, params);
   }
 
   getVerticalURL (data = {}) {
     const verticalConfig = this._verticalsConfig.find(config => config.verticalKey === this.verticalKey) || {};
     const verticalURL = this._config.verticalURL || verticalConfig.url || data.verticalURL || this.verticalKey + '.html';
 
-    const params = {
-      query: this.query,
-      referrerPageUrl: this.core.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL)
-    };
+    const params = new SearchParams(window.location.search.substring(1));
+    params.set(StorageKeys.QUERY, this.query);
+    params.set(
+      StorageKeys.REFERRER_PAGE_URL,
+      this.core.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL)
+    );
     const context = this.core.globalStorage.getState(StorageKeys.API_CONTEXT);
     if (context) {
-      params.context = context;
+      params.set(StorageKeys.API_CONTEXT, context);
     }
-    return addParamsToUrl(verticalURL, params);
+    return replaceUrlParams(verticalURL, params);
   }
 
   setState (data = {}, val) {

--- a/tests/core/utils/urlutils.js
+++ b/tests/core/utils/urlutils.js
@@ -1,0 +1,105 @@
+import SearchParams from '../../../src/ui/dom/searchparams';
+import { PRODUCTION, SANDBOX } from '../../../src/core/constants';
+import {
+  getLiveApiUrl,
+  getCachedLiveApiUrl,
+  getKnowledgeApiUrl,
+  getAnalyticsUrl,
+  replaceUrlParams,
+  urlWithoutQueryParamsAndHash,
+  equivalentParams
+} from '../../../src/core/utils/urlutils';
+
+const baseUrl = 'https://yext.com/';
+
+describe('getUrlFunctions work', () => {
+  it('differentiates sandbox from prod', () => {
+    expect(getLiveApiUrl()).not.toEqual(expect.stringContaining('sandbox'));
+    expect(getCachedLiveApiUrl()).not.toEqual(expect.stringContaining('sandbox'));
+    expect(getKnowledgeApiUrl()).not.toEqual(expect.stringContaining('sandbox'));
+    expect(getAnalyticsUrl()).not.toEqual(expect.stringContaining('sandbox'));
+
+    expect(getLiveApiUrl(SANDBOX)).toEqual(expect.stringContaining('sandbox'));
+    expect(getCachedLiveApiUrl(SANDBOX)).toEqual(expect.stringContaining('sandbox'));
+    expect(getKnowledgeApiUrl(SANDBOX)).toEqual(expect.stringContaining('sandbox'));
+    expect(getAnalyticsUrl(SANDBOX)).toEqual(expect.stringContaining('sandbox'));
+  });
+
+  it('differentiates conversion tracking in analytics url', () => {
+    expect(getAnalyticsUrl(PRODUCTION, true)).toEqual(expect.stringContaining('realtimeanalytics'));
+    expect(getAnalyticsUrl(SANDBOX, true)).toEqual(expect.stringContaining('realtimeanalytics'));
+
+    expect(getAnalyticsUrl(PRODUCTION)).not.toEqual(expect.stringContaining('realtimeanalytics'));
+    expect(getAnalyticsUrl(SANDBOX)).not.toEqual(expect.stringContaining('realtimeanalytics'));
+  });
+});
+
+describe('replaceUrlParams works', () => {
+  it('adds params to a url without query params', () => {
+    expect(replaceUrlParams(baseUrl, new SearchParams('?referrerPageUrl=')))
+      .toEqual(baseUrl + '?referrerPageUrl=');
+  });
+
+  it('replaces params when params already exist in url', () => {
+    const params = 'page=10&facets=true&query=all&referrerPageUrl=';
+    expect(replaceUrlParams(
+      'https://yext.com/?query=test&page=5&context=%7B%7D',
+      new SearchParams(params)
+    )).toEqual(`https://yext.com/?${params}`);
+  });
+
+  it('adds params when new params are empty', () => {
+    expect(replaceUrlParams(baseUrl, new SearchParams())).toEqual(`${baseUrl}?`);
+  });
+
+  it('encodes new params correctly', () => {
+    const params = new SearchParams('?page=10&facets=true');
+    params.set('query', 'all');
+    params.set('referrerPageUrl', 'https://www.yext.com/');
+    expect(replaceUrlParams('https://yext.com/', params))
+      .toEqual('https://yext.com/?page=10&facets=true&query=all&referrerPageUrl=https%3A%2F%2Fwww.yext.com%2F');
+  });
+});
+
+describe('urlWithoutQueryParamsAndHash works', () => {
+  it('removes query params and hashes', () => {
+    expect(urlWithoutQueryParamsAndHash(baseUrl + '?query=hello&referrerPageUrl=#Footer'))
+      .toEqual(baseUrl);
+  });
+
+  it('handles urls without params and hashes', () => {
+    expect(urlWithoutQueryParamsAndHash(baseUrl)).toEqual(baseUrl);
+  });
+});
+
+describe('equivalentParams works', () => {
+  const params1 = new SearchParams('?query=hello');
+  it('checks when one or both params is an empty SearchParams', () => {
+    expect(equivalentParams(params1, new SearchParams())).toEqual(false);
+    expect(equivalentParams(new SearchParams(), params1)).toEqual(false);
+    expect(equivalentParams(new SearchParams(), new SearchParams())).toEqual(true);
+  });
+
+  it('checks when they have different # of params', () => {
+    const params2 = new SearchParams('?query=hello&referrerPageUrl=');
+    expect(equivalentParams(params1, params2)).toEqual(false);
+    expect(equivalentParams(params2, params1)).toEqual(false);
+  });
+
+  it('checks when they have different param values', () => {
+    const paramsString = '?query=hello&referrerPageUrl=';
+    const params2 = new SearchParams(paramsString);
+    const params3 = new SearchParams(paramsString);
+    params3.set('referrerPageUrl', 'https%3A%2F%2Fwww.yext.com%2F');
+    expect(equivalentParams(params2, params3)).toEqual(false);
+    expect(equivalentParams(params3, params2)).toEqual(false);
+  });
+
+  it('checks when they are the exact same', () => {
+    const paramsString = 'query=all&referrerPageUrl=&Facets.filterbox.filter0=%5B%5D&Facets.filterbox.filter1=%5B%5D&Facets.filterbox.filter2=%5B%5D&Facets.filterbox.filter3=%5B%5D&Facets.filterbox.filter4=%5B%5D&Facets.filterbox.filter5=%5B%5D&Facets.filterbox.filter6=%5B%5D&Facets.filterbox.filter7=%5B%5D&Facets.filterbox.filter8=%5B%5D&Facets.filterbox.filter9=%5B%5D&Facets.filterbox.filter10=%5B%5D&context=%7B"state"%3A"hx"%7D&tabOrder=index.html%2CKM%2Cevents%2Cfaq%2Cjob%2Clinks%2Cpeople%2Crestaurant';
+    const params2 = new SearchParams(paramsString);
+    const params3 = new SearchParams(paramsString);
+    expect(equivalentParams(params2, params3)).toEqual(true);
+    expect(equivalentParams(params3, params2)).toEqual(true);
+  });
+});


### PR DESCRIPTION
We refactor the addParamsToUrl function for two reasons:

1. The function relies on window.location.search, a global variable
   usually in the browser. This is not available for change in our jest
   tests without extra work. To make the function easier to work with in
   unit tests, we factor our the global variable dependence.

2. In the cases we use addParamsToUrl, we would like to remove certain
   parameters in this generated URL. This makes it easier to pass in
   exactly what parameters should be generated with the url. SLAP-499

There should be no consumer-facing changes as a result of this refactor.

Make unit tests that test their main usages and edge cases.

J=SLAP-182
TEST=manual

In a local Jambo repository, test all usages of addParamsToUrl
Change Filters in Universal
View All Link in Universal
Alternative Vericals in Vertical

Test that current parameters are being added to the links, correctly.
Test that new parameters are being added to the links, correctly.

