### PR TITLE
Acceptance tests use answers.js instead of answers.min.js

### DIFF
--- a/tests/acceptance/fixtures/html/facets.html
+++ b/tests/acceptance/fixtures/html/facets.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
 
   <script src="http://localhost:9999/dist/answerstemplates.compiled.min.js"></script>
-  <script src="http://localhost:9999/dist/answers.min.js"></script>
+  <script src="http://localhost:9999/dist/answers.js"></script>
   <link rel="stylesheet" type="text/css" href="http://localhost:9999/dist/answers.css">
 </head>
 

--- a/tests/acceptance/fixtures/html/universal.html
+++ b/tests/acceptance/fixtures/html/universal.html
@@ -3,7 +3,7 @@
         <meta charset="utf-8" />
     
         <script src="http://localhost:9999/dist/answerstemplates.compiled.min.js"></script>
-        <script src="http://localhost:9999/dist/answers.min.js"></script>
+        <script src="http://localhost:9999/dist/answers.js"></script>
         <link rel="stylesheet" type="text/css" href="http://localhost:9999/dist/answers.css">
     </head>
     <body>

--- a/tests/acceptance/fixtures/html/vertical.html
+++ b/tests/acceptance/fixtures/html/vertical.html
@@ -3,7 +3,7 @@
         <meta charset="utf-8" />
     
         <script src="http://localhost:9999/dist/answerstemplates.compiled.min.js"></script>
-        <script src="http://localhost:9999/dist/answers.min.js"></script>
+        <script src="http://localhost:9999/dist/answers.js"></script>
         <link rel="stylesheet" type="text/css" href="http://localhost:9999/dist/answers.css">
     </head>
     <body>


### PR DESCRIPTION
Use answers.js instead of answers.min.js in the acceptance tests. This lets us run "npm run dev" to keep the builds that the acceptance tests rely on up to date. This means that we no longer have to run "npm run build" before running acceptance tests.

TEST=auto

I confirmed the acceptance tests still run