### PR TITLE
search: respect back navigation with empty search

### DIFF
--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -160,7 +160,12 @@ class Answers {
     const globalStorage = new GlobalStorage();
     const persistentStorage = new PersistentStorage({
       updateListener: parsedConfig.onStateChange,
-      resetListener: data => globalStorage.setAll(data)
+      resetListener: data => {
+        if (!data[StorageKeys.QUERY]) {
+          this.core.clearResults();
+        }
+        globalStorage.setAll(data);
+      }
     });
     globalStorage.setAll(persistentStorage.getAll());
     globalStorage.set(StorageKeys.SEARCH_CONFIG, parsedConfig.search);

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -160,9 +160,7 @@ class Answers {
     const globalStorage = new GlobalStorage();
     const persistentStorage = new PersistentStorage({
       updateListener: parsedConfig.onStateChange,
-      resetListener: data => {
-        globalStorage.setAll(data)
-      }
+      resetListener: data => globalStorage.setAll(data)
     });
     globalStorage.setAll(persistentStorage.getAll());
     globalStorage.set(StorageKeys.SEARCH_CONFIG, parsedConfig.search);

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -160,7 +160,9 @@ class Answers {
     const globalStorage = new GlobalStorage();
     const persistentStorage = new PersistentStorage({
       updateListener: parsedConfig.onStateChange,
-      resetListener: data => globalStorage.setAll(data)
+      resetListener: data => {
+        globalStorage.setAll(data)
+      }
     });
     globalStorage.setAll(persistentStorage.getAll());
     globalStorage.set(StorageKeys.SEARCH_CONFIG, parsedConfig.search);

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -8,9 +8,7 @@ import QuestionSubmission from './models/questionsubmission';
 import SearchIntents from './models/searchintents';
 import Navigation from './models/navigation';
 import AlternativeVerticals from './models/alternativeverticals';
-import SpellCheck from './models/spellcheck';
 import DirectAnswer from './models/directanswer';
-import DynamicFilters from './models/dynamicfilters';
 import LocationBias from './models/locationbias';
 
 import StorageKeys from './storage/storagekeys';

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -233,6 +233,7 @@ export default class Core {
   }
 
   clearResults () {
+    this.globalStorage.set(StorageKeys.QUERY, null);
     this.globalStorage.set(StorageKeys.QUERY_ID, '');
     this.globalStorage.set(StorageKeys.RESULTS_HEADER, {});
     this.globalStorage.set(StorageKeys.SPELL_CHECK, {}); // TODO has a model but not cleared w new

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -2,10 +2,18 @@
 
 import SearchDataTransformer from './search/searchdatatransformer';
 
-import StorageKeys from './storage/storagekeys';
 import VerticalResults from './models/verticalresults';
 import UniversalResults from './models/universalresults';
 import QuestionSubmission from './models/questionsubmission';
+import SearchIntents from './models/searchintents';
+import Navigation from './models/navigation';
+import AlternativeVerticals from './models/alternativeverticals';
+import SpellCheck from './models/spellcheck';
+import DirectAnswer from './models/directanswer';
+import DynamicFilters from './models/dynamicfilters';
+import LocationBias from './models/locationbias';
+
+import StorageKeys from './storage/storagekeys';
 import AnalyticsEvent from './analytics/analyticsevent';
 import FilterRegistry from './filters/filterregistry';
 
@@ -224,6 +232,21 @@ export default class Core {
           this._analyticsReporter.report(AnalyticsEvent.fromData(analyticsEvent));
         }
       });
+  }
+
+  clearResults () {
+    this.globalStorage.set(StorageKeys.QUERY_ID, '');
+    this.globalStorage.set(StorageKeys.RESULTS_HEADER, {});
+    this.globalStorage.set(StorageKeys.SPELL_CHECK, {}); // TODO has a model but not cleared w new
+    this.globalStorage.set(StorageKeys.DYNAMIC_FILTERS, {}); // TODO has a model but not cleared w new
+    this.globalStorage.set(StorageKeys.QUESTION_SUBMISSION, new QuestionSubmission({}));
+    this.globalStorage.set(StorageKeys.INTENTS, new SearchIntents({}));
+    this.globalStorage.set(StorageKeys.NAVIGATION, new Navigation());
+    this.globalStorage.set(StorageKeys.ALTERNATIVE_VERTICALS, new AlternativeVerticals({}));
+    this.globalStorage.set(StorageKeys.DIRECT_ANSWER, new DirectAnswer({}));
+    this.globalStorage.set(StorageKeys.LOCATION_BIAS, new LocationBias({}));
+    this.globalStorage.set(StorageKeys.VERTICAL_RESULTS, new VerticalResults({}));
+    this.globalStorage.set(StorageKeys.UNIVERSAL_RESULTS, new UniversalResults({}));
   }
 
   /**

--- a/src/core/storage/globalstorage.js
+++ b/src/core/storage/globalstorage.js
@@ -42,6 +42,22 @@ export default class GlobalStorage {
     // TODO: move listeners up so all of storage can be updated at the same time
     if (data[StorageKeys.QUERY]) {
       this.set(StorageKeys.QUERY, data[StorageKeys.QUERY]);
+    } else if (this.getState(StorageKeys.QUERY)) {
+      this.set(StorageKeys.QUERY, null);
+
+      /* IGNORE
+      this.set(StorageKeys.VERTICAL_RESULTS, {
+        searchState: 'search-complete'
+      });
+      this.set(StorageKeys.ALTERNATIVE_VERTICALS, {});
+      */
+      /*t
+      for (const dataKey of Object.keys(this._moduleDataContainer)) {
+        this.set(dataKey, null);
+
+      }
+      */
+      //this.set(StorageKeys.QUERY, '');
     }
   }
 
@@ -49,7 +65,7 @@ export default class GlobalStorage {
     if (key === undefined || key === null || typeof key !== 'string') {
       throw new AnswersStorageError('Invalid storage key provided', key, data);
     }
-    if (data === undefined || data === null) {
+    if (data === undefined) {
       throw new AnswersStorageError('No data provided', key, data);
     }
 
@@ -102,6 +118,11 @@ export default class GlobalStorage {
 
     this._moduleDataContainer[moduleId].on(evt, cb);
     return this;
+  }
+
+  setAllAndPrune (data) {
+    this.setAll(data);
+
   }
 
   off (evt, moduleId, cb) {

--- a/src/core/storage/globalstorage.js
+++ b/src/core/storage/globalstorage.js
@@ -44,20 +44,6 @@ export default class GlobalStorage {
       this.set(StorageKeys.QUERY, data[StorageKeys.QUERY]);
     } else if (this.getState(StorageKeys.QUERY)) {
       this.set(StorageKeys.QUERY, null);
-
-      /* IGNORE
-      this.set(StorageKeys.VERTICAL_RESULTS, {
-        searchState: 'search-complete'
-      });
-      this.set(StorageKeys.ALTERNATIVE_VERTICALS, {});
-      */
-      /*t
-      for (const dataKey of Object.keys(this._moduleDataContainer)) {
-        this.set(dataKey, null);
-
-      }
-      */
-      //this.set(StorageKeys.QUERY, '');
     }
   }
 
@@ -118,11 +104,6 @@ export default class GlobalStorage {
 
     this._moduleDataContainer[moduleId].on(evt, cb);
     return this;
-  }
-
-  setAllAndPrune (data) {
-    this.setAll(data);
-
   }
 
   off (evt, moduleId, cb) {

--- a/src/core/storage/globalstorage.js
+++ b/src/core/storage/globalstorage.js
@@ -42,8 +42,6 @@ export default class GlobalStorage {
     // TODO: move listeners up so all of storage can be updated at the same time
     if (data[StorageKeys.QUERY]) {
       this.set(StorageKeys.QUERY, data[StorageKeys.QUERY]);
-    } else if (this.getState(StorageKeys.QUERY)) {
-      this.set(StorageKeys.QUERY, null);
     }
   }
 

--- a/src/core/storage/moduledata.js
+++ b/src/core/storage/moduledata.js
@@ -26,7 +26,11 @@ export default class ModuleData extends EventEmitter {
   set (data) {
     this.capturePrevious();
 
-    if (typeof data !== 'object' || Array.isArray(data) || Object.keys(data).length !== Object.keys(this._data).length) {
+    if (data === null ||
+      typeof data !== 'object' ||
+      Array.isArray(data) ||
+      Object.keys(data).length !== Object.keys(this._data).length
+    ) {
       this._data = data;
       this.emit('update', this._data);
       return;

--- a/src/ui/components/results/universalresultscomponent.js
+++ b/src/ui/components/results/universalresultscomponent.js
@@ -41,13 +41,14 @@ export default class UniversalResultsComponent extends Component {
 
   setState (data, val) {
     const sections = data.sections || [];
+    const query = this.core.globalStorage.getState(StorageKeys.QUERY);
     const searchState = data.searchState || SearchStates.PRE_SEARCH;
     return super.setState(Object.assign(data, {
       isPreSearch: searchState === SearchStates.PRE_SEARCH,
       isSearchLoading: searchState === SearchStates.SEARCH_LOADING,
       isSearchComplete: searchState === SearchStates.SEARCH_COMPLETE,
-      showNoResults: sections.length === 0,
-      query: this.core.globalStorage.getState(StorageKeys.QUERY),
+      showNoResults: sections.length === 0 && query,
+      query: query,
       sections: sections
     }, val));
   }
@@ -92,7 +93,7 @@ export default class UniversalResultsComponent extends Component {
       // Override vertical config defaults with user given config.
       ...config,
       // Config for the applied filters bar. Must be placed after ...config to not override defaults.
-      appliedFilters: {
+     appliedFilters: {
         // Whether to display applied filters.
         show: defaultConfigOption(config, ['appliedFilters.show', 'showAppliedFilters'], topLevelAppliedFilters.show),
         // Whether to show field names, e.g. Location in Location: Virginia.

--- a/src/ui/components/results/universalresultscomponent.js
+++ b/src/ui/components/results/universalresultscomponent.js
@@ -93,7 +93,7 @@ export default class UniversalResultsComponent extends Component {
       // Override vertical config defaults with user given config.
       ...config,
       // Config for the applied filters bar. Must be placed after ...config to not override defaults.
-     appliedFilters: {
+      appliedFilters: {
         // Whether to display applied filters.
         show: defaultConfigOption(config, ['appliedFilters.show', 'showAppliedFilters'], topLevelAppliedFilters.show),
         // Whether to show field names, e.g. Location in Location: Virginia.

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -143,6 +143,7 @@ export default class SearchComponent extends Component {
           searchState: 'search-complete'
         });
         this.core.globalStorage.set(StorageKeys.ALTERNATIVE_VERTICALS, {});
+        this.core.globalStorage.set(StorageKeys.DYNAMIC_FILTERS, {});
         this.core.globalStorage.set(StorageKeys.LOCATION_BIAS, {});
         return;
       }

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -135,8 +135,19 @@ export default class SearchComponent extends Component {
     this.query = config.query || this.core.globalStorage.getState(StorageKeys.QUERY);
     this.core.globalStorage.on('update', StorageKeys.QUERY, q => {
       this.query = q;
+      console.log('QUERY: ' + q);
       if (this.queryEl) {
+        console.log('entered');
         this.queryEl.value = q;
+      }
+      if (q === null) {
+        this.core.globalStorage.set(StorageKeys.VERTICAL_RESULTS, {
+          searchState: 'search-complete'
+        });
+        this.core.globalStorage.set(StorageKeys.ALTERNATIVE_VERTICALS, {});
+        this.core.globalStorage.set(StorageKeys.ALTERNATIVE_VERTICALS, {});
+        this.core.globalStorage.set(StorageKeys.LOCATION_BIAS, {});
+        return;
       }
       this.debouncedSearch(q);
     });
@@ -446,7 +457,12 @@ export default class SearchComponent extends Component {
     this.core.persistentStorage.delete(StorageKeys.SEARCH_OFFSET);
     this.core.globalStorage.delete(StorageKeys.SEARCH_OFFSET);
     this.core.setQuery(query);
-    this.debouncedSearch(query);
+    if ((!query && !this._verticalKey) ||
+      (!query && this._verticalKey && !this._allowEmptySearch) ||
+      this._isTwin) {
+    } else {
+      this.debouncedSearch(query);
+    }
     return false;
   }
 
@@ -492,10 +508,7 @@ export default class SearchComponent extends Component {
    * @returns {Promise} A promise that will perform the query and update globalStorage accordingly.
    */
   debouncedSearch (query) {
-    if (this._throttled ||
-      (!query && !this._verticalKey) ||
-      (!query && this._verticalKey && !this._allowEmptySearch) ||
-      this._isTwin) {
+    if (this._throttled) {
       return;
     }
 

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -127,6 +127,13 @@ export default class SearchComponent extends Component {
      */
     this._isTwin = config.isTwin;
 
+    this._searchConfig = this.core.globalStorage.getState(StorageKeys.SEARCH_CONFIG);
+    this._defaultInitialSearch = this._searchConfig &&
+      this._searchConfig.defaultInitialSearch !== null &&
+      this._searchConfig.defaultInitialSearch !== undefined
+      ? this._searchConfig.defaultInitialSearch
+      : null;
+
     /**
      * The query string to use for the input box, provided to template for rendering.
      * Optionally provided
@@ -139,12 +146,10 @@ export default class SearchComponent extends Component {
         this.queryEl.value = q;
       }
       if (q === null) {
-        this.core.globalStorage.set(StorageKeys.VERTICAL_RESULTS, {
-          searchState: 'search-complete'
-        });
-        this.core.globalStorage.set(StorageKeys.ALTERNATIVE_VERTICALS, {});
-        this.core.globalStorage.set(StorageKeys.DYNAMIC_FILTERS, {});
-        this.core.globalStorage.set(StorageKeys.LOCATION_BIAS, {});
+        this.core.clearResults();
+        if (this._defaultInitialSearch !== null) {
+          this.core.setQuery(this._defaultInitialSearch);
+        }
         return;
       }
       this.debouncedSearch(q);

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -135,9 +135,7 @@ export default class SearchComponent extends Component {
     this.query = config.query || this.core.globalStorage.getState(StorageKeys.QUERY);
     this.core.globalStorage.on('update', StorageKeys.QUERY, q => {
       this.query = q;
-      console.log('QUERY: ' + q);
       if (this.queryEl) {
-        console.log('entered');
         this.queryEl.value = q;
       }
       if (q === null) {
@@ -456,12 +454,7 @@ export default class SearchComponent extends Component {
     this.core.persistentStorage.delete(StorageKeys.SEARCH_OFFSET);
     this.core.globalStorage.delete(StorageKeys.SEARCH_OFFSET);
     this.core.setQuery(query);
-    if ((!query && !this._verticalKey) ||
-      (!query && this._verticalKey && !this._allowEmptySearch) ||
-      this._isTwin) {
-    } else {
-      this.debouncedSearch(query);
-    }
+    this.debouncedSearch(query);
     return false;
   }
 
@@ -507,7 +500,10 @@ export default class SearchComponent extends Component {
    * @returns {Promise} A promise that will perform the query and update globalStorage accordingly.
    */
   debouncedSearch (query) {
-    if (this._throttled) {
+    if (this._throttled ||
+      (!query && !this._verticalKey) ||
+      (!query && this._verticalKey && !this._allowEmptySearch) ||
+      this._isTwin) {
       return;
     }
 

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -145,7 +145,6 @@ export default class SearchComponent extends Component {
           searchState: 'search-complete'
         });
         this.core.globalStorage.set(StorageKeys.ALTERNATIVE_VERTICALS, {});
-        this.core.globalStorage.set(StorageKeys.ALTERNATIVE_VERTICALS, {});
         this.core.globalStorage.set(StorageKeys.LOCATION_BIAS, {});
         return;
       }

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -146,7 +146,6 @@ export default class SearchComponent extends Component {
         this.queryEl.value = q;
       }
       if (q === null) {
-        this.core.clearResults();
         if (this._defaultInitialSearch !== null) {
           this.core.setQuery(this._defaultInitialSearch);
         }

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -127,12 +127,15 @@ export default class SearchComponent extends Component {
      */
     this._isTwin = config.isTwin;
 
-    this._searchConfig = this.core.globalStorage.getState(StorageKeys.SEARCH_CONFIG);
-    this._defaultInitialSearch = this._searchConfig &&
-      this._searchConfig.defaultInitialSearch !== null &&
-      this._searchConfig.defaultInitialSearch !== undefined
-      ? this._searchConfig.defaultInitialSearch
-      : null;
+    /**
+     * The search config from ANSWERS.init configuration
+     */
+    this._globalSearchConfig = this.core.globalStorage.getState(StorageKeys.SEARCH_CONFIG) || {};
+
+    /**
+     * The default initial search query, can be an empty string
+     */
+    this._defaultInitialSearch = this._globalSearchConfig.defaultInitialSearch;
 
     /**
      * The query string to use for the input box, provided to template for rendering.
@@ -146,7 +149,7 @@ export default class SearchComponent extends Component {
         this.queryEl.value = q;
       }
       if (q === null) {
-        if (this._defaultInitialSearch !== null) {
+        if (this._defaultInitialSearch || this._defaultInitialSearch === '') {
           this.core.setQuery(this._defaultInitialSearch);
         }
         return;

--- a/src/ui/storage/persistentstorage.js
+++ b/src/ui/storage/persistentstorage.js
@@ -66,6 +66,9 @@ export default class PersistentStorage {
       return;
     }
 
+    console.log('updating history w replaceHistory ' + replaceHistory);
+    console.log('before ' + currentParams);
+    console.log('after ' + this._params);
     if (replaceHistory) {
       window.history.replaceState(null, null, `?${this._params.toString()}`);
     } else {

--- a/src/ui/storage/persistentstorage.js
+++ b/src/ui/storage/persistentstorage.js
@@ -66,9 +66,6 @@ export default class PersistentStorage {
       return;
     }
 
-    console.log('updating history w replaceHistory ' + replaceHistory);
-    console.log('before ' + currentParams);
-    console.log('after ' + this._params);
     if (replaceHistory) {
       window.history.replaceState(null, null, `?${this._params.toString()}`);
     } else {


### PR DESCRIPTION
Consider the example below

Land on /index.html (e.g. https://answers.yext.com/?)
In State 1
Search "all"
In State 2
Back navigation in browser history
In State 3

You would expect state 3 == state 1 (in terms of results shown on the page and the query surfaced in the search bar). However, this is not the case, we do not make changes when navigating back into an empty query. Instead state 3 == state 2 in the above scenario. We make fixes here to make it so that state 3 == state 1 (as closely as possible).

There were a few things we need to change.

First, `window.onpopstate` updates current globalStorage by adding any new/updated query params to the globalStorage. It does not remove query params that were in e.g. state 2 but not in state 1 (in our case, `query`). In `setAll`, if we see that there was a query and no longer a query, we remove it. This is something we can iterate on for all possible parameters that should be reset onpopstate.

Second, we must differentiate between an empty search (purposeful) and a null search (landing). This is because these are two separate states. When searchcomponent is listening for updates to StorageKeys.QUERY, query can be `null` when a user lands on the page or when they back nav into the landing page. It can be empty when a user sets that as the `defaultInitialSearch`, the `query` param is `query=`, the user purposefully searches with no query in the searchbar. The latter can show all results, depending on the backend configuration whereas the former should always show a blank experience. We were conflating these definitions.

Third, we must re-do a defaultInitialSearch, if it exists. This requires making searchcomponent cognizant of the ANSWERS.init searchConfig.

Note: currently, (in master)
1. on UniversalResults, if `allowEmptySearch: true`, clicking search with an empty query does *not* show all results
2. on VerticalResults, if landing with `query=` in the parameters and `allowEmptySearch: true`, does *not* show all results

J=SLAP-562
TEST=manual

Test the above example.
Test on a local Jambo site, test on a local client Jambo site, test on a local site referencing the SDK directly.

Test starting from an empty universal search, starting from an empty vertical search:
* Searching empty returns all results if `allowEmptySearch` is true
* Searching for a direct answer and then moving back to empty works
* Searching for alternative verticals and then moving back to empty works
* Searching for spell check and then moving back to empty works
* Searching for a direct answer and then moving back to empty works

Test landing with `query=test` `query=` and no `query` query parameter works as expected.