### PR TITLE
search: Add type="button" to search button for useForm=false

### DIFF
--- a/src/ui/templates/search/search.hbs
+++ b/src/ui/templates/search/search.hbs
@@ -37,7 +37,8 @@
       {{clearText}}
     </span>
   </button>
-  <button {{#if useForm}}type="submit" {{/if}}class="js-yext-submit yxt-SearchBar-button">
+  <button {{#if useForm}}type="submit"{{else}}type="button"{{/if}}
+    class="js-yext-submit yxt-SearchBar-button">
     {{#if submitIcon}}
       <div class="yxt-SearchBar-buttonImage"
           data-component="IconComponent"


### PR DESCRIPTION
For ASP.NET sites, if a user specifies `useForm: false` in ANSWERS.init,
the searchbar html should have a `type="button"` for the search bar
submit button. This is because the entire page is a form for ASP.NET
sites. Omitting this attribute defaults to submit. When a form is
submitted (e.g. on keypress of "enter" in any input), the first submit
button in the DOM is used as the form submit handler. We do not want to
override a client's behavior if they are relying on a certain submit
button.

J=SLAP-530
TEST=manual

Sanity check to see the type is in the DOM when using a searchbar
(especially with a redirectUrl).