### PR TITLE
persistentStorage/urlutils: update get Function docs and naming, remove duplicate fn

### DIFF
--- a/src/core/utils/urlutils.js
+++ b/src/core/utils/urlutils.js
@@ -141,24 +141,3 @@ export function filterParamsForExperienceLink (
   newParams.delete(StorageKeys.SEARCH_OFFSET);
   return newParams;
 }
-
-/**
- * returns if two SearchParams objects have the same key,value entries
- * @param {SearchParams} params1
- * @param {SearchParams} params2
- * @return {boolean} true if params1 and params2 have the same key,value entries, false otherwise
- */
-export function equivalentParams (params1, params2) {
-  const entries1 = Array.from(params1.entries());
-  const entries2 = Array.from(params2.entries());
-
-  if (entries1.length !== entries2.length) {
-    return false;
-  }
-  for (const [key, val] of params1.entries()) {
-    if (val !== params2.get(key)) {
-      return false;
-    }
-  }
-  return true;
-}

--- a/src/ui/storage/persistentstorage.js
+++ b/src/ui/storage/persistentstorage.js
@@ -110,8 +110,9 @@ export default class PersistentStorage {
 
   /**
    * Get a value for a given key in storage
+   * @param {string} key The unique key to get value for
    */
-  get (query) {
-    return this._params.get(query);
+  get (key) {
+    return this._params.get(key);
   }
 }


### PR DESCRIPTION
Update the get function parameter to match the other functions in persistentStorage.
Remove the duplicate fn definition for equivalentParams.

J=SLAP-529
TEST=auto

npm run test