### PR TITLE
SearchComponent: fix urls send to core.search()

### DIFF
--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -570,7 +570,8 @@ export default class SearchComponent extends Component {
             if (params.toString().length > 0) {
               url += '?' + params.toString();
             }
-            urls[tabs[i].configId] = url;
+            const verticalKey = tabs[i].configId || tabs[i].verticalKey;
+            urls[verticalKey] = url;
           }
         }
         return this.core.search(query, urls);

--- a/src/ui/templates/results/resultssectionheader.hbs
+++ b/src/ui/templates/results/resultssectionheader.hbs
@@ -13,11 +13,13 @@
     </h2>
   </div>
   {{#if verticalURL}}
-    <a class="yxt-Results-viewAllLink" href="{{verticalURL}}"
-       data-eventtype="VERTICAL_VIEW_ALL"
-       data-eventoptions='{{eventOptions}}'>
-      {{_config.viewAllText}}
-    </a>
+    {{#if _config.viewAllText}}
+      <a class="yxt-Results-viewAllLink" href="{{verticalURL}}"
+        data-eventtype="VERTICAL_VIEW_ALL"
+        data-eventoptions='{{eventOptions}}'>
+        {{_config.viewAllText}}
+      </a>
+    {{/if}}
   {{/if}}
 </div>
 {{#if appliedQueryFilters}}


### PR DESCRIPTION
SearchComponent was relying on the verticalKeys in
the navigation component's "tab" state having a
configId property. This was changed to verticalKey around 5
months ago.

This commit also changes resultssectionheader.hbs to hide
the view all link if viewAllText is not specified. Previously,
the link element would still be there, just with no text. This
should prevent issues with the view all text dom element
magically appearing for somebody upgrading from 1.3.3 to 1.3.4
due to this fix.

TEST=manual

Test that view all links will now show up in universal without
doing a translateData.

Test that the link will not show up if no viewAllText is specified.