### PR TITLE
alternativeverticals: update universal URL on context change (#1018)

### DIFF
--- a/src/ui/components/results/alternativeverticalscomponent.js
+++ b/src/ui/components/results/alternativeverticalscomponent.js
@@ -47,10 +47,19 @@ export default class AlternativeVerticalsComponent extends Component {
     );
 
     /**
-     * The url to the universal page to link back to with current query
+     * The url to the universal page to link back to without query params
      * @type {string|null}
      */
-    this._universalUrl = opts.universalUrl || '';
+    this._baseUniversalUrl = opts.baseUniversalUrl || '';
+
+    /**
+     * The url to the universal page to link back to with current query params
+     * @type {string|null}
+     */
+    this._universalUrl = this._getUniversalURL(
+      this._baseUniversalUrl,
+      new SearchParams(window.location.search.substring(1))
+    );
 
     /**
      * Whether or not results are displaying, used to control language in the info box
@@ -64,6 +73,10 @@ export default class AlternativeVerticalsComponent extends Component {
         this._verticalsConfig,
         this.core.globalStorage.getState(StorageKeys.API_CONTEXT),
         this.core.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL)
+      );
+      this._universalUrl = this._getUniversalURL(
+        this._baseUniversalUrl,
+        new SearchParams(window.location.search.substring(1))
       );
       this.setState(this.core.globalStorage.getState(StorageKeys.ALERNATIVE_VERTICALS));
     });
@@ -149,5 +162,37 @@ export default class AlternativeVerticalsComponent extends Component {
     }
 
     return verticals;
+  }
+
+  /**
+   * Adds parameters that are dynamically set. Removes parameters for facets,
+   * filters, and pagination, which should not persist across the experience.
+   * @param {string} baseUrl The url append the appropriate params to. Note:
+   *                         params already on the baseUrl will be stripped
+   * @param {SearchParams} params The parameters to include in the experience URL
+   * @return {string} The formatted experience URL with appropriate query params
+   */
+  _getUniversalURL (baseUrl, params) {
+    if (!baseUrl) {
+      return '';
+    }
+
+    params.set(StorageKeys.QUERY, this.core.globalStorage.getState(StorageKeys.QUERY));
+
+    const context = this.core.globalStorage.getState(StorageKeys.API_CONTEXT);
+    if (context) {
+      params.set(StorageKeys.API_CONTEXT, context);
+    }
+    const referrerPageUrl = this.core.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL);
+    if (referrerPageUrl !== null) {
+      params.set(StorageKeys.REFERRER_PAGE_URL, referrerPageUrl);
+    }
+
+    const filteredParams = filterParamsForExperienceLink(
+      params,
+      types => this.componentManager.getComponentNamesForComponentTypes(types)
+    );
+
+    return replaceUrlParams(baseUrl, filteredParams);
   }
 }

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -233,13 +233,18 @@ export default class VerticalResultsComponent extends Component {
     return true;
   }
 
-  getUniversalUrl () {
+  getBaseUniversalUrl () {
     const universalConfig = this._verticalsConfig.find(config => !config.verticalKey) || {};
-    if (!universalConfig.url) {
+    return universalConfig.url;
+  }
+
+  getUniversalUrl () {
+    const baseUniversalUrl = this.getBaseUniversalUrl();
+    if (!baseUniversalUrl) {
       return undefined;
     }
     return this._getExperienceURL(
-      universalConfig.url,
+      baseUniversalUrl,
       new SearchParams(window.location.search.substring(1))
     );
   }
@@ -376,7 +381,7 @@ export default class VerticalResultsComponent extends Component {
       data = this.core.globalStorage.getState(StorageKeys.ALTERNATIVE_VERTICALS);
       const newOpts = {
         template: this._noResultsTemplate,
-        universalUrl: this.getUniversalUrl(),
+        baseUniversalUrl: this.getBaseUniversalUrl(),
         verticalsConfig: this._verticalsConfig,
         isShowingResults: this._displayAllResults && hasResults,
         ...opts


### PR DESCRIPTION
* alternativeverticals: update universal URL on context change

ANSWERS.setContext should update the experience URLs on the page to
include the context so that it persists throughout the experience. This
was done for the vertical suggestions in the Alternative Verticals
component but not for the universal link. Update this link as well.

Implementation detail: Because the universal URL was previously passed
in from the Vertical Results (parent of Alternative Verticals), we
instead pass in the base universal URL to the AV component and calculate
the query params dynamically every time the context is changed.

Nothing is meant to change with the universal URL behavior except for adding
context when the context is changed.

J=SLAP-529
TEST=manual

On a local Jambo site and a local site using the SDK directly, check to
see that the a call to `ANSWERS.setContext({'state': 'hi'})` adds the
context query parameter to the links in the Alternative Verticals
universal link, "view results across all search categories", by default.

* Fix multiline jsdoc comment