### PR TITLE
renderer: Add registerTemplate functionality

### DIFF
--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -388,6 +388,15 @@ class Answers {
   }
 
   /**
+   * Compile and add a template to the current renderer
+   * @param {string} templateName The unique name for the template
+   * @param {string} template The handlebars template string
+   */
+  registerTemplate (templateName, template) {
+    this.renderer.registerTemplate(templateName, template);
+  }
+
+  /**
    * Opt in or out of convertion tracking analytics
    * @param {boolean} optIn
    */

--- a/src/ui/rendering/handlebarsrenderer.js
+++ b/src/ui/rendering/handlebarsrenderer.js
@@ -75,6 +75,15 @@ export default class HandlebarsRenderer extends Renderer {
   }
 
   /**
+   * compile a template and then add it to the current template bundle
+   * @param {string} templateName The unique name for the template
+   * @param {string} template The handlebars template string
+   */
+  registerTemplate (templateName, template) {
+    this._templates[templateName] = this.compile(template);
+  }
+
+  /**
    * render will render a template with data
    * @param {Object} config Provide either a templateName or a pre-compiled template
    * @param {Object} data The data to provide to the template

--- a/src/ui/rendering/renderer.js
+++ b/src/ui/rendering/renderer.js
@@ -18,6 +18,10 @@ export default class Renderer {
 
   }
 
+  registerTemplate (templateName, template) {
+
+  }
+
   compile (template) {
 
   }


### PR DESCRIPTION
In order to add templates to the bundle, we create a registerTemplate
function for the renderer and the ANSWERS object. This allows someone to
register a template and reference it in the templateName for the
component. This is for page speed improvements, so that we do not need
to setTemplate in the constructor for any custom component. Instead we can
register the template and change the template name.

J=SLAP-518
TEST=manual

In a local Jambo site, in a custom component Card, call

```
ANSWERS.registerTemplate(
  'cards/location-standard',
  `{{{read 'cards/location-standard/template' }}}`
);
```

And in the constructor set the templateName

```
this._templateName = 'cards/location-standard';
```

Make sure to see the correctly compiled card and that the compile step
for handlebars is not being run 20 times for each result card in the
Chrome performance tab.

Test that this still works with useTemplateBundle = false;
Test that this still works when templateBundle is provided in
ANSWERS.init