### PR TITLE
Version 1.5.3

### DIFF
--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -160,7 +160,12 @@ class Answers {
     const globalStorage = new GlobalStorage();
     const persistentStorage = new PersistentStorage({
       updateListener: parsedConfig.onStateChange,
-      resetListener: data => globalStorage.setAll(data)
+      resetListener: data => {
+        if (!data[StorageKeys.QUERY]) {
+          this.core.clearResults();
+        }
+        globalStorage.setAll(data);
+      }
     });
     globalStorage.setAll(persistentStorage.getAll());
     globalStorage.set(StorageKeys.SEARCH_CONFIG, parsedConfig.search);

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -2,10 +2,16 @@
 
 import SearchDataTransformer from './search/searchdatatransformer';
 
-import StorageKeys from './storage/storagekeys';
 import VerticalResults from './models/verticalresults';
 import UniversalResults from './models/universalresults';
 import QuestionSubmission from './models/questionsubmission';
+import SearchIntents from './models/searchintents';
+import Navigation from './models/navigation';
+import AlternativeVerticals from './models/alternativeverticals';
+import DirectAnswer from './models/directanswer';
+import LocationBias from './models/locationbias';
+
+import StorageKeys from './storage/storagekeys';
 import AnalyticsEvent from './analytics/analyticsevent';
 import FilterRegistry from './filters/filterregistry';
 
@@ -224,6 +230,22 @@ export default class Core {
           this._analyticsReporter.report(AnalyticsEvent.fromData(analyticsEvent));
         }
       });
+  }
+
+  clearResults () {
+    this.globalStorage.set(StorageKeys.QUERY, null);
+    this.globalStorage.set(StorageKeys.QUERY_ID, '');
+    this.globalStorage.set(StorageKeys.RESULTS_HEADER, {});
+    this.globalStorage.set(StorageKeys.SPELL_CHECK, {}); // TODO has a model but not cleared w new
+    this.globalStorage.set(StorageKeys.DYNAMIC_FILTERS, {}); // TODO has a model but not cleared w new
+    this.globalStorage.set(StorageKeys.QUESTION_SUBMISSION, new QuestionSubmission({}));
+    this.globalStorage.set(StorageKeys.INTENTS, new SearchIntents({}));
+    this.globalStorage.set(StorageKeys.NAVIGATION, new Navigation());
+    this.globalStorage.set(StorageKeys.ALTERNATIVE_VERTICALS, new AlternativeVerticals({}));
+    this.globalStorage.set(StorageKeys.DIRECT_ANSWER, new DirectAnswer({}));
+    this.globalStorage.set(StorageKeys.LOCATION_BIAS, new LocationBias({}));
+    this.globalStorage.set(StorageKeys.VERTICAL_RESULTS, new VerticalResults({}));
+    this.globalStorage.set(StorageKeys.UNIVERSAL_RESULTS, new UniversalResults({}));
   }
 
   /**

--- a/src/core/storage/globalstorage.js
+++ b/src/core/storage/globalstorage.js
@@ -49,7 +49,7 @@ export default class GlobalStorage {
     if (key === undefined || key === null || typeof key !== 'string') {
       throw new AnswersStorageError('Invalid storage key provided', key, data);
     }
-    if (data === undefined || data === null) {
+    if (data === undefined) {
       throw new AnswersStorageError('No data provided', key, data);
     }
 

--- a/src/core/storage/moduledata.js
+++ b/src/core/storage/moduledata.js
@@ -26,7 +26,11 @@ export default class ModuleData extends EventEmitter {
   set (data) {
     this.capturePrevious();
 
-    if (typeof data !== 'object' || Array.isArray(data) || Object.keys(data).length !== Object.keys(this._data).length) {
+    if (data === null ||
+      typeof data !== 'object' ||
+      Array.isArray(data) ||
+      Object.keys(data).length !== Object.keys(this._data).length
+    ) {
       this._data = data;
       this.emit('update', this._data);
       return;

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -659,7 +659,7 @@ export default class FilterOptionsComponent extends Component {
         remove: () => this._clearSingleOption(o)
       }));
 
-    this.core.persistentStorage.set(this.name, this.config.options.filter(o => o.selected).map(o => o.label));
+    this.saveFilterToPersistentStorage();
     const fieldIdToFilterNodes = groupArray(filterNodes, fn => fn.getFilter().getFilterKey());
 
     // OR together filter nodes for the same field id.
@@ -670,5 +670,14 @@ export default class FilterOptionsComponent extends Component {
 
     // AND all of the ORed together nodes.
     return FilterNodeFactory.and(...totalFilterNodes);
+  }
+
+  saveFilterToPersistentStorage () {
+    const replaceHistory = (this.core.persistentStorage.get(this.name) === null);
+    this.core.persistentStorage.set(
+      this.name,
+      this.config.options.filter(o => o.selected).map(o => o.label),
+      replaceHistory
+    );
   }
 }

--- a/src/ui/components/results/alternativeverticalscomponent.js
+++ b/src/ui/components/results/alternativeverticalscomponent.js
@@ -47,10 +47,19 @@ export default class AlternativeVerticalsComponent extends Component {
     );
 
     /**
-     * The url to the universal page to link back to with current query
+     * The url to the universal page to link back to without query params
      * @type {string|null}
      */
-    this._universalUrl = opts.universalUrl || '';
+    this._baseUniversalUrl = opts.baseUniversalUrl || '';
+
+    /**
+     * The url to the universal page to link back to with current query params
+     * @type {string|null}
+     */
+    this._universalUrl = this._getUniversalURL(
+      this._baseUniversalUrl,
+      new SearchParams(window.location.search.substring(1))
+    );
 
     /**
      * Whether or not results are displaying, used to control language in the info box
@@ -64,6 +73,10 @@ export default class AlternativeVerticalsComponent extends Component {
         this._verticalsConfig,
         this.core.globalStorage.getState(StorageKeys.API_CONTEXT),
         this.core.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL)
+      );
+      this._universalUrl = this._getUniversalURL(
+        this._baseUniversalUrl,
+        new SearchParams(window.location.search.substring(1))
       );
       this.setState(this.core.globalStorage.getState(StorageKeys.ALERNATIVE_VERTICALS));
     });
@@ -149,5 +162,37 @@ export default class AlternativeVerticalsComponent extends Component {
     }
 
     return verticals;
+  }
+
+  /**
+   * Adds parameters that are dynamically set. Removes parameters for facets,
+   * filters, and pagination, which should not persist across the experience.
+   * @param {string} baseUrl The url append the appropriate params to. Note:
+   *                         params already on the baseUrl will be stripped
+   * @param {SearchParams} params The parameters to include in the experience URL
+   * @return {string} The formatted experience URL with appropriate query params
+   */
+  _getUniversalURL (baseUrl, params) {
+    if (!baseUrl) {
+      return '';
+    }
+
+    params.set(StorageKeys.QUERY, this.core.globalStorage.getState(StorageKeys.QUERY));
+
+    const context = this.core.globalStorage.getState(StorageKeys.API_CONTEXT);
+    if (context) {
+      params.set(StorageKeys.API_CONTEXT, context);
+    }
+    const referrerPageUrl = this.core.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL);
+    if (referrerPageUrl !== null) {
+      params.set(StorageKeys.REFERRER_PAGE_URL, referrerPageUrl);
+    }
+
+    const filteredParams = filterParamsForExperienceLink(
+      params,
+      types => this.componentManager.getComponentNamesForComponentTypes(types)
+    );
+
+    return replaceUrlParams(baseUrl, filteredParams);
   }
 }

--- a/src/ui/components/results/universalresultscomponent.js
+++ b/src/ui/components/results/universalresultscomponent.js
@@ -41,13 +41,14 @@ export default class UniversalResultsComponent extends Component {
 
   setState (data, val) {
     const sections = data.sections || [];
+    const query = this.core.globalStorage.getState(StorageKeys.QUERY);
     const searchState = data.searchState || SearchStates.PRE_SEARCH;
     return super.setState(Object.assign(data, {
       isPreSearch: searchState === SearchStates.PRE_SEARCH,
       isSearchLoading: searchState === SearchStates.SEARCH_LOADING,
       isSearchComplete: searchState === SearchStates.SEARCH_COMPLETE,
-      showNoResults: sections.length === 0,
-      query: this.core.globalStorage.getState(StorageKeys.QUERY),
+      showNoResults: sections.length === 0 && query,
+      query: query,
       sections: sections
     }, val));
   }

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -233,13 +233,18 @@ export default class VerticalResultsComponent extends Component {
     return true;
   }
 
-  getUniversalUrl () {
+  getBaseUniversalUrl () {
     const universalConfig = this._verticalsConfig.find(config => !config.verticalKey) || {};
-    if (!universalConfig.url) {
+    return universalConfig.url;
+  }
+
+  getUniversalUrl () {
+    const baseUniversalUrl = this.getBaseUniversalUrl();
+    if (!baseUniversalUrl) {
       return undefined;
     }
     return this._getExperienceURL(
-      universalConfig.url,
+      baseUniversalUrl,
       new SearchParams(window.location.search.substring(1))
     );
   }
@@ -376,7 +381,7 @@ export default class VerticalResultsComponent extends Component {
       data = this.core.globalStorage.getState(StorageKeys.ALTERNATIVE_VERTICALS);
       const newOpts = {
         template: this._noResultsTemplate,
-        universalUrl: this.getUniversalUrl(),
+        baseUniversalUrl: this.getBaseUniversalUrl(),
         verticalsConfig: this._verticalsConfig,
         isShowingResults: this._displayAllResults && hasResults,
         ...opts

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -128,6 +128,16 @@ export default class SearchComponent extends Component {
     this._isTwin = config.isTwin;
 
     /**
+     * The search config from ANSWERS.init configuration
+     */
+    this._globalSearchConfig = this.core.globalStorage.getState(StorageKeys.SEARCH_CONFIG) || {};
+
+    /**
+     * The default initial search query, can be an empty string
+     */
+    this._defaultInitialSearch = this._globalSearchConfig.defaultInitialSearch;
+
+    /**
      * The query string to use for the input box, provided to template for rendering.
      * Optionally provided
      * @type {string|null}
@@ -137,6 +147,12 @@ export default class SearchComponent extends Component {
       this.query = q;
       if (this.queryEl) {
         this.queryEl.value = q;
+      }
+      if (q === null) {
+        if (this._defaultInitialSearch || this._defaultInitialSearch === '') {
+          this.core.setQuery(this._defaultInitialSearch);
+        }
+        return;
       }
       this.debouncedSearch(q);
     });

--- a/src/ui/storage/persistentstorage.js
+++ b/src/ui/storage/persistentstorage.js
@@ -26,8 +26,8 @@ export default class PersistentStorage {
 
     window.onpopstate = () => {
       this._params = new SearchParams(window.location.search.substring(1));
-      this._callListener(this._updateListener);
-      this._callListener(this._resetListener);
+      this._callListener(this._updateListener, false);
+      this._callListener(this._resetListener, false);
     };
   }
 
@@ -71,16 +71,17 @@ export default class PersistentStorage {
     } else {
       window.history.pushState(null, null, `?${this._params.toString()}`);
     }
-    this._callListener(this._updateListener);
+    this._callListener(this._updateListener, replaceHistory);
   }
 
   /**
    * Invoke the given list of callbacks with the current storage data
    * @param {function[]} listeners The callbacks to invoke
+   * @param {boolean} replaceHistory Whether to replace the history state in the browser
    * @private
    */
-  _callListener (listener) {
-    listener(this.getAll(), this._params.toString());
+  _callListener (listener, replaceHistory) {
+    listener(this.getAll(), this._params.toString(), replaceHistory);
   }
 
   /**

--- a/src/ui/storage/persistentstorage.js
+++ b/src/ui/storage/persistentstorage.js
@@ -96,8 +96,9 @@ export default class PersistentStorage {
 
   /**
    * Get a value for a given key in storage
+   * @param {string} key The unique key to get value for
    */
-  get (query) {
-    return this._params.get(query);
+  get (key) {
+    return this._params.get(key);
   }
 }

--- a/src/ui/storage/persistentstorage.js
+++ b/src/ui/storage/persistentstorage.js
@@ -93,4 +93,11 @@ export default class PersistentStorage {
     }
     return allParams;
   }
+
+  /**
+   * Get a value for a given key in storage
+   */
+  get (query) {
+    return this._params.get(query);
+  }
 }

--- a/tests/core/storage/persistentstorage.js
+++ b/tests/core/storage/persistentstorage.js
@@ -69,7 +69,7 @@ describe('adding and removing data', () => {
     storage.set('key1', 'val1');
     expect.assertions(1);
     return new Promise(resolve => setTimeout(() => {
-      expect(updateCb).toBeCalledWith({ key1: 'val1' }, 'key1=val1');
+      expect(updateCb).toBeCalledWith({ key1: 'val1' }, 'key1=val1', false);
       resolve();
     }, 200));
   });

--- a/tests/setup/managermocker.js
+++ b/tests/setup/managermocker.js
@@ -30,6 +30,7 @@ export default function mockManager (mockedCore, ...templatePaths) {
     },
     persistentStorage: {
       set: () => {},
+      get: () => {},
       delete: () => {}
     },
     ...mockedCore

--- a/tests/ui/components/filters/filteroptionscomponent.js
+++ b/tests/ui/components/filters/filteroptionscomponent.js
@@ -524,7 +524,8 @@ describe('filter options component', () => {
             delete: () => { }
           },
           persistentStorage: {
-            set: () => { }
+            set: () => { },
+            get: () => { }
           },
           setLocationRadiusFilterNode,
           setStaticFilterNodes


### PR DESCRIPTION
## Changes
* facets/filteroptions: replace state for facets on page load (#1020). When loading a page with facets, a browser history state is no longer pushed for every facet. A history state is only pushed on a change to the facets. This solved a bug where users would get "stuck" after entering a page with facets.
* search: respect back navigation with empty search (#1022). When a user navigates back in browser history to a page without a query, the original state is preserved. That is, the results are hidden and no query is conducted.
* alternativeverticals: update universal URL on context change (#1025). When a user calls `ANSWERS.setContext`, the universal results link in the AlternativeVerticals component (No Results) is updated to reflected the new context.
* persistentstorage: Add replaceHistory as onStateChange param (#1027). To support implementations hoping to recreate SDK query param behavior, we add replaceHistory information to the onStateChange listener params.