### PR TITLE
Remove inputAndButtons inline partial from SearchBar's template.

### DIFF
--- a/src/ui/templates/search/search.hbs
+++ b/src/ui/templates/search/search.hbs
@@ -7,62 +7,103 @@
   <div class="yxt-SearchBar-container">
     {{#if useForm}}
       <form class="yxt-SearchBar-form">
-        {{> inputAndButtons}}
-      </form>
-    {{else}}
-      <div class="yxt-SearchBar-input-wrapper">
-        {{> inputAndButtons}}
-      </div>
-    {{/if}}
-    <div class="yxt-SearchBar-autocomplete yxt-AutoComplete-wrapper js-yxt-AutoComplete-wrapper"></div>
-  </div>
-</div>
-
-{{#*inline "inputAndButtons"}}
-  <input class="js-yext-query yxt-SearchBar-input"
+        <input class="js-yext-query yxt-SearchBar-input"
           type="text"
           name="query"
           value="{{query}}"
           {{#if _config.placeholderText}}placeholder="{{_config.placeholderText}}"{{/if}}
           aria-label="{{labelText}}">
-  <button type="button"
-          class="js-yxt-SearchBar-clear yxt-SearchBar-clear yxt-SearchBar--hidden"
-          data-eventtype="SEARCH_CLEAR_BUTTON"
-          data-eventoptions="{{eventOptions}}"
-          data-component="IconComponent"
-          data-opts='{ "iconName": "close" }'
-          data-prop="icon"
-  >
-    <span class="yxt-SearchBar-clearButtonText sr-only">
-      {{clearText}}
-    </span>
-  </button>
-  <button {{#if useForm}}type="submit"{{else}}type="button"{{/if}}
-    class="js-yext-submit yxt-SearchBar-button">
-    {{#if submitIcon}}
-      <div class="yxt-SearchBar-buttonImage"
-          data-component="IconComponent"
-          data-opts='{ "iconName": "{{submitIcon}}" }'
-      ></div>
-    {{else if _config.customIconUrl}}
-      <div class="yxt-SearchBar-buttonImage"
-          data-component="IconComponent"
-          data-opts='{ "iconUrl": "{{_config.customIconUrl}}" }'
-      ></div>
+        <button type="button"
+                class="js-yxt-SearchBar-clear yxt-SearchBar-clear yxt-SearchBar--hidden"
+                data-eventtype="SEARCH_CLEAR_BUTTON"
+                data-eventoptions="{{eventOptions}}"
+                data-component="IconComponent"
+                data-opts='{ "iconName": "close" }'
+                data-prop="icon"
+        >
+          <span class="yxt-SearchBar-clearButtonText sr-only">
+            {{clearText}}
+          </span>
+        </button>
+        <button {{#if useForm}}type="submit"{{else}}type="button"{{/if}}
+          class="js-yext-submit yxt-SearchBar-button">
+          {{#if submitIcon}}
+            <div class="yxt-SearchBar-buttonImage"
+                data-component="IconComponent"
+                data-opts='{ "iconName": "{{submitIcon}}" }'
+            ></div>
+          {{else if _config.customIconUrl}}
+            <div class="yxt-SearchBar-buttonImage"
+                data-component="IconComponent"
+                data-opts='{ "iconUrl": "{{_config.customIconUrl}}" }'
+            ></div>
+          {{else}}
+            <div class="yxt-SearchBar-AnimatedIcon yxt-SearchBar-AnimatedIcon--paused js-yxt-AnimatedForward
+              {{#if autoFocus}} yxt-SearchBar-AnimatedIcon--inactive{{/if}}"
+              data-component="IconComponent"
+              data-opts="{{json forwardIconOpts}}">
+            </div>
+            <div class="yxt-SearchBar-AnimatedIcon yxt-SearchBar-AnimatedIcon--paused js-yxt-AnimatedReverse
+              {{#unless autoFocus}} yxt-SearchBar-AnimatedIcon--inactive{{/unless}}"
+              data-component="IconComponent"
+              data-opts="{{json reverseIconOpts}}">
+            </div>
+          {{/if}}
+          <span class="yxt-SearchBar-buttonText sr-only">
+            {{submitText}}
+          </span>
+        </button>
+      </form>
     {{else}}
-      <div class="yxt-SearchBar-AnimatedIcon yxt-SearchBar-AnimatedIcon--paused js-yxt-AnimatedForward
-        {{#if autoFocus}} yxt-SearchBar-AnimatedIcon--inactive{{/if}}"
-        data-component="IconComponent"
-        data-opts="{{json forwardIconOpts}}">
-      </div>
-      <div class="yxt-SearchBar-AnimatedIcon yxt-SearchBar-AnimatedIcon--paused js-yxt-AnimatedReverse
-        {{#unless autoFocus}} yxt-SearchBar-AnimatedIcon--inactive{{/unless}}"
-        data-component="IconComponent"
-        data-opts="{{json reverseIconOpts}}">
+      <div class="yxt-SearchBar-input-wrapper">
+        <input class="js-yext-query yxt-SearchBar-input"
+          type="text"
+          name="query"
+          value="{{query}}"
+          {{#if _config.placeholderText}}placeholder="{{_config.placeholderText}}"{{/if}}
+          aria-label="{{labelText}}">
+        <button type="button"
+                class="js-yxt-SearchBar-clear yxt-SearchBar-clear yxt-SearchBar--hidden"
+                data-eventtype="SEARCH_CLEAR_BUTTON"
+                data-eventoptions="{{eventOptions}}"
+                data-component="IconComponent"
+                data-opts='{ "iconName": "close" }'
+                data-prop="icon"
+        >
+          <span class="yxt-SearchBar-clearButtonText sr-only">
+            {{clearText}}
+          </span>
+        </button>
+        <button {{#if useForm}}type="submit"{{else}}type="button"{{/if}}
+          class="js-yext-submit yxt-SearchBar-button">
+          {{#if submitIcon}}
+            <div class="yxt-SearchBar-buttonImage"
+                data-component="IconComponent"
+                data-opts='{ "iconName": "{{submitIcon}}" }'
+            ></div>
+          {{else if _config.customIconUrl}}
+            <div class="yxt-SearchBar-buttonImage"
+                data-component="IconComponent"
+                data-opts='{ "iconUrl": "{{_config.customIconUrl}}" }'
+            ></div>
+          {{else}}
+            <div class="yxt-SearchBar-AnimatedIcon yxt-SearchBar-AnimatedIcon--paused js-yxt-AnimatedForward
+              {{#if autoFocus}} yxt-SearchBar-AnimatedIcon--inactive{{/if}}"
+              data-component="IconComponent"
+              data-opts="{{json forwardIconOpts}}">
+            </div>
+            <div class="yxt-SearchBar-AnimatedIcon yxt-SearchBar-AnimatedIcon--paused js-yxt-AnimatedReverse
+              {{#unless autoFocus}} yxt-SearchBar-AnimatedIcon--inactive{{/unless}}"
+              data-component="IconComponent"
+              data-opts="{{json reverseIconOpts}}">
+            </div>
+          {{/if}}
+          <span class="yxt-SearchBar-buttonText sr-only">
+            {{submitText}}
+          </span>
+        </button>
       </div>
     {{/if}}
-    <span class="yxt-SearchBar-buttonText sr-only">
-      {{submitText}}
-    </span>
-  </button>
-{{/inline}}
+    <div class="yxt-SearchBar-autocomplete yxt-AutoComplete-wrapper js-yxt-AutoComplete-wrapper"></div>
+  </div>
+</div>


### PR DESCRIPTION
This was done to make it such that the SearchBar component can be used on a 
site that does not allow unsafe-eval in its Content Security Policy. We found
that Handlebars makes use of eval in a few cases. One of those is when a
template uses an in-line helper. We did not update other usages of inline
partials in the SDK. This is because most Answers implementations use an
iframe'd experience. In these situations, the SearchBar component would be the
only one subject to the client's CSP.

J=SLAP-585
TEST=auto

Disabled eval on a local site. Verified that I could still interact with the
SearchBar.