### PR TITLE
taborder: dont mutate tabsConfig param in getDefaultTabOrder()

### DIFF
--- a/src/ui/tools/taborder.js
+++ b/src/ui/tools/taborder.js
@@ -12,19 +12,17 @@ export function getDefaultTabOrder (tabsConfig, urlParams) {
     tabOrder = urlParams.get('tabOrder').split(',');
   }
   for (const tab of tabsConfig) {
-    if (!tab.verticalKey) {
-      tab.verticalKey = tab.url;
-    }
+    const verticalKeyOrUrl = tab.verticalKey || tab.url;
     // Avoid duplicates if config was provided from URL
-    if (tabOrder.includes(tab.verticalKey)) {
+    if (tabOrder.includes(verticalKeyOrUrl)) {
       continue;
     }
 
     // isFirst should always be the first element in the list
     if (tab.isFirst) {
-      tabOrder.unshift(tab.verticalKey);
+      tabOrder.unshift(verticalKeyOrUrl);
     } else {
-      tabOrder.push(tab.verticalKey);
+      tabOrder.push(verticverticalKeyOrUrlalKey);
     }
   }
   return tabOrder;

--- a/src/ui/tools/taborder.js
+++ b/src/ui/tools/taborder.js
@@ -22,7 +22,7 @@ export function getDefaultTabOrder (tabsConfig, urlParams) {
     if (tab.isFirst) {
       tabOrder.unshift(verticalKeyOrUrl);
     } else {
-      tabOrder.push(verticverticalKeyOrUrlalKey);
+      tabOrder.push(verticalKeyOrUrl);
     }
   }
   return tabOrder;


### PR DESCRIPTION
getDefaultTabOrder() was setting tab.verticalKey if it was not set.
getUniversalUrl() finds the "universal page" by looking
for a vertical page config without a verticalKey.
We can fix this by not mutating the tabsConfig param.

Double checked that navigationcomponent was not relying on this behavior.
this._tabsConfig is only used in 2 places there, Tab.from() and
getDefaultTabOrder(). Tab.from() is careful to make deep copies
of all the tabs, and also occurs before getDefaultTabOrder(),
so this should be a safe change.

TEST=manual

Test that tab order is preserved in view all links going from universal
to vertical, but that vertical to universal do not preserve tab order

Test that the "Alternatively, you can " link to universal shows up in no results again