### PR TITLE
facets/filteroptions: replace state for facets on page load 

### DIFF
--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -316,9 +316,18 @@ export default class FilterOptionsComponent extends Component {
         ? o.filter
         : Filter.equal(o.field, o.value));
 
-    this.core.persistentStorage.set(this.name, this.config.options.filter(o => o.selected).map(o => o.label));
+    this.saveFilterToPersistentStorage();
     return filters.length > 0
       ? Filter.group(...filters)
       : {};
+  }
+
+  saveFilterToPersistentStorage () {
+    const replaceHistory = (this.core.persistentStorage.get(this.name) === null);
+    this.core.persistentStorage.set(
+      this.name,
+      this.config.options.filter(o => o.selected).map(o => o.label),
+      replaceHistory
+    );
   }
 }

--- a/src/ui/storage/persistentstorage.js
+++ b/src/ui/storage/persistentstorage.js
@@ -110,8 +110,9 @@ export default class PersistentStorage {
 
   /**
    * Get a value for a given key in storage
+   * @param {string} key The unique key to get value for
    */
-  get (query) {
-    return this._params.get(query);
+  get (key) {
+    return this._params.get(key);
   }
 }

--- a/src/ui/storage/persistentstorage.js
+++ b/src/ui/storage/persistentstorage.js
@@ -1,5 +1,6 @@
 import SearchParams from '../dom/searchparams';
 import { AnswersStorageError } from '../../core/errors/errors';
+import { equivalentParams } from '../../core/utils/urlutils';
 
 /** @module PersistentStorage */
 
@@ -69,6 +70,10 @@ export default class PersistentStorage {
     if (this._historyTimer) {
       clearTimeout(this._historyTimer);
     }
+    const currentParams = new SearchParams(window.location.search.substring(1));
+    if (equivalentParams(this._params, currentParams)) {
+      return;
+    }
 
     // batch update calls across components to avoid updating the url too much
     this._historyTimer = setTimeout(
@@ -101,5 +106,12 @@ export default class PersistentStorage {
       allParams[key] = val;
     }
     return allParams;
+  }
+
+  /**
+   * Get a value for a given key in storage
+   */
+  get (query) {
+    return this._params.get(query);
   }
 }

--- a/tests/core/storage/persistentstorage.js
+++ b/tests/core/storage/persistentstorage.js
@@ -47,11 +47,12 @@ describe('adding and removing data', () => {
 
   it('removes data with delete()', () => {
     storage.set('key1', 'val1');
+    storage.set('key2', 'val2');
     storage.delete('key1');
 
     expect.assertions(1);
     return new Promise(resolve => setTimeout(() => {
-      expect(mockPushState).toBeCalledWith(null, null, '?');
+      expect(mockPushState).toBeCalledWith(null, null, '?key2=val2');
       resolve();
     }, 200));
   });


### PR DESCRIPTION
This is necessary for two problems.

When you land on a page, previously a query param would be added to
the persistent storage for /each/ facet. Because we were not
replacing history, this would mean we're pushing x states onto the
browser history on page load, where x is the number of facet types.

When you land on a page with no facet query parameters in the URL,
the correct facet query parameters are automatically added to the URL.
Because we push a state when we automatically add it on page load, if
you try to back nav, you will reach a page without query parameters
again. This will re-add the parameters and you are back where you
started. This continues indefinitely, where you are kept in a loop.

By having replaceHistory for page load, we do not push more states on
page load. We also do not push a state in the looping problem (#2).

Note: we want the state to be pushed on a normal facet apply action.
This should only affect page load with no/incorrect # of facet query
parameters.

J=SLAP-529
TEST=manual

On a vertical page with facets

Test multiple searches and make sure you can back nav through all
searches
Test search, apply facet, search, make sure you can back nav through
all states
On a vertical page with facets and filters

Test multiple searches and make sure you can back nav through all
searches
Test search, apply facet, search, make sure you can back nav through
all states
Test search, apply filter, search, make sure you can back nav through
all states
On a universal page

Test multiple searches and make sure you can back nav through all
searches
Test landing with a query
Test landing with query parameters
^ Make sure for both it only takes one back nav to get to the previous
page before landing.

On a vertical page ("people" verticalKey for me)
        Clicking on a Facet filter option and then clicking apply pushes
        on state to history.
        Landing on the page with Facets and a query does not push state
        when the facet query parameters are added. You can back nav from
        the landed page to whatever page you were on before in only one
        click.

        Searching in a sequence produces the correct history state:
        On State 1
        Navigate and land on empty vertical,
        On State 2
        Search all
        On State 3
        Search max
        On State 4
        Search all
        On State 5
        Click on Facet
        On State 6
        Click Apply
        On State 7

        If you back nav in the browser, you should be able to get to all
        7 states.