### PR TITLE
browser default is used when no target is specifed to RTF formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2143,7 +2143,7 @@ targetConfig = { url: '_blank', phone: '_self', email: '_parent' }
 targetConfig = '_blank'
 ```
 
-When `targetConfig` is a string, it is assumed that any link, regardless of type, has the specified `target` behavior. This parameter, like `eventOptionsFieldName`, is optional. When not provided, no `target` attribute is supplied to the links.
+When `targetConfig` is a string, it is assumed that any link, regardless of type, has the specified `target` behavior. This parameter, like `eventOptionsFieldName`, is optional. When not provided, no `target` attribute is supplied to the links, and it will use the browser default of `_self`.
 
 Note that when using this function, you must ensure that the relevant Handlebars template correctly unescapes the output HTML.
 


### PR DESCRIPTION
see https://yext.slack.com/archives/GREFVUD7V/p1595606176016000?thread_ts=1595605288.013200&cid=GREFVUD7V