### PR TITLE
Create deep copies of Component state using lodash.cloneDeep.

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -5,7 +5,7 @@ module.exports = [
   },
   {
     path: 'dist/answers-modern.min.js',
-    limit: '100kb'
+    limit: '105kb'
   },
   {
     path: 'dist/answerstemplates.compiled.min.js',

--- a/package-lock.json
+++ b/package-lock.json
@@ -10506,6 +10506,11 @@
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+    },
     "lodash.escape": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "handlebars": "^4.7.2",
     "js-levenshtein": "^1.1.6",
     "kind-of": "^6.0.3",
+    "lodash.clonedeep": "^4.5.0",
     "markdown-it-for-inline": "^0.1.1",
     "regenerator-runtime": "^0.13.3",
     "template-helpers": "^1.0.1"

--- a/src/ui/components/component.js
+++ b/src/ui/components/component.js
@@ -1,5 +1,7 @@
 /** @module Component */
 
+import cloneDeep from 'lodash.clonedeep';
+
 import { Renderers } from '../rendering/const';
 
 import DOM from '../dom/dom';
@@ -342,7 +344,7 @@ export default class Component {
     // Process the DOM to determine if we should create
     // in-memory sub-components for rendering
     const domComponents = DOM.queryAll(this._container, '[data-component]:not([data-is-component-mounted])');
-    const data = this.transformData(JSON.parse(JSON.stringify(this._state.get())));
+    const data = this.transformData(cloneDeep(this._state.get()));
     domComponents.forEach(c => this._createSubcomponent(c, data));
 
     this._children.forEach(child => {
@@ -369,7 +371,7 @@ export default class Component {
   render (data = this._state.get()) {
     this.beforeRender();
     // Temporary fix for passing immutable data to transformData().
-    data = this.transformData(JSON.parse(JSON.stringify(data)));
+    data = this.transformData(cloneDeep(data));
 
     let html = '';
     // Use either the custom render function or the internal renderer


### PR DESCRIPTION
This PR updates the Component class so that copies of the state, made prior
to calls to transformData, are made with lodash.cloneDeep. Previously, copies
were made using JSON.parse(JSON.stringify). This old approach had some issues.
For starters, it is limited by what JSON can serialize intelligently. Second,
if the object has a circular structure, JSON serialization will fail. We found
that when the SearchBar's container was managed with React, its child
components had a state with a circular strucutre. This caused errors when
trying to make copies of their state. Effectively, this blocked the SDK from
being used with React.

The lodash.cloneDeep method is able to handle circular structures by default.
It is also not limited by what can be serialized intelligibly with JSON.

J=SLAP-572
TEST=auto,manual

Reran all unit tests. Created a test site where the SearchBar's container was
created by React. The SearchBar redirected to an iframe'd experience. I was
able to use the SearchBar and all its child components without issue. As a
sanity check, I recreated the same site without React to ensure that worked
as expected.

To test that the cloneDeep worked as anticipated, I added some print statements
to the SDK. These ensured that I was not altering component state when using
transformData. I was operating of a full copy.