### PR TITLE
persistentstorage: Add replaceHistory as onStateChange param

### DIFF
--- a/src/ui/storage/persistentstorage.js
+++ b/src/ui/storage/persistentstorage.js
@@ -26,8 +26,8 @@ export default class PersistentStorage {
 
     window.onpopstate = () => {
       this._params = new SearchParams(window.location.search.substring(1));
-      this._callListener(this._updateListener);
-      this._callListener(this._resetListener);
+      this._callListener(this._updateListener, false);
+      this._callListener(this._resetListener, false);
     };
   }
 
@@ -71,16 +71,17 @@ export default class PersistentStorage {
     } else {
       window.history.pushState(null, null, `?${this._params.toString()}`);
     }
-    this._callListener(this._updateListener);
+    this._callListener(this._updateListener, replaceHistory);
   }
 
   /**
    * Invoke the given list of callbacks with the current storage data
    * @param {function[]} listeners The callbacks to invoke
+   * @param {boolean} replaceHistory Whether to replace the history state in the browser
    * @private
    */
-  _callListener (listener) {
-    listener(this.getAll(), this._params.toString());
+  _callListener (listener, replaceHistory) {
+    listener(this.getAll(), this._params.toString(), replaceHistory);
   }
 
   /**

--- a/tests/core/storage/persistentstorage.js
+++ b/tests/core/storage/persistentstorage.js
@@ -69,7 +69,7 @@ describe('adding and removing data', () => {
     storage.set('key1', 'val1');
     expect.assertions(1);
     return new Promise(resolve => setTimeout(() => {
-      expect(updateCb).toBeCalledWith({ key1: 'val1' }, 'key1=val1');
+      expect(updateCb).toBeCalledWith({ key1: 'val1' }, 'key1=val1', false);
       resolve();
     }, 200));
   });


### PR DESCRIPTION
replaceHistory is passed to the onStateChange as a way to provide the
most information about how the state is changing to any listeners.
Previously, only params was passed but this did not allow listeners to
know when the history state was replaced or pushed. This is especially
important for iframe implementations. When iframes try to mock the
SDK query parameter behavior, they must know to replace the history
state with the new parameters or to push state.

This fixes a specific bug where, because replaceHistory was never sent,
a listener defaulted to always pushing state. This causes an infinite loop
as we add query params on page load for a vertical with facets. Thus,
it is impossible to leave a page with facets through the back navigation.

J=SLAP-573
TEST=manual

Test on a local Jambo site that the new replaceHistory parameter is
present onStageChange.

Test on a local html file referencing a local SDK that the new
onStateChange does not interfere with sites not using onStateChange.