### PR TITLE
autocomplete: add wcag attributes to hbs

### DIFF
--- a/src/core/models/autocompletedata.js
+++ b/src/core/models/autocompletedata.js
@@ -13,10 +13,14 @@ export default class AutoCompleteData {
     if (response.sections) {
       sections = response.sections.map(s => ({
         label: s.label,
-        results: s.results.map(r => new AutoCompleteResult(r))
+        results: s.results.map(r => new AutoCompleteResult(r)),
+        resultsCount: s.results.length
       }));
     } else {
-      sections = [{ results: response.results.map(r => new AutoCompleteResult(r)) }];
+      sections = [{
+        results: response.results.map(r => new AutoCompleteResult(r)),
+        resultsCount: response.results.length
+      }];
     }
     let inputIntents = response.input ? response.input.queryIntents : [];
     return new AutoCompleteData({

--- a/src/ui/components/search/autocompletecomponent.js
+++ b/src/ui/components/search/autocompletecomponent.js
@@ -108,10 +108,10 @@ export default class AutoCompleteComponent extends Component {
     this._searchParameters = opts.searchParameters || null;
 
     /**
-     * Aria-label for the autocomplete list
+     * HTML id for the aria-labelledby in the autocomplete list
      * @type {string}
      */
-    this._listLabel = 'Conduct a search by entering in a phrase or selecting an option from the autocomplete';
+    this.listLabelIdName = opts.listLabelIdName || 'yxt-SearchBar-listLabel--SearchBar';
   }
 
   /**
@@ -146,8 +146,7 @@ export default class AutoCompleteComponent extends Component {
       sectionIndex: this._sectionIndex,
       resultIndex: this._resultIndex,
       promptHeader: this._originalQuery.length === 0 ? this.promptHeader : null,
-      listLabel: this._listLabel,
-      listLabelIdModifier: this.name.replace('.', '_')
+      listLabelIdName: this.listLabelIdName
     }));
   }
 

--- a/src/ui/components/search/autocompletecomponent.js
+++ b/src/ui/components/search/autocompletecomponent.js
@@ -106,6 +106,12 @@ export default class AutoCompleteComponent extends Component {
     this._onChange = opts.onChange || function () {};
 
     this._searchParameters = opts.searchParameters || null;
+
+    /**
+     * Aria-label for the autocomplete list
+     * @type {string}
+     */
+    this._listLabel = 'Conduct a search by entering in a phrase or selecting an option from the autocomplete';
   }
 
   /**
@@ -139,7 +145,9 @@ export default class AutoCompleteComponent extends Component {
       hasResults: this.hasResults(data),
       sectionIndex: this._sectionIndex,
       resultIndex: this._resultIndex,
-      promptHeader: this._originalQuery.length === 0 ? this.promptHeader : null
+      promptHeader: this._originalQuery.length === 0 ? this.promptHeader : null,
+      listLabel: this._listLabel,
+      listLabelIdModifier: this.name.replace('.', '_')
     }));
   }
 

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -644,7 +644,8 @@ export default class SearchComponent extends Component {
       forwardIconOpts: forwardIconOpts,
       reverseIconOpts: reverseIconOpts,
       autoFocus: this.autoFocus && !this.query,
-      useForm: this._useForm
+      useForm: this._useForm,
+      autocompleteContainerIdModifier: this.name
     }, data));
   }
 

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -197,6 +197,24 @@ export default class SearchComponent extends Component {
       message: 'We are unable to determine your location',
       ...config.geolocationTimeoutAlert
     };
+
+    /**
+     * The unique HTML id name for the autocomplete container
+     * @type {string}
+     */
+    this.autocompleteContainerIdName = `yxt-SearchBar-autocomplete--${this.name}`;
+
+    /**
+     * The unique HTML id name for the search input label
+     * @type {string}
+     */
+    this.inputLabelIdName = `yxt-SearchBar-inputLabel--${this.name}`;
+
+    /**
+     * The unique HTML id name for the search input
+     * @type {string}
+     */
+    this.inputIdName = `yxt-SearchBar-inputLabel--${this.name}`;
   }
 
   static get type () {
@@ -465,6 +483,7 @@ export default class SearchComponent extends Component {
       promptHeader: this.promptHeader,
       originalQuery: this.query,
       inputEl: inputSelector,
+      listLabelIdName: this.inputLabelIdName,
       onSubmit: () => {
         if (this._useForm) {
           DOM.trigger(DOM.query(this._container, this._formEl), 'submit');
@@ -633,7 +652,9 @@ export default class SearchComponent extends Component {
     };
     return super.setState(Object.assign({
       title: this.title,
+      inputIdName: this.inputIdName,
       labelText: this.labelText,
+      inputLabelIdName: this.inputLabelIdName,
       submitIcon: this.submitIcon,
       submitText: this.submitText,
       clearText: this.clearText,
@@ -645,7 +666,7 @@ export default class SearchComponent extends Component {
       reverseIconOpts: reverseIconOpts,
       autoFocus: this.autoFocus && !this.query,
       useForm: this._useForm,
-      autocompleteContainerIdModifier: this.name
+      autocompleteContainerIdName: this.autocompleteContainerIdName
     }, data));
   }
 

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -214,7 +214,7 @@ export default class SearchComponent extends Component {
      * The unique HTML id name for the search input
      * @type {string}
      */
-    this.inputIdName = `yxt-SearchBar-inputLabel--${this.name}`;
+    this.inputIdName = `yxt-SearchBar-input--${this.name}`;
   }
 
   static get type () {

--- a/src/ui/templates/search/autocomplete.hbs
+++ b/src/ui/templates/search/autocomplete.hbs
@@ -17,7 +17,7 @@
       </span>
       <ul role="listbox"
           class="yxt-AutoComplete-results"
-          aria-labelledby="yxt-AutoComplete-listLabel--{{listLabelClassModifier}}"
+          aria-labelledby="yxt-AutoComplete-listLabel--{{../listLabelIdModifier}}"
       >
       {{#if label}}
         <li class="yxt-AutoComplete-resultHeader">{{label}}</li>

--- a/src/ui/templates/search/autocomplete.hbs
+++ b/src/ui/templates/search/autocomplete.hbs
@@ -8,8 +8,17 @@
         </li>
       </ul>
     {{/if}}
+    <label class="sr-only" id="yxt-AutoComplete-listLabel--{{listLabelIdModifier}}">
+      {{listLabel}}
+    </label>
     {{#each sections}}
-      <ul class="yxt-AutoComplete-results">
+      <span class="yxt-AutoComplete-resultsCount sr-only" aria-live="assertive">
+        {{resultsCount}} results found
+      </span>
+      <ul role="listbox"
+          class="yxt-AutoComplete-results"
+          aria-labelledby="yxt-AutoComplete-listLabel--{{listLabelClassModifier}}"
+      >
       {{#if label}}
         <li class="yxt-AutoComplete-resultHeader">{{label}}</li>
       {{/if}}
@@ -21,6 +30,7 @@
             data-filter='{{json filter}}'
             data-eventtype="AUTO_COMPLETE_SELECTION"
             data-eventoptions='{"suggestedSearchText": "{{value}}"}'
+            role="option"
         >
             {{highlightValue this true}}
         </li>

--- a/src/ui/templates/search/autocomplete.hbs
+++ b/src/ui/templates/search/autocomplete.hbs
@@ -8,16 +8,13 @@
         </li>
       </ul>
     {{/if}}
-    <label class="sr-only" id="yxt-AutoComplete-listLabel--{{listLabelIdModifier}}">
-      {{listLabel}}
-    </label>
     {{#each sections}}
       <span class="yxt-AutoComplete-resultsCount sr-only" aria-live="assertive">
         {{resultsCount}} results found
       </span>
       <ul role="listbox"
           class="yxt-AutoComplete-results"
-          aria-labelledby="yxt-AutoComplete-listLabel--{{../listLabelIdModifier}}"
+          aria-labelledby="{{../listLabelIdName}}"
       >
       {{#if label}}
         <li class="yxt-AutoComplete-resultHeader">{{label}}</li>

--- a/src/ui/templates/search/search.hbs
+++ b/src/ui/templates/search/search.hbs
@@ -14,7 +14,7 @@
         {{> inputAndButtons}}
       </div>
     {{/if}}
-    <div class="yxt-SearchBar-autocomplete yxt-AutoComplete-wrapper js-yxt-AutoComplete-wrapper"></div>
+    <div id="yxt-SearchBar-autocomplete--{{autocompleteContainerIdModifier}}" class="yxt-SearchBar-autocomplete yxt-AutoComplete-wrapper js-yxt-AutoComplete-wrapper"></div>
   </div>
 </div>
 
@@ -24,7 +24,11 @@
           name="query"
           value="{{query}}"
           {{#if _config.placeholderText}}placeholder="{{_config.placeholderText}}"{{/if}}
-          aria-label="{{labelText}}">
+          aria-label="{{labelText}}"
+          aria-autocomplete="list"
+          aria-controls="yxt-SearchBar-autocomplete--{{autocompleteContainerIdModifier}}"
+          aria-haspopup="listbox"
+  >
   <button type="button"
           class="js-yxt-SearchBar-clear yxt-SearchBar-clear yxt-SearchBar--hidden"
           data-eventtype="SEARCH_CLEAR_BUTTON"

--- a/src/ui/templates/search/search.hbs
+++ b/src/ui/templates/search/search.hbs
@@ -14,19 +14,26 @@
         {{> inputAndButtons}}
       </div>
     {{/if}}
-    <div id="yxt-SearchBar-autocomplete--{{autocompleteContainerIdModifier}}" class="yxt-SearchBar-autocomplete yxt-AutoComplete-wrapper js-yxt-AutoComplete-wrapper"></div>
+    <div id="{{autocompleteContainerIdName}}" class="yxt-SearchBar-autocomplete yxt-AutoComplete-wrapper js-yxt-AutoComplete-wrapper"></div>
   </div>
 </div>
 
 {{#*inline "inputAndButtons"}}
+  <label class="sr-only" 
+         for="{{inputIdName}}"
+         id="{{inputLabelIdName}}"
+  >
+    {{labelText}}
+  </label>
   <input class="js-yext-query yxt-SearchBar-input"
+          id="{{inputIdName}}"
           type="text"
           name="query"
           value="{{query}}"
           {{#if _config.placeholderText}}placeholder="{{_config.placeholderText}}"{{/if}}
           aria-label="{{labelText}}"
           aria-autocomplete="list"
-          aria-controls="yxt-SearchBar-autocomplete--{{autocompleteContainerIdModifier}}"
+          aria-controls="{{autocompleteContainerIdName}}"
           aria-haspopup="listbox"
   >
   <button type="button"


### PR DESCRIPTION
For the autocomplete list, we add a variety of labels and roles to
better support screen reader identification.

We add a results count to the autocomplete with an aria-live="assertive"
so this attribute is called as updates are given.

J=SLAP-537
TEST=manual

Test on a local Jambo HH Theme repository with one searchbar.