### PR TITLE
Added a connorSearch and connorNumberSearch methods to the searchapi

### DIFF
--- a/src/core/search/searchapi.js
+++ b/src/core/search/searchapi.js
@@ -158,4 +158,24 @@ export default class SearchApi {
     return request.get()
       .then(response => response.json());
   }
+
+  /**
+   * Initiate a search for Connor
+   */
+  connorSearch () {
+    const query = 'Connor';
+    return this.universalSearch(query, {});
+  }
+
+  /**
+   * Initiate a search for Connor concatenated by a number
+   * @param {number} number the number which is concatenated to the string 'Connor'
+   */
+  searchForConnorNumber (number) {
+    if (number && typeof number !== 'number') {
+      throw new AnswersCoreError('number is not of type number', 'searchForConnorNumber');
+    }
+    const query = `Connor${number.toString()}`;
+    return this.universalSearch(query, {});
+  }
 }

--- a/src/core/search/searchapi.js
+++ b/src/core/search/searchapi.js
@@ -171,9 +171,9 @@ export default class SearchApi {
    * Initiate a search for Connor concatenated by a number
    * @param {number} number the number which is concatenated to the string 'Connor'
    */
-  searchForConnorNumber (number) {
+  connorNumberSearch (number) {
     if (number && typeof number !== 'number') {
-      throw new AnswersCoreError('number is not of type number', 'searchForConnorNumber');
+      throw new AnswersCoreError('number is not of type number', 'connorNumberSearch');
     }
     const query = `Connor${number.toString()}`;
     return this.universalSearch(query, {});

--- a/tests/core/search/searchapi.js
+++ b/tests/core/search/searchapi.js
@@ -87,6 +87,25 @@ describe('vertical searching', () => {
         expect.objectContaining({ input: 'query', limit: 25, offset: 10, verticalKey: 'vertical', queryId: '12345' }));
     });
   });
+});
+
+describe('codelab people searches', () => {
+  const mockedRequest = jest.fn(() => Promise.resolve({ json: () => Promise.resolve({ test: 'value' }) }));
+  let searchApi;
+
+  beforeEach(() => {
+    mockedRequest.mockClear();
+    HttpRequester.mockImplementation(() => {
+      return {
+        get: mockedRequest
+      };
+    });
+    searchApi = new SearchApi({
+      apiKey: '1234abcd',
+      experienceKey: 'abc123',
+      locale: 'en'
+    });
+  });
 
   it('searches with kelly full name and no additional text', () => {
     const result = searchApi.kellySearch(true, false, '');
@@ -105,6 +124,26 @@ describe('vertical searching', () => {
       expect(mockedRequest).toBeCalledWith(
         expect.anything(),
         expect.objectContaining({ input: 'kyu additional' }));
+    });
+  });
+
+  it('performs a search for Connor', () => {
+    const result = searchApi.connorSearch();
+    expect.assertions(1);
+    result.then(results => {
+      expect(mockedRequest).toBeCalledWith(
+        expect.anything(),
+        expect.objectContaining({ input: 'Connor' }));
+    });
+  });
+
+  it('searches for Connor number 9398', () => {
+    const result = searchApi.searchForConnorNumber(9398);
+    expect.assertions(1);
+    result.then(results => {
+      expect(mockedRequest).toBeCalledWith(
+        expect.anything(),
+        expect.objectContaining({ input: 'Connor9398' }));
     });
   });
 });

--- a/tests/core/search/searchapi.js
+++ b/tests/core/search/searchapi.js
@@ -138,7 +138,7 @@ describe('codelab people searches', () => {
   });
 
   it('searches for Connor number 9398', () => {
-    const result = searchApi.searchForConnorNumber(9398);
+    const result = searchApi.connorNumberSearch(9398);
     expect.assertions(1);
     result.then(results => {
       expect(mockedRequest).toBeCalledWith(


### PR DESCRIPTION
Added connorSearch and connorNumberSearch methods in accordance with the codelab. 

connorSearch simply searches for the string 'Connor', and connorNumberSearch will search for 'Connor' appended by the number passed in as the parameter. For example connorNumberSearch(9398) will search for 'Connor9398'. These methods are simply for the codelab and should not be merged into master.

J=none
T=auto

Ran "npm run test" and confirmed tests passed