### PR TITLE
Persist sessionsOptIn value across page navigation.

### DIFF
--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -166,7 +166,22 @@ class Answers {
     globalStorage.set(StorageKeys.SEARCH_CONFIG, parsedConfig.search);
     globalStorage.set(StorageKeys.VERTICAL_PAGES_CONFIG, parsedConfig.verticalPages);
     globalStorage.set(StorageKeys.LOCALE, parsedConfig.locale);
-    globalStorage.set(StorageKeys.SESSIONS_OPT_IN, parsedConfig.sessionTrackingEnabled);
+
+    // Check if sessionsOptIn data is stored in the URL. If it is, prefer that over
+    // what is in parsedConfig.
+    const sessionOptIn = globalStorage.getState(StorageKeys.SESSIONS_OPT_IN);
+    if (!sessionOptIn) {
+      globalStorage.set(
+        StorageKeys.SESSIONS_OPT_IN,
+        { value: parsedConfig.sessionTrackingEnabled, setDynamically: false });
+    } else {
+      // If sessionsOptIn was stored in the URL, it was stored only as a string.
+      // Parse this value and add it back to globalStorage.
+      globalStorage.set(
+        StorageKeys.SESSIONS_OPT_IN,
+        { value: (/^true$/i).test(sessionOptIn), setDynamically: true });
+    }
+
     parsedConfig.noResults && globalStorage.set(StorageKeys.NO_RESULTS_CONFIG, parsedConfig.noResults);
 
     const context = globalStorage.getState(StorageKeys.API_CONTEXT);
@@ -402,7 +417,8 @@ class Answers {
    * @param {boolean} optIn
    */
   setSessionsOptIn (optIn) {
-    this.core.globalStorage.set(StorageKeys.SESSIONS_OPT_IN, optIn);
+    this.core.globalStorage.set(
+      StorageKeys.SESSIONS_OPT_IN, { value: optIn, setDynamically: true });
   }
 
   /**

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -179,7 +179,7 @@ export default class Core {
         isDynamicFiltersEnabled: this._isDynamicFiltersEnabled,
         skipSpellCheck: this.globalStorage.getState('skipSpellCheck'),
         queryTrigger: this.globalStorage.getState('queryTrigger'),
-        sessionTrackingEnabled: this.globalStorage.getState(StorageKeys.SESSIONS_OPT_IN),
+        sessionTrackingEnabled: this.globalStorage.getState(StorageKeys.SESSIONS_OPT_IN).value,
         sortBys: this.globalStorage.getState(StorageKeys.SORT_BYS),
         locationRadius: locationRadiusFilterNode ? locationRadiusFilterNode.getFilter().value : null,
         context: context,
@@ -257,13 +257,12 @@ export default class Core {
     this.globalStorage.set(StorageKeys.QUESTION_SUBMISSION, {});
     this.globalStorage.set(StorageKeys.SPELL_CHECK, {});
     this.globalStorage.set(StorageKeys.LOCATION_BIAS, {});
-
     return this._searcher
       .universalSearch(queryString, {
         geolocation: this.globalStorage.getState(StorageKeys.GEOLOCATION),
         skipSpellCheck: this.globalStorage.getState('skipSpellCheck'),
         queryTrigger: this.globalStorage.getState('queryTrigger'),
-        sessionTrackingEnabled: this.globalStorage.getState(StorageKeys.SESSIONS_OPT_IN),
+        sessionTrackingEnabled: this.globalStorage.getState(StorageKeys.SESSIONS_OPT_IN).value,
         context: context,
         referrerPageUrl: referrerPageUrl
       })

--- a/src/core/http/apirequest.js
+++ b/src/core/http/apirequest.js
@@ -109,9 +109,8 @@ export default class ApiRequest {
       'v': this._version,
       'api_key': this._apiKey,
       'jsLibVersion': LIB_VERSION,
-      'sessionTrackingEnabled': this._globalStorage.getState(StorageKeys.SESSIONS_OPT_IN)
+      'sessionTrackingEnabled': this._globalStorage.getState(StorageKeys.SESSIONS_OPT_IN).value
     };
-
     const urlParams = new SearchParams(window.location.search.substring(1));
     if (urlParams.has('beta')) {
       baseParams['beta'] = urlParams.get('beta');

--- a/src/core/search/searchapi.js
+++ b/src/core/search/searchapi.js
@@ -76,28 +76,31 @@ export default class SearchApi {
       version: this._version,
       environment: this._environment,
       params: {
-        'input': input,
-        'experienceKey': this._experienceKey,
-        'version': this._experienceVersion,
-        'filters': filter,
-        'facetFilters': facetFilter,
-        'verticalKey': verticalKey,
-        'limit': limit,
-        'offset': offset,
-        'location': geolocation ? `${geolocation.lat},${geolocation.lng}` : null,
-        'queryId': id,
-        'retrieveFacets': isDynamicFiltersEnabled,
-        'locale': this._locale,
-        'skipSpellCheck': skipSpellCheck,
-        'queryTrigger': queryTrigger,
-        'sessionTrackingEnabled': sessionTrackingEnabled,
-        'sortBys': sortBys,
-        'locationRadius': locationRadius,
-        'context': context,
-        'referrerPageUrl': referrerPageUrl
+        input: input,
+        experienceKey: this._experienceKey,
+        version: this._experienceVersion,
+        filters: filter,
+        facetFilters: facetFilter,
+        verticalKey: verticalKey,
+        limit: limit,
+        offset: offset,
+        location: geolocation ? `${geolocation.lat},${geolocation.lng}` : null,
+        queryId: id,
+        retrieveFacets: isDynamicFiltersEnabled,
+        locale: this._locale,
+        skipSpellCheck: skipSpellCheck,
+        queryTrigger: queryTrigger,
+        sessionTrackingEnabled: sessionTrackingEnabled,
+        sortBys: sortBys,
+        locationRadius: locationRadius,
+        context: context,
+        referrerPageUrl: referrerPageUrl
       }
     };
-    let request = new ApiRequest(requestConfig, { getState: () => sessionTrackingEnabled });
+    const getState = () => {
+      return { value: sessionTrackingEnabled };
+    };
+    const request = new ApiRequest(requestConfig, { getState });
 
     return request.get()
       .then(response => response.json());
@@ -111,18 +114,21 @@ export default class SearchApi {
       version: this._version,
       environment: this._environment,
       params: {
-        'input': queryString,
-        'experienceKey': this._experienceKey,
-        'location': params.geolocation ? `${params.geolocation.lat},${params.geolocation.lng}` : null,
-        'version': this._experienceVersion,
-        'locale': this._locale,
-        'skipSpellCheck': params.skipSpellCheck,
-        'queryTrigger': params.queryTrigger,
-        'context': params.context,
-        'referrerPageUrl': params.referrerPageUrl
+        input: queryString,
+        experienceKey: this._experienceKey,
+        location: params.geolocation ? `${params.geolocation.lat},${params.geolocation.lng}` : null,
+        version: this._experienceVersion,
+        locale: this._locale,
+        skipSpellCheck: params.skipSpellCheck,
+        queryTrigger: params.queryTrigger,
+        context: params.context,
+        referrerPageUrl: params.referrerPageUrl
       }
     };
-    let request = new ApiRequest(requestConfig, { getState: () => params.sessionTrackingEnabled });
+    const getState = () => {
+      return { value: params.sessionTrackingEnabled };
+    };
+    const request = new ApiRequest(requestConfig, { getState });
 
     return request.get()
       .then(response => response.json());

--- a/src/ui/components/navigation/navigationcomponent.js
+++ b/src/ui/components/navigation/navigationcomponent.js
@@ -86,10 +86,10 @@ export class Tab {
    * @param {object} tabsConfig the configuration to use
    */
   static from (tabsConfig) {
-    let tabs = {};
+    const tabs = {};
     // Parse the options and build out our tabs and
     for (let i = 0; i < tabsConfig.length; i++) {
-      let tab = { ...tabsConfig[i] };
+      const tab = { ...tabsConfig[i] };
 
       // If a tab is configured to be hidden in this component,
       // do not process it
@@ -181,9 +181,12 @@ export default class NavigationComponent extends Component {
     this.checkOutsideClick = this.checkOutsideClick.bind(this);
     this.checkMobileOverflowBehavior = this.checkMobileOverflowBehavior.bind(this);
 
-    this.core.globalStorage.on('update', StorageKeys.API_CONTEXT, () => {
+    const reRender = () => {
       this.setState(this.core.globalStorage.getState(StorageKeys.NAVIGATION) || {});
-    });
+    };
+
+    this.core.globalStorage.on('update', StorageKeys.API_CONTEXT, reRender);
+    this.core.globalStorage.on('update', StorageKeys.SESSIONS_OPT_IN, reRender);
   }
 
   static get type () {
@@ -244,7 +247,7 @@ export default class NavigationComponent extends Component {
     // sum child widths instead of using parent's width to avoid
     // browser inconsistencies
     let mainLinksWidth = 0;
-    for (let el of mainLinks.children) {
+    for (const el of mainLinks.children) {
       mainLinksWidth += el.offsetWidth;
     }
 
@@ -334,9 +337,9 @@ export default class NavigationComponent extends Component {
     // Since the tab ordering can change based on the server data
     // we need to update each tabs URL to include the order as part of their params.
     // This helps with persisting state across verticals.
-    let tabs = [];
+    const tabs = [];
     for (let i = 0; i < this._tabOrder.length; i++) {
-      let tab = this._tabs[this._tabOrder[i]];
+      const tab = this._tabs[this._tabOrder[i]];
       if (tab !== undefined) {
         tab.url = this.generateTabUrl(tab.baseUrl, this.getUrlParams());
         tabs.push(tab);
@@ -357,8 +360,8 @@ export default class NavigationComponent extends Component {
   // https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/prepend#Polyfill
   _prepend (collapsedLinks, lastLink) {
     if (!collapsedLinks.hasOwnProperty('prepend')) {
-      let docFrag = document.createDocumentFragment();
-      let isNode = lastLink instanceof Node;
+      const docFrag = document.createDocumentFragment();
+      const isNode = lastLink instanceof Node;
       docFrag.appendChild(isNode ? lastLink : document.createTextNode(String(lastLink)));
 
       collapsedLinks.insertBefore(docFrag, collapsedLinks.firstChild);
@@ -469,6 +472,10 @@ export default class NavigationComponent extends Component {
     const referrerPageUrl = this.core.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL);
     if (referrerPageUrl !== null) {
       params.set(StorageKeys.REFERRER_PAGE_URL, referrerPageUrl);
+    }
+    const sessionsOptIn = this.core.globalStorage.getState(StorageKeys.SESSIONS_OPT_IN);
+    if (sessionsOptIn && sessionsOptIn.setDynamically) {
+      params.set(StorageKeys.SESSIONS_OPT_IN, sessionsOptIn.value);
     }
 
     // We want to persist the params from the existing URL to the new

--- a/src/ui/components/results/alternativeverticalscomponent.js
+++ b/src/ui/components/results/alternativeverticalscomponent.js
@@ -38,12 +38,8 @@ export default class AlternativeVerticalsComponent extends Component {
      * This gets updated based on the server results
      * @type {AlternativeVertical[]}
      */
-    this.verticalSuggestions = AlternativeVerticalsComponent._buildVerticalSuggestions(
-      this._alternativeVerticals,
-      this._verticalsConfig,
-      this.core.globalStorage.getState(StorageKeys.API_CONTEXT),
-      this.core.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL)
-    );
+    this.verticalSuggestions =
+      this._buildVerticalSuggestions(this._alternativeVerticals, this._verticalsConfig);
 
     /**
      * The url to the universal page to link back to with current query
@@ -57,15 +53,14 @@ export default class AlternativeVerticalsComponent extends Component {
      */
     this._isShowingResults = opts.isShowingResults || false;
 
-    this.core.globalStorage.on('update', StorageKeys.API_CONTEXT, () => {
-      this.verticalSuggestions = AlternativeVerticalsComponent._buildVerticalSuggestions(
-        this._alternativeVerticals,
-        this._verticalsConfig,
-        this.core.globalStorage.getState(StorageKeys.API_CONTEXT),
-        this.core.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL)
-      );
+    const reRender = () => {
+      this.verticalSuggestions =
+        this._buildVerticalSuggestions(this._alternativeVerticals, this._verticalsConfig);
       this.setState(this.core.globalStorage.getState(StorageKeys.ALERNATIVE_VERTICALS));
-    });
+    };
+
+    this.core.globalStorage.on('update', StorageKeys.API_CONTEXT, reRender);
+    this.core.globalStorage.on('update', StorageKeys.SESSIONS_OPT_IN, reRender);
   }
 
   static get type () {
@@ -108,11 +103,13 @@ export default class AlternativeVerticalsComponent extends Component {
    * from alternative verticals and verticalPages configuration
    * @param {object} alternativeVerticals alternativeVerticals server response
    * @param {object} verticalsConfig the configuration to use
-   * @param {string} context the API context query parameter to add to the urls
-   * @param {string} referrerPageUrl the referrerPageUrl query parameter to add to the urls
    */
-  static _buildVerticalSuggestions (alternativeVerticals, verticalsConfig, context, referrerPageUrl) {
-    let verticals = [];
+  _buildVerticalSuggestions (alternativeVerticals, verticalsConfig) {
+    const verticals = [];
+
+    const context = this.core.globalStorage.getState(StorageKeys.API_CONTEXT);
+    const referrerPageUrl = this.core.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL);
+    const sessionsOptIn = this.core.globalStorage.getState(StorageKeys.SESSIONS_OPT_IN);
 
     const params = {};
     if (context) {
@@ -121,8 +118,11 @@ export default class AlternativeVerticalsComponent extends Component {
     if (typeof referrerPageUrl === 'string') {
       params[StorageKeys.REFERRER_PAGE_URL] = referrerPageUrl;
     }
+    if (sessionsOptIn && sessionsOptIn.setDynamically) {
+      params[StorageKeys.SESSIONS_OPT_IN] = sessionsOptIn.value;
+    }
 
-    for (let alternativeVertical of alternativeVerticals) {
+    for (const alternativeVertical of alternativeVerticals) {
       const verticalKey = alternativeVertical.verticalConfigId;
 
       const matchingVerticalConfig = verticalsConfig.find(config => {

--- a/src/ui/components/results/universalresultscomponent.js
+++ b/src/ui/components/results/universalresultscomponent.js
@@ -22,9 +22,10 @@ export default class UniversalResultsComponent extends Component {
       ...config.appliedFilters
     };
 
-    this.core.globalStorage.on('update', StorageKeys.API_CONTEXT, () => {
+    const reRender = () =>
       this.setState(this.core.globalStorage.getState(StorageKeys.UNIVERSAL_RESULTS) || {});
-    });
+    this.core.globalStorage.on('update', StorageKeys.API_CONTEXT, reRender);
+    this.core.globalStorage.on('update', StorageKeys.SESSIONS_OPT_IN, reRender);
   }
 
   static get type () {

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -254,6 +254,11 @@ export default class VerticalResultsComponent extends Component {
     if (context) {
       params.context = context;
     }
+    const sessionsOptIn = this.core.globalStorage.getState(StorageKeys.SESSIONS_OPT_IN);
+    if (sessionsOptIn && sessionsOptIn.setDynamically) {
+      params[StorageKeys.SESSIONS_OPT_IN] = sessionsOptIn.value;
+    }
+
     return addParamsToUrl(verticalURL, params);
   }
 

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -241,6 +241,11 @@ export default class VerticalResultsComponent extends Component {
       params.set(StorageKeys.REFERRER_PAGE_URL, referrerPageUrl);
     }
 
+    const sessionsOptIn = this.core.globalStorage.getState(StorageKeys.SESSIONS_OPT_IN);
+    if (sessionsOptIn && sessionsOptIn.setDynamically) {
+      params.set(StorageKeys.SESSIONS_OPT_IN, sessionsOptIn.value);
+    }
+
     return replaceUrlParams(universalConfig.url, params);
   }
 
@@ -261,7 +266,7 @@ export default class VerticalResultsComponent extends Component {
 
     const sessionsOptIn = this.core.globalStorage.getState(StorageKeys.SESSIONS_OPT_IN);
     if (sessionsOptIn && sessionsOptIn.setDynamically) {
-      params[StorageKeys.SESSIONS_OPT_IN] = sessionsOptIn.value;
+      params.set(StorageKeys.SESSIONS_OPT_IN, sessionsOptIn.value);
     }
 
     return replaceUrlParams(verticalURL, params);

--- a/tests/ui/components/navigation/navigationcomponent.js
+++ b/tests/ui/components/navigation/navigationcomponent.js
@@ -112,6 +112,8 @@ describe('navigation component configuration', () => {
           switch (storageKey) {
             case StorageKeys.VERTICAL_PAGES_CONFIG:
               return verticalsConfig;
+            case StorageKeys.SESSIONS_OPT_IN:
+              return {};
             default:
               return null;
           }

--- a/tests/ui/components/results/verticalresultscomponent.js
+++ b/tests/ui/components/results/verticalresultscomponent.js
@@ -17,6 +17,8 @@ const mockCore = {
         return undefined;
       } else if (storageKey === StorageKeys.REFERRER_PAGE_URL) {
         return '';
+      } else if (storageKey === StorageKeys.SESSIONS_OPT_IN) {
+        return {};
       }
     }
   },

--- a/tests/ui/components/search/autocompleteapi.js
+++ b/tests/ui/components/search/autocompleteapi.js
@@ -43,7 +43,7 @@ describe('querying and responding', () => {
   let autocomplete;
   const mockedGet = jest.fn(() => Promise.resolve({ json: () => Promise.resolve(expectedResponse) }));
 
-  const mockedGetState = jest.fn(() => sessionTrackingEnabled);
+  const mockedGetState = jest.fn(() => { return { value: sessionTrackingEnabled }; });
   GlobalStorage.mockImplementation(() => {
     return {
       getState: mockedGetState


### PR DESCRIPTION
If the setSessionsOptIn method is called, the provided value now persists
across page navigation. This includes navigation via the nav bar, alternative
verticals, or 'View All' links. Note that the value set in the init config's
sessionTrackingEnabled will not be persisted across page navigation. The data
is persisted by storing it in the URL. When loading an experience on a page,
if there is sessionsOptIn data in the URL, that will take precedecne over
the sessionTrackingEnable config option.

Updates had to be made to the VerticalResults, Navigation, and Alternative
Verticals components to ensure they re-rendered properly whenever the
setSessionsOptIn method was called.

The session tracking data in GlobalStorage is now structured differently. It
is an object with a value and a setDynamically attribute. The setDynamically
attribute allows us to differentiate between a session tracking value set on
ANSWERS.init and one set with ANSWERS.setSessionsOptIn. If it was set using the
former, we do not persist the value across pages.

I did some minor code cleanup as well. Specifically, the AlternativeVerticals
class had a static _buildVerticalSuggestions method. I do not beleive this
method needs to be static anymore. It simplifies things to just be a normal,
private method of the class.

J=SLAP-15
TEST=manual

Performed the following tests:
- Called setSessionsOptIn(false) on a page. Navigated to another page via the
  nav bar. Verified that session tracking was disabled there.
- Called setSessionsOptIn(false) on a page. Navigated to another page via the
  'View All' links. Verified that session tracking was diabled there.
- Called setSessionsOptIn(false) on a page. Navigated to another page via the
  AlternativeVerticals links. Verfied that session tracking was disabled there.
- Verified that if sessions-opt-in is present in the URL, it overrides the
  sessionTrackingEnabled config option.
- Verified that if sessions-opt-in is not present in the URL, the session
  TrackingEnabled value is used, as before.
- Called setSessionsOptIn(false) on a page. Navigated to another page and
  called setSessionsOptIn(true) there. Verified that session tracking was then
  enabled there.
- Ensured that ApiRequests are sent with the correct value.
- Ensured that calling setContext triggeres a correct re-render of the
  NavigationComponent.
- Ensured that AlternativeVerticals were still generated as expected.