### PR TITLE
Add preliminary infrastructure for providing localized assets.

### DIFF
--- a/conf/i18n/localfileparser.js
+++ b/conf/i18n/localfileparser.js
@@ -9,12 +9,12 @@ const { gettextToI18next } = require('i18next-conv');
 class LocalFileParser {
   /**
    * Creates a new instance of {@link LocalFileParser}.
-   * 
+   *
    * @param {string} translationsDir The local directory containing .PO files.
    * @param {Object<string,?>} options Used to optionally configure the i18next-conv
    *                                   library.
   */
-  constructor(translationsDir, options) {
+  constructor (translationsDir, options) {
     this._translationsDir = translationsDir;
     this._options = options;
   }
@@ -22,12 +22,12 @@ class LocalFileParser {
   /**
    * Extracts a locale's translations from the local filesystem. If no such
    * translations exist, an empty object is returned.
-   * 
+   *
    * @param {string} locale The desired locale.
    * @returns {Promise<Object>} A Promise containing the parsed translations in
    *                            i18next format.
   */
-  async fetch(locale) {
+  async fetch (locale) {
     const translationFile = path.join(this._translationsDir, `${locale}.po`);
 
     if (existsSync(translationFile)) {

--- a/conf/i18n/localfileparser.js
+++ b/conf/i18n/localfileparser.js
@@ -1,0 +1,42 @@
+const path = require('path');
+const { readFileSync, existsSync } = require('fs');
+const { gettextToI18next } = require('i18next-conv');
+
+/**
+ * This class parses translations from a local .PO file. The i18next-conv
+ * library is used to put the translations in i18next format.
+ */
+class LocalFileParser {
+  /**
+   * Creates a new instance of {@link LocalFileParser}.
+   * 
+   * @param {string} translationsDir The local directory containing .PO files.
+   * @param {Object<string,?>} options Used to optionally configure the i18next-conv
+   *                                   library.
+  */
+  constructor(translationsDir, options) {
+    this._translationsDir = translationsDir;
+    this._options = options;
+  }
+
+  /**
+   * Extracts a locale's translations from the local filesystem. If no such
+   * translations exist, an empty object is returned.
+   * 
+   * @param {string} locale The desired locale.
+   * @returns {Promise<Object>} A Promise containing the parsed translations in
+   *                            i18next format.
+  */
+  async fetch(locale) {
+    const translationFile = path.join(this._translationsDir, `${locale}.po`);
+
+    if (existsSync(translationFile)) {
+      const localeTranslations =
+        gettextToI18next(locale, readFileSync(translationFile), this._options);
+      return localeTranslations.then(data => JSON.parse(data));
+    }
+
+    return {};
+  }
+}
+module.exports = LocalFileParser;

--- a/conf/i18n/models/translationplaceholder.js
+++ b/conf/i18n/models/translationplaceholder.js
@@ -4,7 +4,7 @@
  * or pluralization as well.
  */
 class TranslationPlaceholder {
-  constructor({ phrase, pluralForm, context, count, interpolationValues}) {
+  constructor ({ phrase, pluralForm, context, count, interpolationValues }) {
     this._phrase = phrase;
     this._pluralForm = pluralForm;
     this._context = context;
@@ -14,29 +14,29 @@ class TranslationPlaceholder {
 
   /**
    * The candidate phrase for translation.
-   * 
+   *
    * @returns {string}
    */
-  getPhrase() {
+  getPhrase () {
     return this._phrase;
   }
 
   /**
    * The untranslated, plural form of the candidate phrase. This is only present
    * if pluralization is required.
-   * 
+   *
    * @returns {string}
    */
-  getPluralForm() {
+  getPluralForm () {
     return this._pluralForm;
   }
 
   /**
    * Any added context needed in translating the phrase.
-   * 
+   *
    * @returns {string}
    */
-  getContext() {
+  getContext () {
     return this._context;
   }
 
@@ -44,7 +44,7 @@ class TranslationPlaceholder {
    * The run-time parameter, wrapped in a string, for determing count in the case
    * of pluralization. This quantity must be wrapped in a string to prevent evaluation
    * before run-time.
-   * 
+   *
    * @returns {string}
    */
   getCount () {
@@ -55,10 +55,10 @@ class TranslationPlaceholder {
    * An object containing any interpolation parameters, and their values, needed
    * in the translation. Note that all values are wrapped in a string. This is
    * to prevent them from being evaluated prior to run-time.
-   * 
+   *
    * @returns {Object<string, string>}
    */
-  getInterpolationValues() {
+  getInterpolationValues () {
     return this._interpolationValues;
   }
 }

--- a/conf/i18n/models/translationplaceholder.js
+++ b/conf/i18n/models/translationplaceholder.js
@@ -1,0 +1,66 @@
+/**
+ * A data model representing a phrase needing translation in the SDK's
+ * source code. The model can be used for translations requiring added context
+ * or pluralization as well.
+ */
+class TranslationPlaceholder {
+  constructor({ phrase, pluralForm, context, count, interpolationValues}) {
+    this._phrase = phrase;
+    this._pluralForm = pluralForm;
+    this._context = context;
+    this._count = count;
+    this._interpolationValues = interpolationValues;
+  }
+
+  /**
+   * The candidate phrase for translation.
+   * 
+   * @returns {string}
+   */
+  getPhrase() {
+    return this._phrase;
+  }
+
+  /**
+   * The untranslated, plural form of the candidate phrase. This is only present
+   * if pluralization is required.
+   * 
+   * @returns {string}
+   */
+  getPluralForm() {
+    return this._pluralForm;
+  }
+
+  /**
+   * Any added context needed in translating the phrase.
+   * 
+   * @returns {string}
+   */
+  getContext() {
+    return this._context;
+  }
+
+  /**
+   * The run-time parameter, wrapped in a string, for determing count in the case
+   * of pluralization. This quantity must be wrapped in a string to prevent evaluation
+   * before run-time.
+   * 
+   * @returns {string}
+   */
+  getCount () {
+    return this._count;
+  }
+
+  /**
+   * An object containing any interpolation parameters, and their values, needed
+   * in the translation. Note that all values are wrapped in a string. This is
+   * to prevent them from being evaluated prior to run-time.
+   * 
+   * @returns {Object<string, string>}
+   */
+  getInterpolationValues() {
+    return this._interpolationValues;
+  }
+}
+
+module.exports = TranslationPlaceholder;

--- a/conf/i18n/translationresolver.js
+++ b/conf/i18n/translationresolver.js
@@ -5,7 +5,7 @@
 class TranslationResolver {
   /**
    * Creates a new {@link TranslationResolver}.
-   * 
+   *
    * @param {Translator} translator A {@link Translator} instance to provide the
    *                                build-time translations.
    * @param {Function} runtimeCallGenerator A function to construct the proper run-time
@@ -19,12 +19,12 @@ class TranslationResolver {
   /**
    * Converts the {@link TranslationPlaceholder} of a simple phrase into either
    * an exact translation or the appropriate run-time call.
-   * 
+   *
    * @param {TranslationPlaceholder} placeholder The {@link TranslationPlaceholder}.
    * @returns {string} A fully translated string or the correct call for getting the
    *                   translated string at run-time.
    */
-  resolve(placeholder) {
+  resolve (placeholder) {
     const translationResult =
       this._translator.translate(placeholder.getPhrase());
     const interpValues = placeholder.getInterpolationValues();
@@ -32,14 +32,14 @@ class TranslationResolver {
   }
 
   /**
-   * Converts the {@link TranslationPlaceholder} of a phrase with added context 
+   * Converts the {@link TranslationPlaceholder} of a phrase with added context
    * into either an exact translation or the appropriate run-time call.
-   * 
+   *
    * @param {TranslationPlaceholder} placeholder The {@link TranslationPlaceholder}.
    * @returns {string} A fully translated string or the correct call for getting the
    *                   translated string at run-time.
    */
-  resolveWithContext(placeholder) {
+  resolveWithContext (placeholder) {
     const translationResult = this._translator.translate(
       placeholder.getPhrase(), placeholder.getContext());
     const interpValues = placeholder.getInterpolationValues();
@@ -49,12 +49,12 @@ class TranslationResolver {
   /**
    * Converts the {@link TranslationPlaceholder} of a phrase needing both
    * translation and pluralization into the appropriate run-time call.
-   * 
+   *
    * @param {TranslationPlaceholder} placeholder The {@link TranslationPlaceholder}.
    * @returns {string} The correct call for getting the translated, pluralized
    *                   string at run-time.
    */
-  resolveWithPlural(placeholder) {
+  resolveWithPlural (placeholder) {
     const translationResult = this._translator.translatePlural(
       placeholder.getPhrase(), placeholder.getPluralForm());
     const interpValues = placeholder.getInterpolationValues();
@@ -63,9 +63,9 @@ class TranslationResolver {
   }
 
   /**
-   * Given the translated form(s) of a phrase, this method produces either a 
+   * Given the translated form(s) of a phrase, this method produces either a
    * translated string or the proper call for obtaining this string at run-time.
-   * 
+   *
    * @param {string|Object} translationResult The translation(s) given by the
    *                                          {@link Translator}.
    * @param {Object} interpValues The object containing the interpolation parameters
@@ -74,11 +74,11 @@ class TranslationResolver {
    * @returns {string} A fully translated string or the correct call for getting the
    *                   translated string at run-time.
    */
-  _resolveInternal(translationResult, interpValues, count) {
+  _resolveInternal (translationResult, interpValues, count) {
     const isRuntimeTranslation = count || interpValues;
-    return !isRuntimeTranslation ?
-       translationResult :
-       this._runtimeCallGenerator(translationResult, interpValues, count);
+    return !isRuntimeTranslation
+      ? translationResult
+      : this._runtimeCallGenerator(translationResult, interpValues, count);
   }
 }
 

--- a/conf/i18n/translationresolver.js
+++ b/conf/i18n/translationresolver.js
@@ -1,0 +1,85 @@
+/**
+ * This class provides methods that resolve a {@link TranslationPlaceholder} into
+ * either an exact translation or the proper run-time translation call.
+ */
+class TranslationResolver {
+  /**
+   * Creates a new {@link TranslationResolver}.
+   * 
+   * @param {Translator} translator A {@link Translator} instance to provide the
+   *                                build-time translations.
+   * @param {Function} runtimeCallGenerator A function to construct the proper run-time
+   *                                        translation call.
+   */
+  constructor (translator, runtimeCallGenerator) {
+    this._translator = translator;
+    this._runtimeCallGenerator = runtimeCallGenerator;
+  }
+
+  /**
+   * Converts the {@link TranslationPlaceholder} of a simple phrase into either
+   * an exact translation or the appropriate run-time call.
+   * 
+   * @param {TranslationPlaceholder} placeholder The {@link TranslationPlaceholder}.
+   * @returns {string} A fully translated string or the correct call for getting the
+   *                   translated string at run-time.
+   */
+  resolve(placeholder) {
+    const translationResult =
+      this._translator.translate(placeholder.getPhrase());
+    const interpValues = placeholder.getInterpolationValues();
+    return this._resolveInternal(translationResult, interpValues);
+  }
+
+  /**
+   * Converts the {@link TranslationPlaceholder} of a phrase with added context 
+   * into either an exact translation or the appropriate run-time call.
+   * 
+   * @param {TranslationPlaceholder} placeholder The {@link TranslationPlaceholder}.
+   * @returns {string} A fully translated string or the correct call for getting the
+   *                   translated string at run-time.
+   */
+  resolveWithContext(placeholder) {
+    const translationResult = this._translator.translate(
+      placeholder.getPhrase(), placeholder.getContext());
+    const interpValues = placeholder.getInterpolationValues();
+    return this._resolveInternal(translationResult, interpValues);
+  }
+
+  /**
+   * Converts the {@link TranslationPlaceholder} of a phrase needing both
+   * translation and pluralization into the appropriate run-time call.
+   * 
+   * @param {TranslationPlaceholder} placeholder The {@link TranslationPlaceholder}.
+   * @returns {string} The correct call for getting the translated, pluralized
+   *                   string at run-time.
+   */
+  resolveWithPlural(placeholder) {
+    const translationResult = this._translator.translatePlural(
+      placeholder.getPhrase(), placeholder.getPluralForm());
+    const interpValues = placeholder.getInterpolationValues();
+    return this._resolveInternal(
+      translationResult, interpValues, placeholder.getCount());
+  }
+
+  /**
+   * Given the translated form(s) of a phrase, this method produces either a 
+   * translated string or the proper call for obtaining this string at run-time.
+   * 
+   * @param {string|Object} translationResult The translation(s) given by the
+   *                                          {@link Translator}.
+   * @param {Object} interpValues The object containing the interpolation parameters
+   *                              and their values.
+   * @param {string} count The attribute, as a string, that will provide the count.
+   * @returns {string} A fully translated string or the correct call for getting the
+   *                   translated string at run-time.
+   */
+  _resolveInternal(translationResult, interpValues, count) {
+    const isRuntimeTranslation = count || interpValues;
+    return !isRuntimeTranslation ?
+       translationResult :
+       this._runtimeCallGenerator(translationResult, interpValues, count);
+  }
+}
+
+module.exports = TranslationResolver;

--- a/conf/i18n/translator.js
+++ b/conf/i18n/translator.js
@@ -8,10 +8,10 @@ const i18next = require('i18next');
 class Translator {
   /**
    * Creates a new {@link Translator} that wraps the provided {@link i18next} instance.
-   * 
+   *
    * @param {i18next} i18nextInstance The instance to wrap.
    */
-  constructor(i18nextInstance) {
+  constructor (i18nextInstance) {
     this._i18next = i18nextInstance;
   }
 
@@ -19,27 +19,27 @@ class Translator {
    * Performs a simple translation of the given phrase. If the phrase includes
    * interpolation, a translated format string, with the relevant placeholders,
    * is returned.
-   * 
+   *
    * @param {string} phrase The phrase to translate.
    * @returns {string} The translated phrase or format string.
    */
-  translate(phrase) {
-    const interpPlaceholders = this._getInterpolationPlaceholders(phrase);    
+  translate (phrase) {
+    const interpPlaceholders = this._getInterpolationPlaceholders(phrase);
 
     return this._i18next.t(phrase, interpPlaceholders);
   }
 
   /**
-   * Provides all the translated singular and plural forms of the given phrase. 
+   * Provides all the translated singular and plural forms of the given phrase.
    * The forms will include any of the needed interpolation placeholders.
-   * 
+   *
    * @param {string} phrase The phrase to translate.
    * @param {string} pluralForm The untranslated, plural form of the phrase.
    * @returns {Object<string|number, string>} A map containing the various forms.
    *                                          A form is keyed by the
    *                                          corresponding count or 'plural'.
    */
-  translatePlural(phrase, pluralForm) {
+  translatePlural (phrase, pluralForm) {
     const pluralKeyRegex = new RegExp(`${phrase}_([0-9]+|plural)`);
 
     const i18nextOptions = this._i18next.options;
@@ -50,9 +50,9 @@ class Translator {
       [i18nextOptions.lng, ...i18nextOptions.fallbackLng], pluralKeyRegex);
 
     if (localeWithPluralTranslations) {
-      const localeTranslations = 
+      const localeTranslations =
         i18nextOptions.resources[localeWithPluralTranslations].translation;
-      
+
       // Create a map of count (or 'plural') to the correct translated form.
       return Object.keys(localeTranslations)
         .filter(translationKey => pluralKeyRegex.test(translationKey))
@@ -61,10 +61,10 @@ class Translator {
             const pluralFormIndex = translationKey.split('_')[1];
             pluralForms[pluralFormIndex] = localeTranslations[translationKey];
             return pluralForms;
-          }, 
+          },
           { 1: localeTranslations[phrase] });
-    } 
-    
+    }
+
     // If no translations can be found, we return a map containing the provided
     // singular and plural forms.
     return {
@@ -77,28 +77,28 @@ class Translator {
    * Translates the provided phrase depending on the context. If the phrase includes
    * interpolation, a translated format string, with the relevant placeholders,
    * is returned.
-   * 
+   *
    * @param {string} phrase The phrase to translate.
    * @param {string} context The context of the translation.
    * @returns {string} The translated phrase or format string.
    */
-  translateWithContext(phrase, context) {
+  translateWithContext (phrase, context) {
     const interpPlaceholders = this._getInterpolationPlaceholders(phrase);
 
-    return this._i18next.t(phrase, { context, ...interpPlaceholders});
+    return this._i18next.t(phrase, { context, ...interpPlaceholders });
   }
 
   /**
-   * Creates an object containing the interpolation placeholders for the given 
-   * phrase. Such an object must be passed to i18next to ensure interpolation can 
+   * Creates an object containing the interpolation placeholders for the given
+   * phrase. Such an object must be passed to i18next to ensure interpolation can
    * be performed on the translated phrase.
-   * 
-   * @param {string} phrase The phrase. 
+   *
+   * @param {string} phrase The phrase.
    * @returns {Object<string, string>} A map of interpolation parameter to placeholder.
-   *                                   As an example, if the phrase was: 'My {{name}} is', 
+   *                                   As an example, if the phrase was: 'My {{name}} is',
    *                                   the object would contains { name: '{{name}}' }.
    */
-  _getInterpolationPlaceholders(phrase) {
+  _getInterpolationPlaceholders (phrase) {
     const placeholders = {};
     let placeholderMatch;
 
@@ -115,12 +115,12 @@ class Translator {
   /**
    * Finds the first of the provided locales with a translation whose key matches
    * the regex.
-   * 
+   *
    * @param {Array<string>} locales The list of locales.
    * @param {RegExp} keyRegex The pattern to match translation keys against.
-   * @returns {string} The first matching locale. 
+   * @returns {string} The first matching locale.
    */
-  _findLocaleWithTranslationKey(locales, keyRegex) {
+  _findLocaleWithTranslationKey (locales, keyRegex) {
     const i18nextOptions = this._i18next.options;
 
     return locales.find(locale => {
@@ -134,18 +134,18 @@ class Translator {
   /**
    * Creates a {@link Translator} for the given locale, wrapping a properly configured,
    * new {@link i18next} instance.
-   * 
+   *
    * @param {string} locale The desired locale.
    * @param {Array<string>} fallbacks A prioritized list of translation fallbacks
    *                                  for the locale.
    * @param {string} translations The translations for the locale and associated fallbacks.
    */
-  static async create(locale, fallbacks, translations) {
+  static async create (locale, fallbacks, translations) {
     const i18nextInstance = i18next.createInstance();
     await i18nextInstance.init({
       lng: locale,
       fallbackLng: fallbacks,
-      resources: translations,
+      resources: translations
     });
     const translator = new Translator(i18nextInstance);
 

--- a/conf/i18n/translator.js
+++ b/conf/i18n/translator.js
@@ -1,0 +1,156 @@
+const i18next = require('i18next');
+
+/**
+ * This class wraps an instance of the i18next library and provides methods supporting
+ * run-time and compile-time translation. These methods allow for interpolation, pluralization,
+ * and added context.
+ */
+class Translator {
+  /**
+   * Creates a new {@link Translator} that wraps the provided {@link i18next} instance.
+   * 
+   * @param {i18next} i18nextInstance The instance to wrap.
+   */
+  constructor(i18nextInstance) {
+    this._i18next = i18nextInstance;
+  }
+
+  /**
+   * Performs a simple translation of the given phrase. If the phrase includes
+   * interpolation, a translated format string, with the relevant placeholders,
+   * is returned.
+   * 
+   * @param {string} phrase The phrase to translate.
+   * @returns {string} The translated phrase or format string.
+   */
+  translate(phrase) {
+    const interpPlaceholders = this._getInterpolationPlaceholders(phrase);    
+
+    return this._i18next.t(phrase, interpPlaceholders);
+  }
+
+  /**
+   * Provides all the translated singular and plural forms of the given phrase. 
+   * The forms will include any of the needed interpolation placeholders.
+   * 
+   * @param {string} phrase The phrase to translate.
+   * @param {string} pluralForm The untranslated, plural form of the phrase.
+   * @returns {Object<string|number, string>} A map containing the various forms.
+   *                                          A form is keyed by the
+   *                                          corresponding count or 'plural'.
+   */
+  translatePlural(phrase, pluralForm) {
+    const pluralKeyRegex = new RegExp(`${phrase}_([0-9]+|plural)`);
+
+    const i18nextOptions = this._i18next.options;
+
+    // We first look for the translations in the given locale. If none can be
+    // found there, we iterate through the fallbacks, in order.
+    const localeWithPluralTranslations = this._findLocaleWithTranslationKey(
+      [i18nextOptions.lng, ...i18nextOptions.fallbackLng], pluralKeyRegex);
+
+    if (localeWithPluralTranslations) {
+      const localeTranslations = 
+        i18nextOptions.resources[localeWithPluralTranslations].translation;
+      
+      // Create a map of count (or 'plural') to the correct translated form.
+      return Object.keys(localeTranslations)
+        .filter(translationKey => pluralKeyRegex.test(translationKey))
+        .reduce(
+          (pluralForms, translationKey) => {
+            const pluralFormIndex = translationKey.split('_')[1];
+            pluralForms[pluralFormIndex] = localeTranslations[translationKey];
+            return pluralForms;
+          }, 
+          { 1: localeTranslations[phrase] });
+    } 
+    
+    // If no translations can be found, we return a map containing the provided
+    // singular and plural forms.
+    return {
+      1: phrase,
+      plural: pluralForm
+    };
+  }
+
+  /**
+   * Translates the provided phrase depending on the context. If the phrase includes
+   * interpolation, a translated format string, with the relevant placeholders,
+   * is returned.
+   * 
+   * @param {string} phrase The phrase to translate.
+   * @param {string} context The context of the translation.
+   * @returns {string} The translated phrase or format string.
+   */
+  translateWithContext(phrase, context) {
+    const interpPlaceholders = this._getInterpolationPlaceholders(phrase);
+
+    return this._i18next.t(phrase, { context, ...interpPlaceholders});
+  }
+
+  /**
+   * Creates an object containing the interpolation placeholders for the given 
+   * phrase. Such an object must be passed to i18next to ensure interpolation can 
+   * be performed on the translated phrase.
+   * 
+   * @param {string} phrase The phrase. 
+   * @returns {Object<string, string>} A map of interpolation parameter to placeholder.
+   *                                   As an example, if the phrase was: 'My {{name}} is', 
+   *                                   the object would contains { name: '{{name}}' }.
+   */
+  _getInterpolationPlaceholders(phrase) {
+    const placeholders = {};
+    let placeholderMatch;
+
+    const placeholderRegex = new RegExp(/\{\{([a-zA-Z0-9]+)\}\}/, 'g');
+    while ((placeholderMatch = placeholderRegex.exec(phrase)) != null) {
+      if (placeholderMatch.length >= 2) {
+        placeholders[placeholderMatch[1]] = placeholderMatch[0];
+      }
+    }
+
+    return placeholders;
+  }
+
+  /**
+   * Finds the first of the provided locales with a translation whose key matches
+   * the regex.
+   * 
+   * @param {Array<string>} locales The list of locales.
+   * @param {RegExp} keyRegex The pattern to match translation keys against.
+   * @returns {string} The first matching locale. 
+   */
+  _findLocaleWithTranslationKey(locales, keyRegex) {
+    const i18nextOptions = this._i18next.options;
+
+    return locales.find(locale => {
+      const localeTranslations = i18nextOptions.resources[locale].translation;
+      const hasMatchingTranslationKey = Object.keys(localeTranslations)
+        .some(translationKey => keyRegex.test(translationKey));
+      return hasMatchingTranslationKey;
+    });
+  }
+
+  /**
+   * Creates a {@link Translator} for the given locale, wrapping a properly configured,
+   * new {@link i18next} instance.
+   * 
+   * @param {string} locale The desired locale.
+   * @param {Array<string>} fallbacks A prioritized list of translation fallbacks
+   *                                  for the locale.
+   * @param {string} translations The translations for the locale and associated fallbacks.
+   */
+  static async create(locale, fallbacks, translations) {
+    const i18nextInstance = i18next.createInstance();
+    await i18nextInstance.init({
+      lng: locale,
+      fallbackLng: fallbacks,
+      resources: translations,
+    });
+    const translator = new Translator(i18nextInstance);
+
+    return translator;
+  }
+}
+
+module.exports = Translator;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1169,6 +1169,23 @@
         }
       }
     },
+    "@babel/runtime": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+      "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+          "dev": true
+        }
+      }
+    },
     "@babel/runtime-corejs3": {
       "version": "7.8.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.8.7.tgz",
@@ -1570,6 +1587,12 @@
       "requires": {
         "@babel/types": "^7.3.0"
       }
+    },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
     },
     "@types/error-stack-parser": {
       "version": "1.3.18",
@@ -6172,6 +6195,26 @@
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
     },
+    "encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "^0.6.2"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+          "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
+      }
+    },
     "end-of-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
@@ -7777,6 +7820,37 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "gettext-parser": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-4.0.4.tgz",
+      "integrity": "sha512-VDZEeOIYd0veZXt5iAn0SS3I0Fz14fJw+59avRNa7VIslEDriRLxcfrBd/xeQyOcm6nyS4uuufxm2iw88qirAg==",
+      "dev": true,
+      "requires": {
+        "content-type": "^1.0.4",
+        "encoding": "^0.1.13",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        }
+      }
+    },
     "glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
@@ -8570,6 +8644,99 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
       "dev": true
+    },
+    "i18next": {
+      "version": "19.7.0",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-19.7.0.tgz",
+      "integrity": "sha512-sxZhj6u7HbEYOMx81oGwq5MiXISRBVg2wRY3n6YIbe+HtU8ydzlGzv6ErHdrRKYxATBFssVXYbc3lNZoyB4vfA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.10.1"
+      }
+    },
+    "i18next-conv": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/i18next-conv/-/i18next-conv-10.0.2.tgz",
+      "integrity": "sha512-KZp+OfvPN50ZQHCiqhVhxA5uowuE6xIZ42M1Mtht87/xh2tp3GJl3ds0wsewhFxQRmHOVWOaq0ZYoK/oHWrbzg==",
+      "dev": true,
+      "requires": {
+        "arrify": "^2.0.1",
+        "chalk": "^4.0.0",
+        "commander": "^5.1.0",
+        "gettext-parser": "^4.0.3",
+        "mkdirp": "^1.0.4",
+        "node-gettext": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "arrify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+          "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "commander": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "iconv-lite": {
       "version": "0.4.23",
@@ -11534,6 +11701,15 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "node-gettext": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/node-gettext/-/node-gettext-3.0.0.tgz",
+      "integrity": "sha512-/VRYibXmVoN6tnSAY2JWhNRhWYJ8Cd844jrZU/DwLVoI4vBI6ceYbd8i42sYZ9uOgDH3S7vslIKOWV/ZrT2YBA==",
+      "dev": true,
+      "requires": {
+        "lodash.get": "^4.4.2"
+      }
     },
     "node-gyp": {
       "version": "3.8.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "gulp-uglify-es": "^1.0.4",
     "gulp-umd": "^2.0.0",
     "gulp-wrap": "^0.14.0",
+    "i18next": "^19.7.0",
+    "i18next-conv": "^10.0.2",
     "jest": "^24.8.0",
     "jsdoc": "^3.6.3",
     "node-sass": "^4.12.0",


### PR DESCRIPTION
This PR adds a number of classes that will support the creation of localized
SDK assets. The classes added are:

- Translator: A class, backed by i18next, that supplies translations. These
  translations can be used either at run-time or build-time.
- LocalFileParser: A class that can read in a .PO file for a locale and convert
  it into a form understood by i18next and the Translator.
- TranslationPlaceholder: A data model representing content in SDK source that
  needs translation.
- TranslationResolver: A class that resolves TranslationPlaceholders to either
  a translated string or a run-time call to provide that string.

Eventually, test coverage will be added for these various classes. Tests were
omitted for now because these classes may be subject to change as we're just
starting our SDK localization effort.

TEST=manual

Manually generated a French version of the SDK (with a single run-time
translation) using this infrastructure.