### PR TITLE
Create a BundleTaskFactory class that provides Gulp tasks for differe…

### DIFF
--- a/conf/gulp-tasks/bundle/bundletaskfactory.js
+++ b/conf/gulp-tasks/bundle/bundletaskfactory.js
@@ -1,0 +1,169 @@
+const fs = require('fs');
+
+const { dest } = require('gulp');
+
+const rollup = require('gulp-rollup-lightweight');
+const babel = require('rollup-plugin-babel');
+const resolve = require('rollup-plugin-node-resolve');
+const commonjs = require('rollup-plugin-commonjs');
+const insert = require('rollup-plugin-insert');
+
+const source = require('vinyl-source-stream');
+const replace = require('gulp-replace');
+
+// An enum describing the different types of SDK bundle.
+const BundleType = {
+  MODERN: 'modern',
+  LEGACY_IIFE: 'legacy-iife',
+  LEGACY_UMD: 'legacy-umd'
+};
+Object.freeze(BundleType);
+
+/**
+ * A factory class that provides Gulp tasks for the different kinds of SDK bundle.
+ */
+class BundleTaskFactory {
+  constructor (libVersion) {
+    this._libVersion = libVersion;
+    this._namespace = 'ANSWERS';
+  }
+
+  /**
+   * Provides a Gulp task to create an SDK bundle of the specified type.
+   *
+   * @param {BundleType} bundleType The type of SDK bundle to build.
+   * @returns {Function} Gulp task for producing the requested SDK bundle.
+   */
+  create (bundleType) {
+    switch (bundleType) {
+      case BundleType.MODERN:
+        return () => this._modernBundle();
+      case BundleType.LEGACY_IIFE:
+        return () => this._legacyBundleIIFE();
+      case BundleType.LEGACY_UMD:
+        return () => this._legacyBundleUMD();
+      default:
+        throw new Error('Unrecognized BundleType');
+    }
+  }
+
+  /**
+   * The Gulp task for producing the modern version of the SDK bundle.
+   *
+   * @returns {stream.Writable} A {@link Writable} stream containing the modern
+   *                            SDK bundle.
+   */
+  _modernBundle () {
+    const rollupConfig = {
+      input: './src/answers-umd.js',
+      output: {
+        format: 'umd',
+        name: this._namespace,
+        exports: 'default',
+        sourcemap: true
+      },
+      plugins: [
+        resolve(),
+        commonjs({
+          include: './node_modules/**'
+        }),
+        babel({
+          babelrc: false,
+          exclude: 'node_modules/**',
+          presets: ['@babel/env']
+        })
+      ]
+    };
+    return rollup(rollupConfig)
+      .pipe(source('answers-modern.js'))
+      .pipe(replace('@@LIB_VERSION', this._libVersion))
+      .pipe(dest('dist'));
+  }
+
+  /**
+   * The Gulp task for producing the legacy, IIFE-style SDK bundle.
+   *
+   * @returns {stream.Writable} A {@link Writable} stream containing the legacy,
+   *                            IIFE-style SDK bundle.
+   */
+  _legacyBundleIIFE () {
+    const legacyBundleConfig = {
+      format: 'iife',
+      name: this._namespace,
+      sourcemap: true
+    };
+    return this._legacyBundle(legacyBundleConfig, 'answers.js');
+  }
+
+  /**
+   * The Gulp task for producing the legacy, UMD-style SDK bundle.
+   *
+   * @returns {stream.Writable} A {@link Writable} stream containing the legacy,
+   *                            UMD-style SDK bundle.
+   */
+  _legacyBundleUMD () {
+    const legacyBundleConfig = {
+      format: 'umd',
+      name: this._namespace,
+      export: 'default',
+      sourcemap: true
+    };
+    return this._legacyBundle(legacyBundleConfig, 'answers-umd.js');
+  }
+
+  /**
+   * The Gulp task for producing either variant of the legacy SDK bundle.
+   *
+   * @param {Object<string, ?>} outputConfig Any variant-specific configuration
+   *                                         for the legacy bundle.
+   * @param {string} fileName The filename of the created bundle.
+   * @returns {stream.Writable} A {@link Writable} stream cotaining the legacy
+   *                            SDK bundle.
+   */
+  _legacyBundle (outputConfig, fileName) {
+    const rollupConfig = {
+      input: './src/answers-umd.js',
+      output: outputConfig,
+      plugins: [
+        resolve(),
+        insert.prepend(
+          fs.readFileSync('./conf/gulp-tasks/polyfill-prefix.js').toString(),
+          {
+            include: './src/answers-umd.js'
+          }),
+        commonjs({
+          include: './node_modules/**'
+        }),
+        babel({
+          runtimeHelpers: true,
+          babelrc: false,
+          exclude: 'node_modules/**',
+          presets: [
+            [
+              '@babel/preset-env',
+              {
+                loose: true,
+                modules: false
+              }
+            ]
+          ],
+          plugins: [
+            '@babel/syntax-dynamic-import',
+            ['@babel/plugin-transform-runtime', {
+              corejs: 3
+            }],
+            '@babel/plugin-transform-arrow-functions',
+            '@babel/plugin-proposal-object-rest-spread'
+          ]
+        })
+      ]
+    };
+    return rollup(rollupConfig)
+      .pipe(source(fileName))
+      .pipe(replace('@@LIB_VERSION', this._libVersion))
+      .pipe(dest('dist'));
+  }
+}
+
+exports.BundleType = BundleType;
+exports.BundleTaskFactory = BundleTaskFactory;

--- a/conf/gulp-tasks/library.gulpfile.js
+++ b/conf/gulp-tasks/library.gulpfile.js
@@ -1,131 +1,25 @@
 const { series, parallel, src, dest, watch } = require('gulp');
 
-const fs = require('fs');
-
-const rollup = require('gulp-rollup-lightweight');
-const babel = require('rollup-plugin-babel');
-const resolve = require('rollup-plugin-node-resolve');
-const commonjs = require('rollup-plugin-commonjs');
-const insert = require('rollup-plugin-insert');
-
-const source = require('vinyl-source-stream');
 const rename = require('gulp-rename');
-const replace = require('gulp-replace');
-
 const sass = require('gulp-sass');
-
 const postcss = require('gulp-postcss');
-
 const uglify = require('gulp-uglify-es').default;
 
-const NAMESPACE = 'ANSWERS';
+const getLibraryVersion = require('./utils/libversion');
+const { BundleType, BundleTaskFactory } = require('./bundle/bundletaskfactory');
 
-function getLibVersion () {
-  try {
-    const insideWorkTree = require('child_process')
-      .execSync('git rev-parse --is-inside-work-tree 2>/dev/null')
-      .toString().trim();
-    if (insideWorkTree === 'true') {
-      return require('child_process')
-        .execSync('git describe --tags')
-        .toString().trim();
-    }
-  } catch (e) {
-    // if above command fails, catch error and continue, as we are not in a git repository
-  }
-
-  console.warn('Warning: Not in a github repository, using default hardcoded library version.');
-  return 'TEST';
-}
+const bundleTaskFactory = new BundleTaskFactory(getLibraryVersion());
 
 function bundle () {
-  return rollup({
-    input: './src/answers-umd.js',
-    output: {
-      format: 'umd',
-      name: NAMESPACE,
-      exports: 'default',
-      sourcemap: true
-    },
-    plugins: [
-      resolve(),
-      commonjs({
-        include: './node_modules/**'
-      }),
-      babel({
-        babelrc: false,
-        exclude: 'node_modules/**',
-        presets: ['@babel/env']
-      })
-    ]
-  })
-    .pipe(source('answers-modern.js'))
-    .pipe(replace('@@LIB_VERSION', getLibVersion()))
-    .pipe(dest('dist'));
+  return bundleTaskFactory.create(BundleType.MODERN)();
 }
 
 function legacyBundleIIFE () {
-  return legacyBundle({
-    format: 'iife',
-    name: NAMESPACE,
-    sourcemap: true
-  },
-  'answers.js'
-  );
+  return bundleTaskFactory.create(BundleType.LEGACY_IIFE)();
 }
 
 function legacyBundleUMD () {
-  return legacyBundle({
-    format: 'umd',
-    name: NAMESPACE,
-    export: 'default',
-    sourcemap: true
-  },
-  'answers-umd.js'
-  );
-}
-
-function legacyBundle (outputConfig, fileName) {
-  return rollup({
-    input: './src/answers-umd.js',
-    output: outputConfig,
-    plugins: [
-      resolve(),
-      insert.prepend(
-        fs.readFileSync('./conf/gulp-tasks/polyfill-prefix.js').toString(),
-        {
-          include: './src/answers-umd.js'
-        }),
-      commonjs({
-        include: './node_modules/**'
-      }),
-      babel({
-        runtimeHelpers: true,
-        babelrc: false,
-        exclude: 'node_modules/**',
-        presets: [
-          [
-            '@babel/preset-env',
-            {
-              'loose': true,
-              'modules': false
-            }
-          ]
-        ],
-        plugins: [
-          '@babel/syntax-dynamic-import',
-          ['@babel/plugin-transform-runtime', {
-            'corejs': 3
-          }],
-          '@babel/plugin-transform-arrow-functions',
-          '@babel/plugin-proposal-object-rest-spread'
-        ]
-      })
-    ]
-  })
-    .pipe(source(fileName))
-    .pipe(replace('@@LIB_VERSION', getLibVersion()))
-    .pipe(dest('dist'));
+  return bundleTaskFactory.create(BundleType.LEGACY_UMD)();
 }
 
 function minifyJS () {

--- a/conf/gulp-tasks/utils/libversion.js
+++ b/conf/gulp-tasks/utils/libversion.js
@@ -1,0 +1,24 @@
+/**
+ * Attempts to compute the correct library version for an SDK asset.
+ *
+ * @returns {string} The SDK asset's library version.
+ */
+function getLibVersion () {
+  try {
+    const insideWorkTree = require('child_process')
+      .execSync('git rev-parse --is-inside-work-tree 2>/dev/null')
+      .toString().trim();
+    if (insideWorkTree === 'true') {
+      return require('child_process')
+        .execSync('git describe --tags')
+        .toString().trim();
+    }
+  } catch (e) {
+    // if above command fails, catch error and continue, as we are not in a git repository
+  }
+
+  console.warn('Warning: Not in a github repository, using default hardcoded library version.');
+  return 'TEST';
+}
+
+module.exports = getLibVersion;


### PR DESCRIPTION
…nt SDK bundles (#1038)

This PR adds the BundleTaskFactory class. This class provides Gulp tasks for the different types of SDK bundle: modern, legacy-iife, and legacy-umd. With this class, we can simplify the library.gulpfile.js file. That file was getting too bulky and the work required for creating translated SDK bundles would have only made this worse.

TEST=manual

For the same ref, built all the SDK assets with and without my changes. Using a diff, ensured that the generated assets were the same in both cases.