### PR TITLE
WIP.

### DIFF
--- a/conf/i18n/translations/fr-FR.po
+++ b/conf/i18n/translations/fr-FR.po
@@ -1,0 +1,42 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: i18next-conv\n"
+"mime-version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1)\n"
+"POT-Creation-Date: 2020-08-04T20:43:15.907Z\n"
+"PO-Revision-Date: 2020-08-04T20:43:15.907Z\n"
+"Language: fr\n"
+
+msgid "Item"
+msgid_plural "Item"
+msgstr[0] "Article"
+msgstr[1] "Articles"
+
+msgid "Hello {{name}}"
+msgstr "Bonjour {{name}}"
+
+msgid "Unfortunately search engines don't always work in your&nbsp;favor.<br/><br/><span class=\"fw-bold\">{{name}}</span> can."
+msgstr "Malheureusement, l'expérience de recherche sur votre site laisse la plupart des questions&nbsp;sans réponse.​<br/>​​<br/>​​<span class=\"fw-bold\">{{name}}</span>​ peut."
+
+msgid "There is {{count}} item {{name}}"
+msgid_plural "There are {{count}} items {{name}}"
+msgstr[0] "Il y a {{count}} article {{name}}"
+msgstr[1] "Il y a {{count}} articles {{name}}"
+
+msgctxt "male"
+msgid "Child"
+msgstr "fils"
+
+msgctxt "female"
+msgid "Child"
+msgstr "fille"
+
+msgctxt "male"
+msgid "I am looking for my child named {{name}}"
+msgstr "Je cherche mon fils nommé {{name}}"
+
+msgctxt "female"
+msgid "I am looking for my child named {{name}}"
+msgstr "Je cherche mon fille nommé {{name}}"

--- a/src/ui/components/cards/standardcardcomponent.js
+++ b/src/ui/components/cards/standardcardcomponent.js
@@ -160,6 +160,7 @@ export default class StandardCardComponent extends Component {
         ? `${this._config.details.substring(0, this._config.showMoreLimit)}...`
         : this._config.details;
     }
+    const temp = translatePluralJS("There is {{count}} item {{name}}", "There are {{count}} items {{name}}", this._config.details.length, { name: this._config.title });
     return super.setState({
       ...data,
       hideExcessDetails: this.hideExcessDetails,
@@ -167,7 +168,8 @@ export default class StandardCardComponent extends Component {
       hasCTAs: CTACollectionComponent.hasCTAs(this.result._raw, this._config.callsToAction),
       entityId: this.result._raw.id,
       verticalKey: this.verticalKey,
-      details
+      details,
+      translatedText: temp
     });
   }
 

--- a/src/ui/templates/cards/standard.hbs
+++ b/src/ui/templates/cards/standard.hbs
@@ -60,6 +60,9 @@
 
 {{#*inline "content"}}
   <div class="yxt-StandardCard-content">
+    <div class="yxt-translated-text">
+      {{translatedText}}
+    </div>
     {{> details}}
     {{> ctas}}
   </div>


### PR DESCRIPTION
This WIP shows how I got run-time translations working in a Component. It outlines how I thought we'd go about run-time translations in JS. Basically, we use the gulp replace plugin to find usages of a method: translateJS, translatePluralJS, translateWithContextJS, translatePluralWithContextJS. For each usage, we'd create a TranslationPlaceholder, then resolve it with the TranslationResolver. This WIP is by no means a complete accounting of this. I hard-coded things, made assumptions, etc. It's meant as a POC. 

As you work on this stuff, take a critical eye to everything you do. Are there ways we can improve this approach, is it missing things, is it clunky, etc.

I think we can follow a similar pathway for building the SDK template bundles as well. Look for instances of a method with gulp replace and use the TranslationResolver to slap in the correct run-time call. 