### PR TITLE
facets/filteroptions: replace state for facets on page load

### DIFF
--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -674,6 +674,10 @@ export default class FilterOptionsComponent extends Component {
 
   saveFilterToPersistentStorage () {
     const replaceHistory = (this.core.persistentStorage.get(this.name) === null);
-    this.core.persistentStorage.set(this.name, this.config.options.filter(o => o.selected).map(o => o.label), replaceHistory);
+    this.core.persistentStorage.set(
+      this.name,
+      this.config.options.filter(o => o.selected).map(o => o.label),
+      replaceHistory
+    );
   }
 }

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -659,7 +659,7 @@ export default class FilterOptionsComponent extends Component {
         remove: () => this._clearSingleOption(o)
       }));
 
-    this.core.persistentStorage.set(this.name, this.config.options.filter(o => o.selected).map(o => o.label));
+    this.saveFilterToPersistentStorage();
     const fieldIdToFilterNodes = groupArray(filterNodes, fn => fn.getFilter().getFilterKey());
 
     // OR together filter nodes for the same field id.
@@ -670,5 +670,10 @@ export default class FilterOptionsComponent extends Component {
 
     // AND all of the ORed together nodes.
     return FilterNodeFactory.and(...totalFilterNodes);
+  }
+
+  saveFilterToPersistentStorage () {
+    const replaceHistory = (this.core.persistentStorage.get(this.name) === null);
+    this.core.persistentStorage.set(this.name, this.config.options.filter(o => o.selected).map(o => o.label), replaceHistory);
   }
 }

--- a/src/ui/storage/persistentstorage.js
+++ b/src/ui/storage/persistentstorage.js
@@ -66,6 +66,9 @@ export default class PersistentStorage {
       return;
     }
 
+    console.log('updating history w replaceHistory ' + replaceHistory);
+    console.log('before ' + currentParams);
+    console.log('after ' + this._params);
     if (replaceHistory) {
       window.history.replaceState(null, null, `?${this._params.toString()}`);
     } else {

--- a/src/ui/storage/persistentstorage.js
+++ b/src/ui/storage/persistentstorage.js
@@ -66,9 +66,6 @@ export default class PersistentStorage {
       return;
     }
 
-    console.log('updating history w replaceHistory ' + replaceHistory);
-    console.log('before ' + currentParams);
-    console.log('after ' + this._params);
     if (replaceHistory) {
       window.history.replaceState(null, null, `?${this._params.toString()}`);
     } else {

--- a/src/ui/storage/persistentstorage.js
+++ b/src/ui/storage/persistentstorage.js
@@ -93,4 +93,11 @@ export default class PersistentStorage {
     }
     return allParams;
   }
+
+  /**
+   * Get a value for a given key in storage
+   */
+  get (query) {
+    return this._params.get(query);
+  }
 }

--- a/tests/setup/managermocker.js
+++ b/tests/setup/managermocker.js
@@ -30,6 +30,7 @@ export default function mockManager (mockedCore, ...templatePaths) {
     },
     persistentStorage: {
       set: () => {},
+      get: () => {},
       delete: () => {}
     },
     ...mockedCore

--- a/tests/ui/components/filters/filteroptionscomponent.js
+++ b/tests/ui/components/filters/filteroptionscomponent.js
@@ -524,7 +524,8 @@ describe('filter options component', () => {
             delete: () => { }
           },
           persistentStorage: {
-            set: () => { }
+            set: () => { },
+            get: () => { }
           },
           setLocationRadiusFilterNode,
           setStaticFilterNodes


### PR DESCRIPTION
This is necessary for two problems.

1. When you land on a page, previously a query param would be added to
   the persistent storage for /each/ facet. Because we were not
   replacing history, this would mean we're pushing x states onto the
   browser history on page load, where x is the number of facet types.

2. When you land on a page with no facet query parameters in the URL,
   the correct facet query parameters are automatically added to the URL.
   Because we push a state when we automatically add it on page load, if
   you try to back nav, you will reach a page without query parameters
   again. This will re-add the parameters and you are back where you
   started. This continues indefinitely, where you are kept in a loop.

By having replaceHistory for page load, we do not push more states on
page load. We also do not push a state in the looping problem (#2).

Note: we want the state to be pushed on a normal facet apply action.
This should only affect page load with no/incorrect # of facet query
parameters.

J=SLAP-529
TEST=manual

On a vertical page with facets
 - Test multiple searches and make sure you can back nav through all
   searches
 - Test search, apply facet, search, make sure you can back nav through
   all states

On a vertical page with facets and filters
 - Test multiple searches and make sure you can back nav through all
   searches
 - Test search, apply facet, search, make sure you can back nav through
   all states
 - Test search, apply filter, search, make sure you can back nav through
   all states

On a universal page
 - Test multiple searches and make sure you can back nav through all
   searches

Test landing with a query
Test landing with query parameters
^ Make sure for both it only takes one back nav to get to the previous
page before landing.