### PR TITLE
handlebarsrenderer: add runtimeTranslation helper

### DIFF
--- a/src/ui/rendering/handlebarsrenderer.js
+++ b/src/ui/rendering/handlebarsrenderer.js
@@ -3,6 +3,7 @@
 import Renderer from './renderer';
 import Icons from '../icons';
 import HighlightedValue from '../../core/models/highlightedvalue';
+import translateJS from '../../core/i18n/translateJS';
 
 /**
  * HandlebarsRenderer is a wrapper around the nativate handlebars renderer.
@@ -194,14 +195,7 @@ export default class HandlebarsRenderer extends Renderer {
 
     this.registerHelper('runtimeTranslation', function (options) {
       let { phrase, count } = options.hash;
-      try {
-        const pluralForms = JSON.parse(phrase);
-        phrase = count > 1 ? pluralForms['plural'] : pluralForms['1'];
-      } catch (e) {}
-      const interpolationRegex = /\{\{([a-zA-Z0-9]+)\}\}/g;
-      return phrase.replace(interpolationRegex, (match, interpolationName) => {
-        return options.hash[interpolationName];
-      });
+      return translateJS(phrase, options.hash, count);
     });
 
     let self = this;

--- a/src/ui/rendering/handlebarsrenderer.js
+++ b/src/ui/rendering/handlebarsrenderer.js
@@ -199,10 +199,9 @@ export default class HandlebarsRenderer extends Renderer {
         phrase = count > 1 ? pluralForms['plural'] : pluralForms['1'];
       } catch (e) {}
       const interpolationRegex = /\{\{([a-zA-Z0-9]+)\}\}/g;
-      phrase = phrase.replace(interpolationRegex, (match, interpolationName) => {
+      return phrase.replace(interpolationRegex, (match, interpolationName) => {
         return options.hash[interpolationName];
       });
-      return phrase;
     });
 
     let self = this;

--- a/src/ui/rendering/handlebarsrenderer.js
+++ b/src/ui/rendering/handlebarsrenderer.js
@@ -66,6 +66,7 @@ export default class HandlebarsRenderer extends Renderer {
    * compile a handlebars template so that it can be rendered,
    * using the {Handlebars} compiler
    * @param {string} template The template string to compile
+   * @returns {Function}
    */
   compile (template) {
     if (typeof template !== 'string') {
@@ -189,6 +190,19 @@ export default class HandlebarsRenderer extends Renderer {
       return number === 1
         ? singularText
         : pluralText;
+    });
+
+    this.registerHelper('runtimeTranslation', function (options) {
+      let { phrase, count } = options.hash;
+      try {
+        const pluralForms = JSON.parse(phrase);
+        phrase = count > 1 ? pluralForms['plural'] : pluralForms['1'];
+      } catch (e) {}
+      const interpolationRegex = /\{\{([a-zA-Z0-9]+)\}\}/g;
+      phrase = phrase.replace(interpolationRegex, (match, interpolationName) => {
+        return options.hash[interpolationName];
+      });
+      return phrase;
     });
 
     let self = this;

--- a/tests/ui/rendering/handlebarsrenderer.js
+++ b/tests/ui/rendering/handlebarsrenderer.js
@@ -1,0 +1,63 @@
+import HandlebarsRenderer from '../../../src/ui/rendering/handlebarsrenderer';
+import Handlebars from 'handlebars';
+
+describe('the handlebars runtimeTranslation helper', () => {
+  const renderer = new HandlebarsRenderer();
+  renderer.init({
+    '_hb': Handlebars
+  });
+
+  it('can translate a string phrase', () => {
+    const template = `{{runtimeTranslation
+      phrase='Hello my name is {{firstName}} {{lastName}}'
+      firstName=myFirstName
+      lastName=myLastName
+    }}`;
+    const data = {
+      myFirstName: 'Cat',
+      myLastName: 'Lady'
+    };
+    const translation = renderer.compile(template)(data);
+    expect(translation).toEqual('Hello my name is Cat Lady');
+  });
+
+  describe('when translating plural phrase', () => {
+    const template = `{{runtimeTranslation
+      phrase='{
+        "1":"a {{size}} {{color}} cow tried to make a {{food}}",
+        "plural":"{{count}} {{size}} {{color}} cows tried to make a {{food}}"
+      }'
+      size=mySize
+      color=myColor
+      food=myFood
+      count=myCount
+    }}`;
+    const data = {
+      mySize: 'large',
+      myColor: 'red',
+      myFood: 'pizza',
+      myCount: 1
+    };
+
+    it('works when count = 1', () => {
+      const translation = renderer.compile(template)(data);
+      expect(translation).toEqual('a large red cow tried to make a pizza');
+    });
+
+    it('works when count > 1', () => {
+      const translation = renderer.compile(template)({
+        ...data,
+        myCount: 82
+      });
+      expect(translation).toEqual('82 large red cows tried to make a pizza');
+    });
+
+    it('works when count is a string', () => {
+      const translation = renderer.compile(template)({
+        ...data,
+        myCount: '82'
+      });
+      expect(translation).toEqual('82 large red cows tried to make a pizza');
+    });
+  });
+});


### PR DESCRIPTION
this commit adds the runtimeTranslation helper to the handlebars
renderer. this is a simple helper that combines the passed in
translation phrase, which contains the phrase to be translated as
either an object containing the phrases plural forms or just a string,
with interpolated values.

J=SLAP-558
TEST=auto

Added unit tests for handlebarsrenderer