### PR TITLE
Answers init returns a promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ function initAnswers() {
     apiKey: '<API_KEY_HERE>',
     // Required, the key used for your Answers experience
     experienceKey: '<EXPERIENCE_KEY_HERE>',
-    // Required, initialize components here, invoked when the Answers component library is loaded/ready.
-    //   Components may instead be initialized after the init promise resolves.
+    // Optional, initialize components here, invoked when the Answers component library is loaded/ready.
+    //    If components are not added here, they must be added when the init promise resolves
     onReady: function() {},
     // Optional*, Yext businessId, *required to send analytics events
     businessId: 'businessId',

--- a/README.md
+++ b/README.md
@@ -85,6 +85,24 @@ function initAnswers() {
 }
 ```
 
+ANSWERS.init() returns a promise which optionally allows components to be added using promise syntax
+```js
+function initAnswers() {
+  ANSWERS.init({
+    apiKey: '<API_KEY_HERE>', // See [1]
+    experienceKey: '<EXPERIENCE_KEY_HERE>',
+  }).then(function() {
+    ANSWERS.addComponent('SearchBar', {
+      container: '#SearchBarContainer',
+    });
+
+    ANSWERS.addComponent('UniversalResults', {
+      container: '#UniversalResultsContainer',
+    });
+  });
+}
+```
+
 [1] Learn more about [getting your API key](https://developer.yext.com/docs/guides/get-started/).
 
 # ANSWERS.init Configuration Options
@@ -98,7 +116,8 @@ function initAnswers() {
     apiKey: '<API_KEY_HERE>',
     // Required, the key used for your Answers experience
     experienceKey: '<EXPERIENCE_KEY_HERE>',
-    // Required, initialize components here, invoked when the Answers component library is loaded/ready
+    // Required, initialize components here, invoked when the Answers component library is loaded/ready.
+    //   Components may instead be initialized after the init promise resolves.
     onReady: function() {},
     // Optional*, Yext businessId, *required to send analytics events
     businessId: 'businessId',

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ function initAnswers() {
     // Required, the key used for your Answers experience
     experienceKey: '<EXPERIENCE_KEY_HERE>',
     // Optional, initialize components here, invoked when the Answers component library is loaded/ready.
-    //    If components are not added here, they must be added when the init promise resolves
+    //    If components are not added here, they can also be added when the init promise resolves
     onReady: function() {},
     // Optional*, Yext businessId, *required to send analytics events
     businessId: 'businessId',

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -270,10 +270,12 @@ class Answers {
     const onReadyPromise = new Promise((resolve, reject) => {
       this._handlePonyfillCssVariables(parsedConfig.disableCssVariablesPonyfill)
         .then(this._masterSwitchApi.isDisabled())
-        .then((isDisabled) => {
+        .then(isDisabled => {
           if (!isDisabled) {
             this._onReady();
             resolve();
+          } else {
+            reject(new Error('MasterSwitchApi determined the front-end should be disabled'));
           }
         }, () => {
           this._onReady();

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -439,7 +439,7 @@ class Answers {
     }
     return new Promise((resolve, reject) => {
       this.ponyfillCssVariables({
-        onFinally: resolve()
+        onFinally: resolve
       });
     });
   }

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -432,6 +432,7 @@ class Answers {
    * A promise that resolves when ponyfillCssVariables resolves,
    * or resolves immediately if ponyfill is disabled
    * @param {boolean} option to opt out of the css variables ponyfill
+   * @param {Promise} resolves after ponyfillCssVariables, or immediately if disabled
    */
   _handlePonyfillCssVariables (ponyfillDisabled) {
     return new Promise((resolve, reject) => {

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -267,23 +267,17 @@ class Answers {
       });
     }
 
-    const onReadyPromise = new Promise((resolve, reject) => {
-      this._handlePonyfillCssVariables(parsedConfig.disableCssVariablesPonyfill)
-        .then(this._masterSwitchApi.isDisabled())
-        .then(isDisabled => {
-          if (!isDisabled) {
-            this._onReady();
-            resolve();
-          } else {
-            reject(new Error('MasterSwitchApi determined the front-end should be disabled'));
-          }
-        }, () => {
+    return this._handlePonyfillCssVariables(parsedConfig.disableCssVariablesPonyfill)
+      .then(() => this._masterSwitchApi.isDisabled())
+      .then(isDisabled => {
+        if (!isDisabled) {
           this._onReady();
-          resolve();
-        });
-    });
-
-    return onReadyPromise;
+        } else {
+          throw new Error('MasterSwitchApi determined the front-end should be disabled');
+        }
+      }, () => {
+        this._onReady();
+      });
   }
 
   domReady (cb) {
@@ -437,7 +431,7 @@ class Answers {
    * A promise that resolves when ponyfillCssVariables resolves,
    * or resolves immediately if ponyfill is disabled
    * @param {boolean} option to opt out of the css variables ponyfill
-   * @param {Promise} resolves after ponyfillCssVariables, or immediately if disabled
+   * @return {Promise} resolves after ponyfillCssVariables, or immediately if disabled
    */
   _handlePonyfillCssVariables (ponyfillDisabled) {
     return new Promise((resolve, reject) => {

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -267,7 +267,7 @@ class Answers {
       });
     }
 
-    this.promise = new Promise((resolve, reject) => {
+    const onReadyPromise = new Promise((resolve, reject) => {
       this._handlePonyfillCssVariables(parsedConfig.disableCssVariablesPonyfill)
         .then(this._masterSwitchApi.isDisabled())
         .then((isDisabled) => {
@@ -275,10 +275,13 @@ class Answers {
             this._onReady();
             resolve();
           }
+        }, () => {
+          this._onReady();
+          resolve();
         });
     });
 
-    return this;
+    return onReadyPromise;
   }
 
   domReady (cb) {


### PR DESCRIPTION
This PR changes ANSWERS.init() such that it returns a promise which resolves when initialization is complete. Both the onReady callback and the promise may be used. If both are included, the onReady callback is called first, and then the promise is resolved.

Usage looks like this:
```javascript
ANSWERS.init({
  //config
}).then(() => {
  //onReady code 
});
```

This commit also changes _handlePonyfillCssVariables such that it returns a promise.

J=SLAP-504
TEST=manual

I tested this with html that initializes the SearchBar and Universal results. I tested onReady code just in the callback, in both the callback and in the promise, and in just the promise. I confirmed onReady executes before the promise resolves.

I tested the code with MasterSwitchAPI and with ponyfillCss manually disabled.

I also tested on IE11 and confirmed that the existing polylfills work so long as arrow functions are not used.