### PR TITLE
autocomplete: refactor wrapper div, add aria-expanded

### DIFF
--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -482,6 +482,7 @@ export default class SearchComponent extends Component {
         DOM.trigger(DOM.query(this._container, inputSelector), 'input');
       }
     });
+    this._autocomplete.mount();
   }
 
   /**

--- a/src/ui/templates/search/autocomplete.hbs
+++ b/src/ui/templates/search/autocomplete.hbs
@@ -1,31 +1,33 @@
-{{#if hasResults}}
-  <div class="yxt-AutoComplete">
-    {{assign 'currentSelected' sectionIndex resultIndex}}
-    {{#if promptHeader}}
-      <ul class="yxt-AutoComplete-results">
-        <li class="yxt-AutoComplete-option yxt-AutoComplete-option--promptHeader">
-          {{promptHeader}}
-        </li>
-      </ul>
-    {{/if}}
-    {{#each sections}}
-      <ul class="yxt-AutoComplete-results">
-      {{#if label}}
-        <li class="yxt-AutoComplete-resultHeader">{{label}}</li>
+<div class="yxt-AutoComplete-wrapper js-yxt-AutoComplete-wrapper" aria-expanded="{{hasResults}}">
+  {{#if hasResults}}
+    <div class="yxt-AutoComplete">
+      {{assign 'currentSelected' sectionIndex resultIndex}}
+      {{#if promptHeader}}
+        <ul class="yxt-AutoComplete-results">
+          <li class="yxt-AutoComplete-option yxt-AutoComplete-option--promptHeader">
+            {{promptHeader}}
+          </li>
+        </ul>
       {{/if}}
-      {{#each results}}
-        {{assign 'currentIndex' @../index @index}}
-        <li class="js-yext-autocomplete-option yxt-AutoComplete-option yxt-AutoComplete-option--item{{#ifeq ../../currentSelected ../../currentIndex}} yxt-selected{{/ifeq}}"
-            data-value="{{value}}"
-            data-short="{{shortValue}}"
-            data-filter='{{json filter}}'
-            data-eventtype="AUTO_COMPLETE_SELECTION"
-            data-eventoptions='{"suggestedSearchText": "{{value}}"}'
-        >
-            {{highlightValue this true}}
-        </li>
+      {{#each sections}}
+        <ul class="yxt-AutoComplete-results">
+        {{#if label}}
+          <li class="yxt-AutoComplete-resultHeader">{{label}}</li>
+        {{/if}}
+        {{#each results}}
+          {{assign 'currentIndex' @../index @index}}
+          <li class="js-yext-autocomplete-option yxt-AutoComplete-option yxt-AutoComplete-option--item{{#ifeq ../../currentSelected ../../currentIndex}} yxt-selected{{/ifeq}}"
+              data-value="{{value}}"
+              data-short="{{shortValue}}"
+              data-filter='{{json filter}}'
+              data-eventtype="AUTO_COMPLETE_SELECTION"
+              data-eventoptions='{"suggestedSearchText": "{{value}}"}'
+          >
+              {{highlightValue this true}}
+          </li>
+        {{/each}}
+        </ul>
       {{/each}}
-      </ul>
-    {{/each}}
-  </div>
-{{/if}}
+    </div>
+  {{/if}}
+</div>

--- a/src/ui/templates/search/search.hbs
+++ b/src/ui/templates/search/search.hbs
@@ -14,7 +14,7 @@
         {{> inputAndButtons}}
       </div>
     {{/if}}
-    <div class="yxt-SearchBar-autocomplete yxt-AutoComplete-wrapper js-yxt-AutoComplete-wrapper"></div>
+    <div class="yxt-SearchBar-autocomplete"></div>
   </div>
 </div>
 


### PR DESCRIPTION
As a part of WCAG fixes, we want to add the aria-expanded attribute to
the wrapper of the autocomplete. This will be true when the autocomplete
is visible and false otherwise.

This requires a refactor because the wrapper for the Autocomplete lives
in the Search component. It would require a js change on setState to
update the container div in search when autocomplete is notified of a
change (see below for what we were trying to avoid). To support this
functionality in the hbs, and instead of adding a side effect to the
setState, we move the AutoComplete classes to their appropriate place in
the autocomplete.hbs (Note: yxt-AutoComplete prefixed classes should
always be in the associated file).

Trying to avoid: in autocompletecomponent.js
```
setState (data) {
  this._container.setAttribute('aria-expanded', this.hasResults(data));
}
```

Breaking changes: There is a new div in between
yxt-SearchBar-autcomplete and yxt-AutoComplete: yxt-AutoCompleteWrapper.
This has classes that were moved from yxt-SearchBar-autocomplete.

Implementation detail: we call onMount because otherwise the
autocomplete does not mount until the searchbar input is clicked. We
want the aria-expanded attribute to always be present.

J=SLAP-537
TEST=manual

Test on a local Jambo site and a local site referencing a local SDK
answers script and templatebundle.

Test that on load of all pages with a searchbar, the following div
exists, with aria-expanded false
```
<div class="yxt-AutoComplete-wrapper js-yxt-AutoComplete-wrapper" aria-expanded="false">
</div>
```

Test that on click of search input / tabbing into the search input,
aria-expanded is true.

Test that aria-expanded returns to false when clicking outside of the
searchbar and visually seeing the autocomplete disappear.

Test that styling is exactly the same as before (in these examples,
there are no promises that custom styling will not be affected).

Test that a redirectUrl searchbar still shows an autocomplete.

Test that a searchbar with autoFocus: true still autofocuses the
searchbar and shows an autocomplete with suggested queries.

Test that you can still have two searchbars on the page.