### PR TITLE
Add translateJS helper

### DIFF
--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -34,6 +34,7 @@ import RichTextFormatter from './core/utils/richtextformatter';
 import { isValidContext } from './core/utils/apicontext';
 import FilterNodeFactory from './core/filters/filternodefactory';
 import { urlWithoutQueryParamsAndHash } from './core/utils/urlutils';
+import translateJS from './core/i18n/translateJS';
 
 /** @typedef {import('./core/services/searchservice').default} SearchService */
 /** @typedef {import('./core/services/autocompleteservice').default} AutoCompleteService */
@@ -104,6 +105,11 @@ class Answers {
      * @type {Core}
      */
     this.core = null;
+
+    /**
+     * A local reference to translateJS
+     */
+    this.translateJS = translateJS;
 
     /**
      * A callback function to invoke once the library is ready.

--- a/src/core/i18n/translateJS.js
+++ b/src/core/i18n/translateJS.js
@@ -3,7 +3,7 @@
  * interpolation, pluralization, or both
  * @param {string} translations The translations, or a stringified JSON of possible translations
  * @param {Object} interpolationParams Params to use during interpolation
- * @param {number} The count associated with the pluralization
+ * @param {number} count The count associated with the pluralization
  */
 export default function translateJS (translations, interpolationParams, count) {
   let stringToInterpolate;

--- a/src/core/i18n/translateJS.js
+++ b/src/core/i18n/translateJS.js
@@ -17,9 +17,7 @@ export default function translateJS (translations, interpolationParams, count) {
 
   const interpolationRegex = new RegExp(/\{\{([a-zA-Z0-9]+)\}\}/, 'g');
 
-  const finalTranslation = stringToInterpolate.replace(interpolationRegex, (match, interpolationKey) => {
+  return stringToInterpolate.replace(interpolationRegex, (match, interpolationKey) => {
     return interpolationParams[interpolationKey];
   });
-
-  return finalTranslation;
 }

--- a/src/core/i18n/translateJS.js
+++ b/src/core/i18n/translateJS.js
@@ -1,0 +1,25 @@
+/**
+ * Performs a translation at runtime which includes
+ * interpolation, pluralization, or both
+ * @param {string} translations The translations, or a stringified JSON of possible translations
+ * @param {Object} interpolationParams Params to use during interpolation
+ * @param {count} The count associated with the pluralization
+ */
+export default function translateJS (translations, interpolationParams, count) {
+  let stringToInterpolate;
+
+  try {
+    translations = JSON.parse(translations);
+    stringToInterpolate = count > 1 ? translations['plural'] : translations['1'];
+  } catch (e) {
+    stringToInterpolate = translations;
+  }
+
+  const interpolationRegex = new RegExp(/\{\{([a-zA-Z0-9]+)\}\}/, 'g');
+
+  const finalTranslation = stringToInterpolate.replace(interpolationRegex, (match, interpolationKey) => {
+    return interpolationParams[interpolationKey];
+  });
+
+  return finalTranslation;
+}

--- a/src/core/i18n/translateJS.js
+++ b/src/core/i18n/translateJS.js
@@ -3,7 +3,7 @@
  * interpolation, pluralization, or both
  * @param {string} translations The translations, or a stringified JSON of possible translations
  * @param {Object} interpolationParams Params to use during interpolation
- * @param {count} The count associated with the pluralization
+ * @param {number} The count associated with the pluralization
  */
 export default function translateJS (translations, interpolationParams, count) {
   let stringToInterpolate;

--- a/tests/core/i18n/translateJS.js
+++ b/tests/core/i18n/translateJS.js
@@ -1,0 +1,33 @@
+import translateJS from '../../../src/core/i18n/translateJS';
+
+describe('translateJS usage', () => {
+  it('simple interpolation', () => {
+    const translation = translateJS('Mail maintenant {{id1}}', { id1: 'Connor' });
+    expect(translation).toEqual('Mail maintenant Connor');
+  });
+
+  it('interpolation with multiple interpolation values', () => {
+    const translation = translateJS('Mail maintenant {{id1}} et {{id2}}', { id1: 'Connor', id2: 'Oliver' });
+    expect(translation).toEqual('Mail maintenant Connor et Oliver');
+  });
+
+  it('simple pluralization with singular count', () => {
+    const translation = translateJS('{"1":"fleur","plural":"fleurs"}', {}, 1);
+    expect(translation).toEqual('fleur');
+  });
+
+  it('simple pluralization with plural count', () => {
+    const translation = translateJS('{"1":"fleur","plural":"fleurs"}', {}, 2);
+    expect(translation).toEqual('fleurs');
+  });
+
+  it('pluralization with singular count and interpolation', () => {
+    const translation = translateJS('{"1":"Un article {{name}}","plural":"Les articles {{name}}"}', { name: 'de presse' }, 1);
+    expect(translation).toEqual('Un article de presse');
+  });
+
+  it('pluralization with plural count and interpolation', () => {
+    const translation = translateJS('{"1":"Un article {{name}}","plural":"Les articles {{name}}"}', { name: 'de presse' }, 2);
+    expect(translation).toEqual('Les articles de presse');
+  });
+});


### PR DESCRIPTION
Add a translateJS helper which is can be called from ANSWERS.translateJS(). This helper finalizes translations by performing interpolation, pluralization, or both.

J=SLAP-559
TEST=auto, manual

Added unit tests to test the helper. Also, manually tested ANSWERS.translateJS() in a test answers site.