### PR TITLE
gulp: Remove global polyfills

### DIFF
--- a/conf/gulp-tasks/bundle/bundletaskfactory.js
+++ b/conf/gulp-tasks/bundle/bundletaskfactory.js
@@ -1,12 +1,9 @@
-const fs = require('fs');
-
 const { dest } = require('gulp');
 
 const rollup = require('gulp-rollup-lightweight');
 const babel = require('rollup-plugin-babel');
 const resolve = require('rollup-plugin-node-resolve');
 const commonjs = require('rollup-plugin-commonjs');
-const insert = require('rollup-plugin-insert');
 
 const source = require('vinyl-source-stream');
 const replace = require('gulp-replace');
@@ -126,18 +123,13 @@ class BundleTaskFactory {
       output: outputConfig,
       plugins: [
         resolve(),
-        insert.prepend(
-          fs.readFileSync('./conf/gulp-tasks/polyfill-prefix.js').toString(),
-          {
-            include: './src/answers-umd.js'
-          }),
         commonjs({
           include: './node_modules/**'
         }),
         babel({
           runtimeHelpers: true,
           babelrc: false,
-          exclude: 'node_modules/**',
+          exclude: /node_modules\/(?!whatwg-fetch).*/,
           presets: [
             [
               '@babel/preset-env',
@@ -153,7 +145,8 @@ class BundleTaskFactory {
               corejs: 3
             }],
             '@babel/plugin-transform-arrow-functions',
-            '@babel/plugin-proposal-object-rest-spread'
+            '@babel/plugin-proposal-object-rest-spread',
+            '@babel/plugin-transform-object-assign'
           ]
         })
       ]

--- a/conf/gulp-tasks/polyfill-prefix.js
+++ b/conf/gulp-tasks/polyfill-prefix.js
@@ -1,3 +1,0 @@
-import 'regenerator-runtime/runtime';
-
-/* eslint-env browser */

--- a/conf/gulp-tasks/polyfill-prefix.js
+++ b/conf/gulp-tasks/polyfill-prefix.js
@@ -1,4 +1,3 @@
-import 'core-js/stable';
 import 'regenerator-runtime/runtime';
 
 /* eslint-env browser */

--- a/conf/gulp-tasks/templates-polyfill-prefix.js
+++ b/conf/gulp-tasks/templates-polyfill-prefix.js
@@ -1,1 +1,0 @@
-import 'core-js/features/reflect';

--- a/conf/gulp-tasks/templates.gulpfile.js
+++ b/conf/gulp-tasks/templates.gulpfile.js
@@ -1,8 +1,6 @@
 const { parallel, series, src, dest, watch } = require('gulp');
 
-const fs = require('fs');
 const del = require('del');
-const insert = require('rollup-plugin-insert');
 
 const rollup = require('gulp-rollup-lightweight');
 const babel = require('rollup-plugin-babel');
@@ -71,17 +69,26 @@ function bundleTemplates (outputConfig, fileName) {
     output: outputConfig,
     plugins: [
       resolve(),
-      insert.prepend(
-        fs.readFileSync('./conf/gulp-tasks/templates-polyfill-prefix.js').toString(),
-        {
-          include: `./dist/${filenamePrecompiled}`
-        }),
       builtins(),
       commonjs({
         include: './node_modules/**'
       }),
       babel({
-        presets: ['@babel/env']
+        runtimeHelpers: true,
+        babelrc: false,
+        exclude: /node_modules\/(@babel|core-js).*/,
+        presets: [
+          '@babel/preset-env'
+        ],
+        plugins: [
+          '@babel/syntax-dynamic-import',
+          ['@babel/plugin-transform-runtime', {
+            'corejs': 3
+          }],
+          '@babel/plugin-transform-arrow-functions',
+          '@babel/plugin-proposal-object-rest-spread',
+          '@babel/plugin-transform-object-assign'
+        ]
       })
     ]
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -920,6 +920,23 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-transform-object-assign": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.10.4.tgz",
+      "integrity": "sha512-6zccDhYEICfMeQqIjuY5G09/yhKzG30DKHJeYBQUHIsJH7c2jXSGvgwRalufLAXAq432OSlsEfAOLlzEsQzxVw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+          "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+          "dev": true
+        }
+      }
+    },
     "@babel/plugin-transform-object-super": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.5.5.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5044,11 +5044,6 @@
         "is-plain-object": "^2.0.1"
       }
     },
-    "core-js": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
-    },
     "core-js-compat": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.2.1.tgz",
@@ -6945,12 +6940,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
       "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-      "dev": true
-    },
-    "estree-walker": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
       "dev": true
     },
     "esutils": {
@@ -13564,11 +13553,6 @@
         "regenerate": "^1.4.0"
       }
     },
-    "regenerator-runtime": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
-    },
     "regenerator-transform": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.1.tgz",
@@ -14038,36 +14022,6 @@
           "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.2.tgz",
           "integrity": "sha512-XpCnW/AE10ws/kDAs37cngSkvgIR8aN3G0MS85m7dUpuK2EREo9VJ00uvw6Dg/hXEpfsE1I1TvJOJr+Z+TL+ig==",
           "dev": true
-        }
-      }
-    },
-    "rollup-plugin-insert": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-insert/-/rollup-plugin-insert-1.2.0.tgz",
-      "integrity": "sha512-5bK/K27+hiK8FBN/4bgxDqtwELSQR1oFtV47xjHz56Y6CxCQV+9WtLdaan5sWMG77iSCjUaqihSc087DM8ArIw==",
-      "dev": true,
-      "requires": {
-        "magic-string": "^0.25.6",
-        "rollup-pluginutils": "^2.8.2"
-      },
-      "dependencies": {
-        "magic-string": {
-          "version": "0.25.6",
-          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.6.tgz",
-          "integrity": "sha512-3a5LOMSGoCTH5rbqobC2HuDNRtE2glHZ8J7pK+QZYppyWA36yuNpsX994rIY2nCuyP7CZYy7lQq/X2jygiZ89g==",
-          "dev": true,
-          "requires": {
-            "sourcemap-codec": "^1.4.4"
-          }
-        },
-        "rollup-pluginutils": {
-          "version": "2.8.2",
-          "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
-          "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
-          "dev": true,
-          "requires": {
-            "estree-walker": "^0.6.1"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.9.5",
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@babel/plugin-transform-arrow-functions": "^7.8.3",
+    "@babel/plugin-transform-object-assign": "^7.10.4",
     "@babel/plugin-transform-runtime": "^7.9.0",
     "@babel/preset-env": "^7.6.0",
     "@babel/runtime-corejs3": "^7.8.4",

--- a/package.json
+++ b/package.json
@@ -5,14 +5,12 @@
   "main": "gulpfile.js",
   "dependencies": {
     "@yext/rtf-converter": "^1.2.0",
-    "core-js": "^3.6.5",
     "css-vars-ponyfill": "^2.3.1",
     "handlebars": "^4.7.2",
     "js-levenshtein": "^1.1.6",
     "kind-of": "^6.0.3",
     "markdown-it-for-inline": "^0.1.1",
     "plural-forms": "^0.5.1",
-    "regenerator-runtime": "^0.13.3",
     "template-helpers": "^1.0.1"
   },
   "devDependencies": {
@@ -49,7 +47,6 @@
     "rollup": "^1.4.1",
     "rollup-plugin-babel": "^4.3.2",
     "rollup-plugin-commonjs": "^9.2.1",
-    "rollup-plugin-insert": "1.2.0",
     "rollup-plugin-node-builtins": "^2.1.2",
     "rollup-plugin-node-resolve": "^4.0.1",
     "semistandard": "^13.0.1",

--- a/src/ui/dom/searchparams.js
+++ b/src/ui/dom/searchparams.js
@@ -37,7 +37,7 @@ export default class SearchParams {
     let params = {};
     let search = url;
 
-    if (search === '') {
+    if (!search) {
       return params;
     }
 


### PR DESCRIPTION
We remove the global polyfills in our SDK builds. Previously, we prepended our
polyfill-prefix file to every file in our builds. This is for both template
builds and our answers library builds. As a result of this, any page that
imported these assets would have their global polyfills replaced with the
polyfills defined in the libraries we imported. In particular, this is the
core-js/stable/* and regnenerator-runtime libraries.

Instead of using these globally, we transpile our code with babel and
associated plugins to make up for the loss of the polyfills. This decision is
in response to many techops where client sites, seeing that our polyfills clash
with their implementations. This is in effort to make our library and
templatebundle self-contained, not to touch any code outside of our
implementation.

Implementation detail: we must also run one of our node_modules
(whatwg-fetch polyfill) through babel as well because it relies on a
Promise implementation (noted in their documentation).

J=SLAP-555
TEST=manual

Test that an answers experience (not Jambo) using a local reference to
the SDK will run basic search functions. Not a Jambo site because the
HH theme is running code that requires a polyfill outside
of the SDK (Object.assign). Note: The core-js code will be added to the
theme in the short-term.

In IE11, Edge (Windows) Firefox, Chrome (MacOS) iPhone Safari (iOS)
Test search on universal
Test search on vertical
Test facets/filters/pagination on vertical
Test map on universal
Test view more links / change filters on universal
Test direct answers on universal and feedback (error on IE11 on develop,
see SLAP-556)
Test autocomplete shows on both universal / vertical
