### PR TITLE
urls: remove facets/pagination/filters from inter-experience links

### DIFF
--- a/src/core/utils/urlutils.js
+++ b/src/core/utils/urlutils.js
@@ -1,5 +1,7 @@
 import { PRODUCTION, SANDBOX } from '../constants';
 import SearchParams from '../../ui/dom/searchparams';
+import StorageKeys from '../storage/storagekeys';
+import ComponentTypes from '../../ui/components/componenttypes';
 
 /**
  * Returns the base url for the live api backend in the desired environment.
@@ -81,4 +83,61 @@ export function equivalentParams (params1, params2) {
     }
   }
   return true;
+}
+
+/**
+ * Creates a copy of the provided {@link SearchParams}, with the specified
+ * attributes filtered out
+ * @param {SearchParams} params The parameters to remove from
+ * @param {string[]} prefixes The prefixes of parameters to remove
+ * @return {SearchParams} A new instance of SearchParams without removed params
+ *   from the params parameter
+ */
+export function removeParamsWithPrefixes (params, prefixes) {
+  const newParams = new SearchParams();
+  for (const [key, val] of params.entries()) {
+    const includeEntry = prefixes.every(prefix => !key.startsWith(prefix));
+    if (includeEntry) {
+      newParams.set(key, val);
+    }
+  }
+  return newParams;
+}
+
+/**
+ * Removes parameters for filters, facets, sort options, and pagination
+ * from the provided {@link SearchParams}. This is useful for constructing
+ * inter-experience answers links.
+ * @param {SearchParams} params The parameters to remove from
+ * @param {function} getComponentNamesForComponentTypes Given string[]
+ *   component types, returns string[] component names for those types
+ * @return {SearchParams} Parameters that have filtered out params that
+ *   should not persist across the answers experience
+ */
+export function filterParamsForExperienceLink (
+  params,
+  getComponentNamesForComponentTypes
+) {
+  const componentTypesToExclude = [
+    ComponentTypes.FACETS,
+    ComponentTypes.FILTER_BOX,
+    ComponentTypes.FILTER_OPTIONS,
+    ComponentTypes.RANGE_FILTER,
+    ComponentTypes.DATE_RANGE_FILTER,
+    ComponentTypes.SORT_OPTIONS,
+    ComponentTypes.GEOLOCATION_FILTER,
+    ComponentTypes.FILTER_SEARCH
+  ];
+  let paramsToFilter = componentTypesToExclude.flatMap(type => {
+    let params = getComponentNamesForComponentTypes([type]);
+    if (type === ComponentTypes.GEOLOCATION_FILTER || type === ComponentTypes.FILTER_SEARCH) {
+      params = params.map(param => `${StorageKeys.QUERY}.${param}`);
+    }
+    return params;
+  });
+  paramsToFilter = paramsToFilter.concat([StorageKeys.FILTER]);
+
+  const newParams = removeParamsWithPrefixes(params, paramsToFilter);
+  newParams.delete(StorageKeys.SEARCH_OFFSET);
+  return newParams;
 }

--- a/src/core/utils/urlutils.js
+++ b/src/core/utils/urlutils.js
@@ -42,16 +42,43 @@ export function getAnalyticsUrl (env = PRODUCTION, conversionTrackingEnabled = f
 }
 
 /**
- * Returns the passed in url, with all url params from the current url, as well as any
- * pasased in params, appended to it.
+ * Returns the passed in url with the passed in params appended as query params
+ * Note: query parameters in the url are stripped, you should include those query parameters
+ * in `params` if you want to keep them
  * @param {string} url
- * @param {Object} params
+ * @param {SearchParams} params to add to the url
  * @returns {string}
  */
-export function addParamsToUrl (url, params = {}) {
-  const urlParams = new SearchParams(window.location.search.substring(1));
-  for (const paramKey in params) {
-    urlParams.set(paramKey, params[paramKey]);
+export function replaceUrlParams (url, params = new SearchParams()) {
+  return url.split('?')[0] + '?' + params.toString();
+}
+
+/**
+ * Returns the given url without query params and hashes
+ * @param {string} url Full url e.g. https://yext.com/?query=hello#Footer
+ * @returns {string} Url without query params and hashes e.g. https://yext.com/
+ */
+export function urlWithoutQueryParamsAndHash (url) {
+  return url.split('?')[0].split('#')[0];
+}
+
+/**
+ * returns if two SearchParams objects have the same key,value entries
+ * @param {SearchParams} params1
+ * @param {SearchParams} params2
+ * @return {boolean} true if params1 and params2 have the same key,value entries, false otherwise
+ */
+export function equivalentParams (params1, params2) {
+  const entries1 = Array.from(params1.entries());
+  const entries2 = Array.from(params2.entries());
+
+  if (entries1.length !== entries2.length) {
+    return false;
   }
-  return url.split('?')[0] + '?' + urlParams;
+  for (const [key, val] of params1.entries()) {
+    if (val !== params2.get(key)) {
+      return false;
+    }
+  }
+  return true;
 }

--- a/src/ui/components/componentmanager.js
+++ b/src/ui/components/componentmanager.js
@@ -41,6 +41,11 @@ export default class ComponentManager {
      * A local reference to the analytics reporter dependency
      */
     this._analyticsReporter = null;
+
+    /**
+     * A mapping from component types to component names, as these may be configured by a user
+     */
+    this._componentTypeToComponentNames = {};
   }
 
   static getInstance () {
@@ -134,6 +139,10 @@ export default class ComponentManager {
         .init(config);
 
     this._activeComponents.push(component);
+    if (!this._componentTypeToComponentNames[componentType]) {
+      this._componentTypeToComponentNames[componentType] = [];
+    }
+    this._componentTypeToComponentNames[componentType].push(component.name);
 
     // If there is a global storage to power state, apply the state
     // from the storage to the component, and then bind the component
@@ -176,5 +185,16 @@ export default class ComponentManager {
 
   getActiveComponent (type) {
     return this._activeComponents.find(c => c.constructor.type === type);
+  }
+
+  /**
+   * Returns a concatenated list of all names associated with the given component types
+   * @param {string[]} type The types of the component
+   * @returns {string[]} The component names for the component types
+   */
+  getComponentNamesForComponentTypes (types) {
+    return types.reduce((names, type) => {
+      return names.concat(this._componentTypeToComponentNames[type] || []);
+    }, []);
   }
 }

--- a/src/ui/components/componenttypes.js
+++ b/src/ui/components/componenttypes.js
@@ -1,0 +1,17 @@
+/** @module */
+
+/**
+ * An enum listing the different Component types supported in the SDK
+ * TODO: add all component types
+ * @type {Object.<string, string>}
+ */
+export default {
+  FILTER_BOX: 'FilterBox',
+  FILTER_OPTIONS: 'FilterOptions',
+  RANGE_FILTER: 'RangeFilter',
+  DATE_RANGE_FILTER: 'DateRangeFilter',
+  FACETS: 'Facets',
+  GEOLOCATION_FILTER: 'GeoLocationFilter',
+  SORT_OPTIONS: 'SortOptions',
+  FILTER_SEARCH: 'FilterSearch'
+};

--- a/src/ui/components/filters/daterangefiltercomponent.js
+++ b/src/ui/components/filters/daterangefiltercomponent.js
@@ -5,6 +5,7 @@ import Filter from '../../../core/models/filter';
 import DOM from '../../dom/dom';
 import FilterNodeFactory from '../../../core/filters/filternodefactory';
 import FilterMetadata from '../../../core/filters/filtermetadata';
+import ComponentTypes from '../../components/componenttypes';
 
 /**
  * A filter for a range of dates
@@ -82,7 +83,7 @@ export default class DateRangeFilterComponent extends Component {
   }
 
   static get type () {
-    return 'DateRangeFilter';
+    return ComponentTypes.DATE_RANGE_FILTER;
   }
 
   setState (data) {

--- a/src/ui/components/filters/facetscomponent.js
+++ b/src/ui/components/filters/facetscomponent.js
@@ -3,6 +3,7 @@
 import Component from '../component';
 import StorageKeys from '../../../core/storage/storagekeys';
 import ResultsContext from '../../../core/storage/resultscontext';
+import ComponentTypes from '../../components/componenttypes';
 
 class FacetsConfig {
   constructor (config) {
@@ -178,7 +179,7 @@ export default class FacetsComponent extends Component {
   }
 
   static get type () {
-    return 'Facets';
+    return ComponentTypes.FACETS;
   }
 
   /**

--- a/src/ui/components/filters/filterboxcomponent.js
+++ b/src/ui/components/filters/filterboxcomponent.js
@@ -3,6 +3,7 @@
 import Component from '../component';
 import { AnswersComponentError } from '../../../core/errors/errors';
 import DOM from '../../dom/dom';
+import ComponentTypes from '../../components/componenttypes';
 
 class FilterBoxConfig {
   constructor (config) {
@@ -166,7 +167,7 @@ export default class FilterBoxComponent extends Component {
   }
 
   static get type () {
-    return 'FilterBox';
+    return ComponentTypes.FILTER_BOX;
   }
 
   static defaultTemplateName () {

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -12,6 +12,7 @@ import FilterNodeFactory from '../../../core/filters/filternodefactory';
 import FilterMetadata from '../../../core/filters/filtermetadata';
 import { groupArray } from '../../../core/utils/arrayutils';
 import FilterType from '../../../core/filters/filtertype';
+import ComponentTypes from '../../components/componenttypes';
 
 /**
  * The currently supported controls
@@ -275,7 +276,7 @@ export default class FilterOptionsComponent extends Component {
   }
 
   static get type () {
-    return 'FilterOptions';
+    return ComponentTypes.FILTER_OPTIONS;
   }
 
   /**

--- a/src/ui/components/filters/geolocationcomponent.js
+++ b/src/ui/components/filters/geolocationcomponent.js
@@ -6,6 +6,7 @@ import Filter from '../../../core/models/filter';
 import StorageKeys from '../../../core/storage/storagekeys';
 import buildSearchParameters from '../../tools/searchparamsparser';
 import FilterNodeFactory from '../../../core/filters/filternodefactory';
+import ComponentTypes from '../../components/componenttypes';
 
 const METERS_PER_MILE = 1609.344;
 
@@ -133,7 +134,7 @@ export default class GeoLocationComponent extends Component {
   }
 
   static get type () {
-    return 'GeoLocationFilter';
+    return ComponentTypes.GEOLOCATION_FILTER;
   }
 
   static defaultTemplateName () {

--- a/src/ui/components/filters/rangefiltercomponent.js
+++ b/src/ui/components/filters/rangefiltercomponent.js
@@ -5,6 +5,7 @@ import DOM from '../../dom/dom';
 import Component from '../component';
 import FilterNodeFactory from '../../../core/filters/filternodefactory';
 import FilterMetadata from '../../../core/filters/filtermetadata';
+import ComponentTypes from '../../components/componenttypes';
 
 const DEFAULT_CONFIG = {
   minPlaceholderText: 'Min',
@@ -90,7 +91,7 @@ export default class RangeFilterComponent extends Component {
   }
 
   static get type () {
-    return 'RangeFilter';
+    return ComponentTypes.RANGE_FILTER;
   }
 
   static defaultTemplateName () {

--- a/src/ui/components/filters/sortoptionscomponent.js
+++ b/src/ui/components/filters/sortoptionscomponent.js
@@ -6,6 +6,7 @@ import DOM from '../../dom/dom';
 import StorageKeys from '../../../core/storage/storagekeys';
 import ResultsContext from '../../../core/storage/resultscontext';
 import SearchStates from '../../../core/storage/searchstates';
+import ComponentTypes from '../../components/componenttypes';
 
 /**
  * Renders configuration options for sorting Vertical Results.
@@ -134,7 +135,7 @@ export default class SortOptionsComponent extends Component {
   }
 
   static get type () {
-    return 'SortOptions';
+    return ComponentTypes.SORT_OPTIONS;
   }
 
   static defaultTemplateName () {

--- a/src/ui/components/navigation/navigationcomponent.js
+++ b/src/ui/components/navigation/navigationcomponent.js
@@ -7,8 +7,7 @@ import { AnswersComponentError } from '../../../core/errors/errors';
 import StorageKeys from '../../../core/storage/storagekeys';
 import SearchParams from '../../dom/searchparams';
 import DOM from '../../dom/dom';
-import { replaceUrlParams } from '../../../core/utils/urlutils';
-import SearchParams from '../../dom/searchparams';
+import { replaceUrlParams, filterParamsForExperienceLink } from '../../../core/utils/urlutils';
 
 /**
  * The debounce duration for resize events
@@ -329,6 +328,14 @@ export default class NavigationComponent extends Component {
       this._tabOrder = this.mergeTabOrder(data.tabOrder, this._tabOrder);
     }
 
+    const params = this.getUrlParams();
+    params.set('tabOrder', this._tabOrder);
+
+    const filteredParams = filterParamsForExperienceLink(
+      params,
+      types => this.componentManager.getComponentNamesForComponentTypes(types)
+    );
+
     // Since the tab ordering can change based on the server data
     // we need to update each tabs URL to include the order as part of their params.
     // This helps with persisting state across verticals.
@@ -336,9 +343,7 @@ export default class NavigationComponent extends Component {
     for (let i = 0; i < this._tabOrder.length; i++) {
       let tab = this._tabs[this._tabOrder[i]];
       if (tab !== undefined) {
-        const params = new SearchParams(window.location.search);
-        params.set('tabOrder', this._tabOrder);
-        tab.url = replaceUrlParams(tab.baseUrl, params);
+        tab.url = replaceUrlParams(tab.baseUrl, filteredParams);
         tabs.push(tab);
       }
     }

--- a/src/ui/components/navigation/navigationcomponent.js
+++ b/src/ui/components/navigation/navigationcomponent.js
@@ -7,6 +7,8 @@ import { AnswersComponentError } from '../../../core/errors/errors';
 import StorageKeys from '../../../core/storage/storagekeys';
 import SearchParams from '../../dom/searchparams';
 import DOM from '../../dom/dom';
+import { replaceUrlParams } from '../../../core/utils/urlutils';
+import SearchParams from '../../dom/searchparams';
 
 /**
  * The debounce duration for resize events
@@ -334,7 +336,9 @@ export default class NavigationComponent extends Component {
     for (let i = 0; i < this._tabOrder.length; i++) {
       let tab = this._tabs[this._tabOrder[i]];
       if (tab !== undefined) {
-        tab.url = this.generateTabUrl(tab.baseUrl, this.getUrlParams());
+        const params = new SearchParams(window.location.search);
+        params.set('tabOrder', this._tabOrder);
+        tab.url = replaceUrlParams(tab.baseUrl, params);
         tabs.push(tab);
       }
     }

--- a/src/ui/components/results/alternativeverticalscomponent.js
+++ b/src/ui/components/results/alternativeverticalscomponent.js
@@ -3,6 +3,8 @@
 import AlternativeVertical from '../../../core/models/alternativevertical';
 import Component from '../component';
 import StorageKeys from '../../../core/storage/storagekeys';
+import { replaceUrlParams } from '../../../core/utils/urlutils';
+import SearchParams from '../../dom/searchparams';
 
 export default class AlternativeVerticalsComponent extends Component {
   constructor (opts = {}, systemOpts = {}) {
@@ -98,7 +100,7 @@ export default class AlternativeVerticalsComponent extends Component {
    */
   static _buildVerticalSuggestions (alternativeVerticals, verticalsConfig) {
     let verticals = [];
-    let queryParams = window.location.search;
+    let queryParams = new SearchParams(window.location.search);
 
     for (let alternativeVertical of alternativeVerticals) {
       const verticalKey = alternativeVertical.verticalConfigId;
@@ -113,7 +115,7 @@ export default class AlternativeVerticalsComponent extends Component {
 
       verticals.push(new AlternativeVertical({
         label: matchingVerticalConfig.label,
-        url: matchingVerticalConfig.url + queryParams,
+        url: replaceUrlParams(matchingVerticalConfig.url, queryParams),
         iconName: matchingVerticalConfig.icon,
         iconUrl: matchingVerticalConfig.iconUrl,
         resultsCount: alternativeVertical.resultsCount

--- a/src/ui/components/results/alternativeverticalscomponent.js
+++ b/src/ui/components/results/alternativeverticalscomponent.js
@@ -3,7 +3,7 @@
 import AlternativeVertical from '../../../core/models/alternativevertical';
 import Component from '../component';
 import StorageKeys from '../../../core/storage/storagekeys';
-import { replaceUrlParams } from '../../../core/utils/urlutils';
+import { replaceUrlParams, filterParamsForExperienceLink } from '../../../core/utils/urlutils';
 import SearchParams from '../../dom/searchparams';
 
 export default class AlternativeVerticalsComponent extends Component {
@@ -102,7 +102,12 @@ export default class AlternativeVerticalsComponent extends Component {
     let verticals = [];
     let queryParams = new SearchParams(window.location.search);
 
-    for (let alternativeVertical of alternativeVerticals) {
+    const filteredParams = filterParamsForExperienceLink(
+      queryParams,
+      types => this.componentManager.getComponentNamesForComponentTypes(types)
+    );
+
+    for (const alternativeVertical of alternativeVerticals) {
       const verticalKey = alternativeVertical.verticalConfigId;
 
       const matchingVerticalConfig = verticalsConfig.find(config => {
@@ -115,7 +120,7 @@ export default class AlternativeVerticalsComponent extends Component {
 
       verticals.push(new AlternativeVertical({
         label: matchingVerticalConfig.label,
-        url: replaceUrlParams(matchingVerticalConfig.url, queryParams),
+        url: replaceUrlParams(matchingVerticalConfig.url, filteredParams),
         iconName: matchingVerticalConfig.icon,
         iconUrl: matchingVerticalConfig.iconUrl,
         resultsCount: alternativeVertical.resultsCount

--- a/src/ui/components/results/alternativeverticalscomponent.js
+++ b/src/ui/components/results/alternativeverticalscomponent.js
@@ -39,7 +39,7 @@ export default class AlternativeVerticalsComponent extends Component {
      * This gets updated based on the server results
      * @type {AlternativeVertical[]}
      */
-    this.verticalSuggestions = AlternativeVerticalsComponent._buildVerticalSuggestions(
+    this.verticalSuggestions = this._buildVerticalSuggestions(
       this._alternativeVerticals,
       this._verticalsConfig
     );
@@ -98,7 +98,7 @@ export default class AlternativeVerticalsComponent extends Component {
    * @param {object} alternativeVerticals alternativeVerticals server response
    * @param {object} verticalsConfig the configuration to use
    */
-  static _buildVerticalSuggestions (alternativeVerticals, verticalsConfig) {
+  _buildVerticalSuggestions (alternativeVerticals, verticalsConfig) {
     let verticals = [];
     let queryParams = new SearchParams(window.location.search);
 

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -9,9 +9,11 @@ import StorageKeys from '../../../core/storage/storagekeys';
 import SearchStates from '../../../core/storage/searchstates';
 import CardComponent from '../cards/cardcomponent';
 import ResultsHeaderComponent from './resultsheadercomponent';
-import { addParamsToUrl } from '../../../core/utils/urlutils';
 import Icons from '../../icons/index';
 import { defaultConfigOption } from '../../../core/utils/configutils';
+import { replaceUrlParams } from '../../../core/utils/urlutils';
+import { getTabOrder } from '../../tools/taborder';
+import SearchParams from '../../dom/searchparams';
 
 class VerticalResultsConfig {
   constructor (config = {}) {
@@ -233,15 +235,25 @@ export default class VerticalResultsComponent extends Component {
 
   getUniversalUrl () {
     const universalConfig = this._verticalsConfig.find(config => !config.verticalKey) || {};
-    if (universalConfig.url) {
-      return addParamsToUrl(universalConfig.url, { query: this.query });
+    if (!universalConfig.url) {
+      return undefined;
     }
+
+    const params = new SearchParams(window.location.search.substring(1));
+    params.set(StorageKeys.QUERY, this.query);
+    return replaceUrlParams(universalConfig.url, params);
   }
 
   getVerticalURL (data = {}) {
     const verticalConfig = this._verticalsConfig.find(config => config.verticalKey === this.verticalKey) || {};
     const verticalURL = this._config.verticalURL || verticalConfig.url || data.verticalURL || this.verticalKey + '.html';
-    return addParamsToUrl(verticalURL, { query: this.query });
+    const dataTabOrder = this.core.globalStorage.getState(StorageKeys.NAVIGATION) ? this.core.globalStorage.getState(StorageKeys.NAVIGATION).tabOrder : [];
+    const tabOrder = getTabOrder(this._verticalsConfig, dataTabOrder);
+
+    const params = new SearchParams(window.location.search.substring(1));
+    params.set('tabOrder', tabOrder);
+    params.set(StorageKeys.QUERY, this.query);
+    return replaceUrlParams(verticalURL, params);
   }
 
   setState (data = {}, val) {

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -237,7 +237,10 @@ export default class VerticalResultsComponent extends Component {
     if (!universalConfig.url) {
       return undefined;
     }
-    return this._getExperienceURL(universalConfig.url);
+    return this._getExperienceURL(
+      universalConfig.url,
+      new SearchParams(window.location.search.substring(1))
+    );
   }
 
   getVerticalURL (data = {}) {
@@ -246,7 +249,15 @@ export default class VerticalResultsComponent extends Component {
     ) || {};
     const verticalURL = this._config.verticalURL || verticalConfig.url ||
       data.verticalURL || this.verticalKey + '.html';
-    return this._getExperienceURL(verticalURL);
+
+    const dataTabOrder = this.core.globalStorage.getState(StorageKeys.NAVIGATION)
+      ? this.core.globalStorage.getState(StorageKeys.NAVIGATION).tabOrder
+      : [];
+    const tabOrder = getTabOrder(this._verticalsConfig, dataTabOrder);
+    const params = new SearchParams(window.location.search.substring(1));
+    params.set('tabOrder', tabOrder);
+
+    return this._getExperienceURL(verticalURL, params);
   }
 
   /**
@@ -254,10 +265,10 @@ export default class VerticalResultsComponent extends Component {
    * filters, and pagination, which should not persist across the experience.
    * @param {string} baseUrl The url append the appropriate params to. Note:
    *    params already on the baseUrl will be stripped
+   * @param {SearchParams} params The parameters to include in the experience URL
    * @return {string} The formatted experience URL with appropriate query params
    */
-  _getExperienceURL (baseUrl) {
-    const params = new SearchParams(window.location.search.substring(1));
+  _getExperienceURL (baseUrl, params) {
     params.set(StorageKeys.QUERY, this.query);
 
     const filteredParams = filterParamsForExperienceLink(

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -250,13 +250,7 @@ export default class VerticalResultsComponent extends Component {
     const verticalURL = this._config.verticalURL || verticalConfig.url ||
       data.verticalURL || this.verticalKey + '.html';
 
-    const dataTabOrder = this.core.globalStorage.getState(StorageKeys.NAVIGATION)
-      ? this.core.globalStorage.getState(StorageKeys.NAVIGATION).tabOrder
-      : [];
-    const tabOrder = getTabOrder(this._verticalsConfig, dataTabOrder);
     const params = new SearchParams(window.location.search.substring(1));
-    params.set('tabOrder', tabOrder);
-
     return this._getExperienceURL(verticalURL, params);
   }
 

--- a/src/ui/components/search/filtersearchcomponent.js
+++ b/src/ui/components/search/filtersearchcomponent.js
@@ -7,6 +7,7 @@ import Filter from '../../../core/models/filter';
 import SearchParams from '../../dom/searchparams';
 import buildSearchParameters from '../../tools/searchparamsparser';
 import FilterNodeFactory from '../../../core/filters/filternodefactory';
+import ComponentTypes from '../../components/componenttypes';
 
 /**
  * FilterSearchComponent is used for autocomplete using the FilterSearch backend.
@@ -117,7 +118,7 @@ export default class FilterSearchComponent extends Component {
   }
 
   static get type () {
-    return 'FilterSearch';
+    return ComponentTypes.FILTER_SEARCH;
   }
 
   /**

--- a/tests/core/utils/urlutils.js
+++ b/tests/core/utils/urlutils.js
@@ -7,7 +7,8 @@ import {
   getAnalyticsUrl,
   replaceUrlParams,
   urlWithoutQueryParamsAndHash,
-  equivalentParams
+  equivalentParams,
+  removeParamsWithPrefixes
 } from '../../../src/core/utils/urlutils';
 
 const baseUrl = 'https://yext.com/';
@@ -101,5 +102,28 @@ describe('equivalentParams works', () => {
     const params3 = new SearchParams(paramsString);
     expect(equivalentParams(params2, params3)).toEqual(true);
     expect(equivalentParams(params3, params2)).toEqual(true);
+  });
+});
+
+describe('removeParamsWithPrefixes works', () => {
+  const baseParams = new SearchParams('?query=all&referrerPageUrl=&search-offset=10&Facets.filterbox.filter1=hello&Facets.filterbox.filter2=bye&FilterBox.filter1=what');
+
+  it('does not blow up on empty function parameters', () => {
+    const params2 = removeParamsWithPrefixes(new SearchParams(baseParams.toString()), []);
+    expect(params2).toEqual(baseParams);
+
+    const params3 = removeParamsWithPrefixes(new SearchParams(), ['query', 'Facets']);
+    expect(params3).toEqual(new SearchParams());
+
+    const params4 = removeParamsWithPrefixes(new SearchParams(), []);
+    expect(params4).toEqual(new SearchParams());
+  });
+
+  it('removes params with multiple prefixes', () => {
+    const params2 = removeParamsWithPrefixes(new SearchParams(baseParams.toString()), ['search', 'Facets', 'referrer']);
+    expect(params2).toEqual(new SearchParams('?query=all&FilterBox.filter1=what'));
+
+    const params3 = removeParamsWithPrefixes(new SearchParams(baseParams.toString()), ['search', 'Facets', 'referrer', 'search']);
+    expect(params3).toEqual(new SearchParams('?query=all&FilterBox.filter1=what'));
   });
 });

--- a/tests/core/utils/urlutils.js
+++ b/tests/core/utils/urlutils.js
@@ -1,0 +1,105 @@
+import SearchParams from '../../../src/ui/dom/searchparams';
+import { PRODUCTION, SANDBOX } from '../../../src/core/constants';
+import {
+  getLiveApiUrl,
+  getCachedLiveApiUrl,
+  getKnowledgeApiUrl,
+  getAnalyticsUrl,
+  replaceUrlParams,
+  urlWithoutQueryParamsAndHash,
+  equivalentParams
+} from '../../../src/core/utils/urlutils';
+
+const baseUrl = 'https://yext.com/';
+
+describe('getUrlFunctions work', () => {
+  it('differentiates sandbox from prod', () => {
+    expect(getLiveApiUrl()).not.toEqual(expect.stringContaining('sandbox'));
+    expect(getCachedLiveApiUrl()).not.toEqual(expect.stringContaining('sandbox'));
+    expect(getKnowledgeApiUrl()).not.toEqual(expect.stringContaining('sandbox'));
+    expect(getAnalyticsUrl()).not.toEqual(expect.stringContaining('sandbox'));
+
+    expect(getLiveApiUrl(SANDBOX)).toEqual(expect.stringContaining('sandbox'));
+    expect(getCachedLiveApiUrl(SANDBOX)).toEqual(expect.stringContaining('sandbox'));
+    expect(getKnowledgeApiUrl(SANDBOX)).toEqual(expect.stringContaining('sandbox'));
+    expect(getAnalyticsUrl(SANDBOX)).toEqual(expect.stringContaining('sandbox'));
+  });
+
+  it('differentiates conversion tracking in analytics url', () => {
+    expect(getAnalyticsUrl(PRODUCTION, true)).toEqual(expect.stringContaining('realtimeanalytics'));
+    expect(getAnalyticsUrl(SANDBOX, true)).toEqual(expect.stringContaining('realtimeanalytics'));
+
+    expect(getAnalyticsUrl(PRODUCTION)).not.toEqual(expect.stringContaining('realtimeanalytics'));
+    expect(getAnalyticsUrl(SANDBOX)).not.toEqual(expect.stringContaining('realtimeanalytics'));
+  });
+});
+
+describe('replaceUrlParams works', () => {
+  it('adds params to a url without query params', () => {
+    expect(replaceUrlParams(baseUrl, new SearchParams('?referrerPageUrl=')))
+      .toEqual(baseUrl + '?referrerPageUrl=');
+  });
+
+  it('replaces params when params already exist in url', () => {
+    const params = 'page=10&facets=true&query=all&referrerPageUrl=';
+    expect(replaceUrlParams(
+      'https://yext.com/?query=test&page=5&context=%7B%7D',
+      new SearchParams(params)
+    )).toEqual(`https://yext.com/?${params}`);
+  });
+
+  it('adds params when new params are empty', () => {
+    expect(replaceUrlParams(baseUrl, new SearchParams())).toEqual(`${baseUrl}?`);
+  });
+
+  it('encodes new params correctly', () => {
+    const params = new SearchParams('?page=10&facets=true');
+    params.set('query', 'all');
+    params.set('referrerPageUrl', 'https://www.yext.com/');
+    expect(replaceUrlParams('https://yext.com/', params))
+      .toEqual('https://yext.com/?page=10&facets=true&query=all&referrerPageUrl=https%3A%2F%2Fwww.yext.com%2F');
+  });
+});
+
+describe('urlWithoutQueryParamsAndHash works', () => {
+  it('removes query params and hashes', () => {
+    expect(urlWithoutQueryParamsAndHash(baseUrl + '?query=hello&referrerPageUrl=#Footer'))
+      .toEqual(baseUrl);
+  });
+
+  it('handles urls without params and hashes', () => {
+    expect(urlWithoutQueryParamsAndHash(baseUrl)).toEqual(baseUrl);
+  });
+});
+
+describe('equivalentParams works', () => {
+  const params1 = new SearchParams('?query=hello');
+  it('checks when one or both params is an empty SearchParams', () => {
+    expect(equivalentParams(params1, new SearchParams())).toEqual(false);
+    expect(equivalentParams(new SearchParams(), params1)).toEqual(false);
+    expect(equivalentParams(new SearchParams(), new SearchParams())).toEqual(true);
+  });
+
+  it('checks when they have different # of params', () => {
+    const params2 = new SearchParams('?query=hello&referrerPageUrl=');
+    expect(equivalentParams(params1, params2)).toEqual(false);
+    expect(equivalentParams(params2, params1)).toEqual(false);
+  });
+
+  it('checks when they have different param values', () => {
+    const paramsString = '?query=hello&referrerPageUrl=';
+    const params2 = new SearchParams(paramsString);
+    const params3 = new SearchParams(paramsString);
+    params3.set('referrerPageUrl', 'https%3A%2F%2Fwww.yext.com%2F');
+    expect(equivalentParams(params2, params3)).toEqual(false);
+    expect(equivalentParams(params3, params2)).toEqual(false);
+  });
+
+  it('checks when they are the exact same', () => {
+    const paramsString = 'query=all&referrerPageUrl=&Facets.filterbox.filter0=%5B%5D&Facets.filterbox.filter1=%5B%5D&Facets.filterbox.filter2=%5B%5D&Facets.filterbox.filter3=%5B%5D&Facets.filterbox.filter4=%5B%5D&Facets.filterbox.filter5=%5B%5D&Facets.filterbox.filter6=%5B%5D&Facets.filterbox.filter7=%5B%5D&Facets.filterbox.filter8=%5B%5D&Facets.filterbox.filter9=%5B%5D&Facets.filterbox.filter10=%5B%5D&context=%7B"state"%3A"hx"%7D&tabOrder=index.html%2CKM%2Cevents%2Cfaq%2Cjob%2Clinks%2Cpeople%2Crestaurant';
+    const params2 = new SearchParams(paramsString);
+    const params3 = new SearchParams(paramsString);
+    expect(equivalentParams(params2, params3)).toEqual(true);
+    expect(equivalentParams(params3, params2)).toEqual(true);
+  });
+});

--- a/tests/setup/mockcomponentmanager.js
+++ b/tests/setup/mockcomponentmanager.js
@@ -68,4 +68,8 @@ export default class MockComponentManager {
   getActiveComponent () {
     throw new Error('getActiveComponent is not implemented');
   }
+
+  getComponentNamesForComponentTypes () {
+    throw new Error('getComponentNamesForComponentTypes is not implemented');
+  }
 }

--- a/tests/ui/components/results/verticalresultscomponent.js
+++ b/tests/ui/components/results/verticalresultscomponent.js
@@ -27,6 +27,9 @@ const COMPONENT_MANAGER = mockManager(
   mockCore,
   VerticalResultsComponent.defaultTemplateName()
 );
+COMPONENT_MANAGER.getComponentNamesForComponentTypes = () => {
+  return [];
+};
 
 describe('vertical results component', () => {
   let defaultConfig;


### PR DESCRIPTION
NOTE: This includes all refactors assumed during its development in the
develop branch, including the urlutils refactor for replaceUrlParams and 
the alternativeVerticals buildVerticalSuggestions class function. We also
remove references to tabOrder because that is not currently in this branch.

We remove query parameters dealing with facets, pagination, or filters
from the inter-experience links. This is because this encoded
information should not persist as we move throughout the experience
(ie to another vertical).

For example: if you land on a vertical page with facets, these facets are
automatically added to the URL. When you try to navigate to another
tab, these query parameters persist (encoded within the nav URL) and
can lead to confusion when another vertical also has facets with similar
facet names.

re Implementation: Because name is a configurable option for components, and because
facets/filters use this as a basis for the persistentStorage key, we
must account for the different types of possible names. Thus, we store
the componentNames mapped to a component type, for easier access.

To avoid a circular dependency (Component -> urlUtils -> Component.type),
we split out the types into a different ComponentTypes class that allow
one source of truth for the component type for both the new urlutils function
and the components themselves.

J=SLAP-499
TEST=manual

Test that navigation links on a page with filters, pagination, and
facets do not contain those query parameters.

filter search
geolocation
facets
filterbox with specific CF filter
Test that View More links, Change Filter links on universal do not
contain those query parameters.

Test that Alternative Verticals vertical and universal links do not
contain those query parameters.

Add acceptance test for going from page with facets to universal
and to vertical page and make sure those do not contain the
facet/filter/pagination params.