### PR TITLE
facets/filteroptions: replace state for facets on page load 

### DIFF
--- a/src/core/utils/urlutils.js
+++ b/src/core/utils/urlutils.js
@@ -55,3 +55,24 @@ export function addParamsToUrl (url, params = {}) {
   }
   return url.split('?')[0] + '?' + urlParams;
 }
+
+/**
+ * returns if two SearchParams objects have the same key,value entries
+ * @param {SearchParams} params1
+ * @param {SearchParams} params2
+ * @return {boolean} true if params1 and params2 have the same key,value entries, false otherwise
+ */
+export function equivalentParams (params1, params2) {
+  const entries1 = Array.from(params1.entries());
+  const entries2 = Array.from(params2.entries());
+
+  if (entries1.length !== entries2.length) {
+    return false;
+  }
+  for (const [key, val] of params1.entries()) {
+    if (val !== params2.get(key)) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -658,7 +658,7 @@ export default class FilterOptionsComponent extends Component {
         remove: () => this._clearSingleOption(o)
       }));
 
-    this.core.persistentStorage.set(this.name, this.config.options.filter(o => o.selected).map(o => o.label));
+    this.saveFilterToPersistentStorage();
     const fieldIdToFilterNodes = groupArray(filterNodes, fn => fn.getFilter().getFilterKey());
 
     // OR together filter nodes for the same field id.
@@ -669,5 +669,10 @@ export default class FilterOptionsComponent extends Component {
 
     // AND all of the ORed together nodes.
     return FilterNodeFactory.and(...totalFilterNodes);
+  }
+
+  saveFilterToPersistentStorage () {
+    const replaceHistory = (this.core.persistentStorage.get(this.name) === null);
+    this.core.persistentStorage.set(this.name, this.config.options.filter(o => o.selected).map(o => o.label), replaceHistory);
   }
 }

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -673,6 +673,10 @@ export default class FilterOptionsComponent extends Component {
 
   saveFilterToPersistentStorage () {
     const replaceHistory = (this.core.persistentStorage.get(this.name) === null);
-    this.core.persistentStorage.set(this.name, this.config.options.filter(o => o.selected).map(o => o.label), replaceHistory);
+    this.core.persistentStorage.set(
+      this.name,
+      this.config.options.filter(o => o.selected).map(o => o.label),
+      replaceHistory
+    );
   }
 }

--- a/src/ui/storage/persistentstorage.js
+++ b/src/ui/storage/persistentstorage.js
@@ -107,4 +107,11 @@ export default class PersistentStorage {
     }
     return allParams;
   }
+
+  /**
+   * Get a value for a given key in storage
+   */
+  get (query) {
+    return this._params.get(query);
+  }
 }

--- a/src/ui/storage/persistentstorage.js
+++ b/src/ui/storage/persistentstorage.js
@@ -1,5 +1,6 @@
 import SearchParams from '../dom/searchparams';
 import { AnswersStorageError } from '../../core/errors/errors';
+import { equivalentParams } from '../../core/utils/urlutils';
 
 /** @module PersistentStorage */
 
@@ -68,6 +69,10 @@ export default class PersistentStorage {
   _updateHistory (replaceHistory = false) {
     if (this._historyTimer) {
       clearTimeout(this._historyTimer);
+    }
+    const currentParams = new SearchParams(window.location.search.substring(1));
+    if (equivalentParams(this._params, currentParams)) {
+      return;
     }
 
     // batch update calls across components to avoid updating the url too much

--- a/tests/core/storage/persistentstorage.js
+++ b/tests/core/storage/persistentstorage.js
@@ -47,11 +47,12 @@ describe('adding and removing data', () => {
 
   it('removes data with delete()', () => {
     storage.set('key1', 'val1');
+    storage.set('key2', 'val2');
     storage.delete('key1');
 
     expect.assertions(1);
     return new Promise(resolve => setTimeout(() => {
-      expect(mockPushState).toBeCalledWith(null, null, '?');
+      expect(mockPushState).toBeCalledWith(null, null, '?key2=val2');
       resolve();
     }, 200));
   });

--- a/tests/setup/managermocker.js
+++ b/tests/setup/managermocker.js
@@ -30,6 +30,7 @@ export default function mockManager (mockedCore, ...templatePaths) {
     },
     persistentStorage: {
       set: () => {},
+      get: () => {},
       delete: () => {}
     },
     ...mockedCore

--- a/tests/ui/components/filters/filteroptionscomponent.js
+++ b/tests/ui/components/filters/filteroptionscomponent.js
@@ -80,6 +80,10 @@ describe('filter options component', () => {
           return null;
         },
         delete: () => { }
+      },
+      persistentStorage: {
+        get: () => { },
+        set: () => { }
       }
     };
 
@@ -524,7 +528,8 @@ describe('filter options component', () => {
             delete: () => { }
           },
           persistentStorage: {
-            set: () => { }
+            set: () => { },
+            get: () => { }
           },
           setLocationRadiusFilterNode,
           setStaticFilterNodes


### PR DESCRIPTION
This is necessary for two problems.

When you land on a page, previously a query param would be added to
the persistent storage for /each/ facet. Because we were not
replacing history, this would mean we're pushing x states onto the
browser history on page load, where x is the number of facet types.

When you land on a page with no facet query parameters in the URL,
the correct facet query parameters are automatically added to the URL.
Because we push a state when we automatically add it on page load, if
you try to back nav, you will reach a page without query parameters
again. This will re-add the parameters and you are back where you
started. This continues indefinitely, where you are kept in a loop.

By having replaceHistory for page load, we do not push more states on
page load. We also do not push a state in the looping problem (#2).

Note: we want the state to be pushed on a normal facet apply action.
This should only affect page load with no/incorrect # of facet query
parameters.

J=SLAP-529
TEST=manual

On a vertical page with facets

Test multiple searches and make sure you can back nav through all
searches
Test search, apply facet, search, make sure you can back nav through
all states
On a vertical page with facets and filters

Test multiple searches and make sure you can back nav through all
searches
Test search, apply facet, search, make sure you can back nav through
all states
Test search, apply filter, search, make sure you can back nav through
all states
On a universal page

Test multiple searches and make sure you can back nav through all
searches
Test landing with a query
Test landing with query parameters
^ Make sure for both it only takes one back nav to get to the previous
page before landing.