### PR TITLE
Add translation extractor

### DIFF
--- a/conf/gulp-tasks/bundle/bundle.js
+++ b/conf/gulp-tasks/bundle/bundle.js
@@ -8,6 +8,7 @@ const replace = require('gulp-replace');
 const resolve = require('rollup-plugin-node-resolve');
 const rollup = require('gulp-rollup-lightweight');
 const source = require('vinyl-source-stream');
+const { TRANSLATION_FLAGGER_REGEX } = require('../../i18n/constants');
 
 const TranslateCallParser = require('../../i18n/translatecallparser');
 const TranslationResolver = require('../../i18n/translationresolver');
@@ -115,7 +116,7 @@ function _buildBundle (callback, rollupConfig, bundleName, locale, libVersion, t
     .pipe(source(`${bundleName}.js`))
     .pipe(replace('@@LIB_VERSION', libVersion))
     .pipe(replace('@@LOCALE', locale))
-    .pipe(replace(/TranslationFlagger.flag\([^;]+?\)/g, translateCall => {
+    .pipe(replace(TRANSLATION_FLAGGER_REGEX, translateCall => {
       const placeholder = new TranslateCallParser().parse(translateCall);
       const translationResult = translationResolver.resolve(placeholder);
       const canBeTranslatedStatically = typeof translationResult === 'string'

--- a/conf/gulp-tasks/extracttranslations.gulpfile.js
+++ b/conf/gulp-tasks/extracttranslations.gulpfile.js
@@ -1,0 +1,33 @@
+const { src } = require('gulp');
+const { Transform } = require('readable-stream');
+const path = require('path');
+const TranslationExtractor = require('../i18n/extract/translationextractor');
+
+module.exports = function precompileTemplates (callback) {
+  const extractor = new TranslationExtractor();
+
+  const transform = new Transform({
+    objectMode: true,
+    transform (chunk, encoding, callback) {
+      const contents = chunk.contents.toString();
+      const extname = path.extname(chunk.path);
+      const pathFromBase = path.relative('./', chunk.path);
+      switch (extname) {
+        case '.js':
+          extractor.extractFromJS(contents, pathFromBase);
+          break;
+        case '.hbs':
+          extractor.extractFromHBS(contents, pathFromBase);
+          break;
+      }
+      callback();
+    }
+  });
+
+  const templatesStream = src(['./src/ui/templates/**/*.hbs', './src/**/*.js'])
+    .pipe(transform)
+    .on('end', () => {
+      extractor.savePotFile('./conf/i18n/translations/messages.pot');
+    });
+  return templatesStream;
+};

--- a/conf/gulp-tasks/extracttranslations.gulpfile.js
+++ b/conf/gulp-tasks/extracttranslations.gulpfile.js
@@ -7,26 +7,16 @@ module.exports = function extractTranslations () {
   const extractor = new TranslationExtractor();
 
   /**
-   * Extracts messages from a given source file.
-   * 
-   * @param {vinyl.File} file 
-   * @param {string} encoding 
-   * @param {Function} next 
+   * Extracts messages from a given source file into the extractor.
+   *
+   * @param {vinyl.File} file
+   * @param {string} encoding
+   * @param {Function} next
    */
-  function extractMessagesFromFile(file, encoding, next) {
+  function extractMessagesFromFile (file, encoding, next) {
     const contents = file.contents.toString();
-    const extname = path.extname(file.path);
     const pathFromBase = path.relative('./', file.path);
-    switch (extname) {
-      case '.js':
-        extractor.extractFromJS(contents, pathFromBase);
-        break;
-      case '.hbs':
-        extractor.extractFromHBS(contents, pathFromBase);
-        break;
-      default: 
-        throw new Error(`Unknown file extension for ${pathFromBase}`);
-    }
+    extractor.extract(contents, pathFromBase);
     next();
   }
 

--- a/conf/gulp-tasks/extracttranslations.gulpfile.js
+++ b/conf/gulp-tasks/extracttranslations.gulpfile.js
@@ -1,33 +1,43 @@
 const { src } = require('gulp');
-const { Transform } = require('readable-stream');
+const { Writable } = require('stream');
 const path = require('path');
 const TranslationExtractor = require('../i18n/extract/translationextractor');
 
-module.exports = function precompileTemplates (callback) {
+module.exports = function extractTranslations () {
   const extractor = new TranslationExtractor();
 
-  const transform = new Transform({
-    objectMode: true,
-    transform (chunk, encoding, callback) {
-      const contents = chunk.contents.toString();
-      const extname = path.extname(chunk.path);
-      const pathFromBase = path.relative('./', chunk.path);
-      switch (extname) {
-        case '.js':
-          extractor.extractFromJS(contents, pathFromBase);
-          break;
-        case '.hbs':
-          extractor.extractFromHBS(contents, pathFromBase);
-          break;
-      }
-      callback();
+  /**
+   * Extracts messages from a given source file.
+   * 
+   * @param {vinyl.File} file 
+   * @param {string} encoding 
+   * @param {Function} next 
+   */
+  function extractMessagesFromFile(file, encoding, next) {
+    const contents = file.contents.toString();
+    const extname = path.extname(file.path);
+    const pathFromBase = path.relative('./', file.path);
+    switch (extname) {
+      case '.js':
+        extractor.extractFromJS(contents, pathFromBase);
+        break;
+      case '.hbs':
+        extractor.extractFromHBS(contents, pathFromBase);
+        break;
+      default: 
+        throw new Error(`Unknown file extension for ${pathFromBase}`);
     }
+    next();
+  }
+
+  const processSourceFiles = new Writable({
+    objectMode: true,
+    write: extractMessagesFromFile
   });
 
-  const templatesStream = src(['./src/ui/templates/**/*.hbs', './src/**/*.js'])
-    .pipe(transform)
-    .on('end', () => {
+  return src(['./src/ui/templates/**/*.hbs', './src/**/*.js'])
+    .pipe(processSourceFiles)
+    .on('finish', () => {
       extractor.savePotFile('./conf/i18n/translations/messages.pot');
     });
-  return templatesStream;
 };

--- a/conf/i18n/constants.js
+++ b/conf/i18n/constants.js
@@ -1,3 +1,5 @@
 exports.DEV_LOCALE = 'en';
 
 exports.BUILD_LOCALES = ['en'];
+
+exports.TRANSLATION_FLAGGER_REGEX = /TranslationFlagger.flag\([^;]+?\)/g;

--- a/conf/i18n/extract/hbsplaceholderparser.js
+++ b/conf/i18n/extract/hbsplaceholderparser.js
@@ -1,0 +1,48 @@
+const Handlebars = require('handlebars');
+
+const { fromMustacheStatementNode } = require('../translationplaceholderutils');
+
+class HbsPlaceholderParser {
+  constructor () {
+    this._translateHelpers = ['translate'];
+  }
+
+  /**
+   * Parses {@link TranslationPlaceholder}s from a given hbs template.
+   *
+   * @param {string} template
+   * @param {string} filepath
+   * @returns {Array<TranslationPlaceholder>}
+   */
+  parse (template, filepath) {
+    const tree = Handlebars.parseWithoutProcessing(template);
+    const visitor = new Handlebars.Visitor();
+    const placeholderAccumulator = [];
+    visitor.MustacheStatement = statement => {
+      const placeholder = this._parseFromMustacheNode(statement, filepath);
+      if (placeholder) {
+        placeholderAccumulator.push(placeholder);
+      }
+    };
+    visitor.accept(tree);
+    return placeholderAccumulator;
+  }
+
+  /**
+   * Parses a {@link TranslationPlaceholder} from a single MustacheStatement.
+   *
+   * @param {hbs.AST.MustacheStatement} statement
+   * @param {string} filepath
+   * @returns {TranslationPlaceholder}
+   */
+  _parseFromMustacheNode (statement, filepath) {
+    const isTranslationHelper = this._translateHelpers.includes(statement.path.original);
+    if (!isTranslationHelper) {
+      return;
+    }
+    const placeholder = fromMustacheStatementNode(statement, filepath);
+    return placeholder;
+  }
+}
+
+module.exports = HbsPlaceholderParser;

--- a/conf/i18n/extract/jsplaceholderparser.js
+++ b/conf/i18n/extract/jsplaceholderparser.js
@@ -1,0 +1,33 @@
+const TranslateCallParser = require('../translatecallparser');
+const { TRANSLATION_FLAGGER_REGEX } = require('../constants');
+
+class JsPlaceholderParser {
+  /**
+   * Parses {@link TranslationPlaceholder}s from javascript code.
+   *
+   * @param {string} code
+   * @param {string} filepath
+   * @returns {Array<TranslationPlaceholder>}
+   */
+  parse (code, filepath) {
+    const matches = [...code.matchAll(TRANSLATION_FLAGGER_REGEX)];
+    return matches.map(match => this._parseJsCall(match, filepath));
+  }
+
+  /**
+   * Parses a {@link TranslationPlacehodler} from a regex match.
+   *
+   * @param {Array<string>} match the regex match
+   * @param {string} filepath
+   * @returns {TranslationPlaceholder}
+   */
+  _parseJsCall (match, filepath) {
+    const { index, input } = match;
+    const translateCall = match[0];
+    const lineNumber = input.substring(0, index).match(/\n/g).length + 1;
+    const placeholder = new TranslateCallParser().parse(translateCall, lineNumber, filepath);
+    return placeholder;
+  }
+}
+
+module.exports = JsPlaceholderParser;

--- a/conf/i18n/extract/translationextractor.js
+++ b/conf/i18n/extract/translationextractor.js
@@ -1,0 +1,93 @@
+const { GettextExtractor } = require('gettext-extractor');
+const Handlebars = require('handlebars');
+const fsExtra = require('fs-extra');
+const { fromMustacheStatementNode } = require('../translationplaceholderutils');
+const { TRANSLATION_FLAGGER_REGEX } = require('../constants');
+const TranslateCallParser = require('../translatecallparser');
+
+/**
+ * TranslationExtractor extracts translation invocations from a file.
+ */
+class TranslationExtractor {
+  constructor () {
+    this._extractor = new GettextExtractor();
+    this._translateHelpers = ['translate'];
+  }
+
+  extractFromHBS (template, filepath) {
+    const tree = Handlebars.parseWithoutProcessing(template);
+    const visitor = new Handlebars.Visitor();
+    visitor.MustacheStatement = statement =>
+      this._extractFromMustacheNode(statement, filepath);
+    visitor.accept(tree);
+  }
+
+  /**
+   * @param {string} code
+   * @param {string} filepath
+   */
+  extractFromJS (code, filepath) {
+    const matches = [...code.matchAll(TRANSLATION_FLAGGER_REGEX)];
+    for (const match of matches) {
+      this._extractFromJSCall(match, filepath);
+    }
+  }
+
+  /**
+   * @param {Array<string>} match also contains additional index and input properties
+   * @param {string} filepath
+   */
+  _extractFromJSCall (match, filepath) {
+    const { index, input } = match;
+    const translateCall = match[0];
+    const lineNumber = input.substring(0, index).match(/\n/g).length + 1;
+    const placeholder = new TranslateCallParser().parse(translateCall, lineNumber);
+    this._registerTranslationPlaceholder(placeholder, filepath);
+  }
+
+  /**
+   * Returns the extracted messages as a pot file string.
+   * @returns {Array<Object>}
+   */
+  getPotString () {
+    return this._extractor.getPotString();
+  }
+
+  /**
+   * Saves the currently extracted messages to a pot file with the designed path.
+   * Creates any parent directories as necessary.
+   *
+   * @param {string} outputPath
+   */
+  savePotFile (outputPath) {
+    const parentDirectory = outputPath.substring(0, outputPath.lastIndexOf('/'));
+    parentDirectory && fsExtra.mkdirpSync(parentDirectory);
+    this._extractor.savePotFile(outputPath);
+  }
+
+  _registerTranslationPlaceholder (placeholder, filepath) {
+    this._extractor.addMessage({
+      text: placeholder.getPhrase(),
+      textPlural: placeholder.getPluralForm(),
+      context: placeholder.getContext(),
+      references: [`${filepath}:${placeholder.getLineNumber()}`]
+    });
+  }
+
+  /**
+   * Extracts translations from a given mustache node.
+   *
+   * @param {hbs.AST.MustacheStatement} statement
+   * @param {string} filepath
+   */
+  _extractFromMustacheNode (statement, filepath) {
+    const isTranslationHelper = this._translateHelpers.includes(statement.path.original);
+    if (!isTranslationHelper) {
+      return;
+    }
+    const placeholder = fromMustacheStatementNode(statement);
+    this._registerTranslationPlaceholder(placeholder, filepath);
+  }
+}
+
+module.exports = TranslationExtractor;

--- a/conf/i18n/models/translationplaceholder.js
+++ b/conf/i18n/models/translationplaceholder.js
@@ -4,13 +4,14 @@
  * or pluralization as well.
  */
 class TranslationPlaceholder {
-  constructor ({ phrase, pluralForm, context, count, interpolationValues, lineNumber }) {
+  constructor ({ phrase, pluralForm, context, count, interpolationValues, lineNumber, filepath }) {
     this._phrase = phrase;
     this._pluralForm = pluralForm;
     this._context = context;
     this._count = count;
     this._interpolationValues = interpolationValues;
     this._lineNumber = lineNumber;
+    this._filepath = filepath;
   }
 
   /**
@@ -70,6 +71,15 @@ class TranslationPlaceholder {
    */
   getLineNumber () {
     return this._lineNumber;
+  }
+
+  /**
+   * The filepath of the original source file.
+   *
+   * @returns {number}
+   */
+  getFilePath () {
+    return this._filepath;
   }
 
   /**

--- a/conf/i18n/models/translationplaceholder.js
+++ b/conf/i18n/models/translationplaceholder.js
@@ -4,12 +4,13 @@
  * or pluralization as well.
  */
 class TranslationPlaceholder {
-  constructor ({ phrase, pluralForm, context, count, interpolationValues }) {
+  constructor ({ phrase, pluralForm, context, count, interpolationValues, lineNumber }) {
     this._phrase = phrase;
     this._pluralForm = pluralForm;
     this._context = context;
     this._count = count;
     this._interpolationValues = interpolationValues;
+    this._lineNumber = lineNumber;
   }
 
   /**
@@ -60,6 +61,15 @@ class TranslationPlaceholder {
    */
   getInterpolationValues () {
     return this._interpolationValues;
+  }
+
+  /**
+   * The line number of this translation placeholder in its source file.
+   *
+   * @returns {number}
+   */
+  getLineNumber () {
+    return this._lineNumber;
   }
 
   /**

--- a/conf/i18n/translatecallparser.js
+++ b/conf/i18n/translatecallparser.js
@@ -56,7 +56,7 @@ class TranslateCallParser {
    */
   _parseParams (str) {
     const paramRegex =
-      /[a-zA-Z0-9]+:[\s]*((['"`][a-zA-Z\s\d[\].]+['"`])|\d+|([a-zA-Z\d_.]+))/g;
+      /[a-zA-Z0-9]+:[\s]*((['"`][^'"`]+['"`])|\d+|([a-zA-Z\d_.]+))/g;
     return (str.match(paramRegex) || [])
       .reduce((accumulator, params) => {
         const paramOperands = params.split(':');

--- a/conf/i18n/translatecallparser.js
+++ b/conf/i18n/translatecallparser.js
@@ -10,10 +10,11 @@ class TranslateCallParser {
    * to return a {@link TranslationPlaceholder}
    *
    * @param {string} translateCall
-   * @param {number}
+   * @param {number} lineNumber
+   * @param {string} filepath
    * @returns {TranslationPlaceholder}
    */
-  parse (translateCall, lineNumber) {
+  parse (translateCall, lineNumber, filepath) {
     const parsedTranslateCall = this._convertToObject(translateCall);
 
     return new TranslationPlaceholder({
@@ -22,7 +23,8 @@ class TranslateCallParser {
       count: parsedTranslateCall.count,
       context: parsedTranslateCall.context,
       interpolationValues: parsedTranslateCall.interpolationValues,
-      lineNumber: lineNumber
+      lineNumber: lineNumber,
+      filepath: filepath
     });
   }
 

--- a/conf/i18n/translatecallparser.js
+++ b/conf/i18n/translatecallparser.js
@@ -10,17 +10,19 @@ class TranslateCallParser {
    * to return a {@link TranslationPlaceholder}
    *
    * @param {string} translateCall
+   * @param {number}
    * @returns {TranslationPlaceholder}
    */
-  parse (translateCall) {
+  parse (translateCall, lineNumber) {
     const parsedTranslateCall = this._convertToObject(translateCall);
 
     return new TranslationPlaceholder({
       phrase: parsedTranslateCall.phrase,
-      pluralPhrase: parsedTranslateCall.pluralPhrase,
+      pluralForm: parsedTranslateCall.pluralForm,
       count: parsedTranslateCall.count,
       context: parsedTranslateCall.context,
-      interpolationValues: parsedTranslateCall.interpolationValues
+      interpolationValues: parsedTranslateCall.interpolationValues,
+      lineNumber: lineNumber
     });
   }
 

--- a/conf/i18n/translationplaceholderutils.js
+++ b/conf/i18n/translationplaceholderutils.js
@@ -9,12 +9,14 @@ function fromMustacheStatementNode (mustacheStatement) {
   const params = _convertHashPairsToParamsMap(hashPairs);
   // Exclude phrase, pluralForm, and context (but not count) from interpolationValues.
   const { phrase, pluralForm, context, ...interpolationValues } = params;
+  const lineNumber = mustacheStatement.loc.start.line;
   return new TranslationPlaceholder({
     phrase: phrase,
     pluralForm: pluralForm,
     context: context,
     count: params.count,
-    interpolationValues: interpolationValues
+    interpolationValues: interpolationValues,
+    lineNumber: lineNumber
   });
 }
 

--- a/conf/i18n/translationplaceholderutils.js
+++ b/conf/i18n/translationplaceholderutils.js
@@ -3,8 +3,9 @@ const TranslationPlaceholder = require('./models/translationplaceholder');
 /**
  * Creates a {@link TranslateInvocation} from a Handlebars MustacheStatement.
  * @param {hbs.AST.MustacheStatement} mustacheStatement
+ * @param {string} filepath
  */
-function fromMustacheStatementNode (mustacheStatement) {
+function fromMustacheStatementNode (mustacheStatement, filepath) {
   const hashPairs = mustacheStatement.hash.pairs;
   const params = _convertHashPairsToParamsMap(hashPairs);
   // Exclude phrase, pluralForm, and context (but not count) from interpolationValues.
@@ -16,7 +17,8 @@ function fromMustacheStatementNode (mustacheStatement) {
     context: context,
     count: params.count,
     interpolationValues: interpolationValues,
-    lineNumber: lineNumber
+    lineNumber: lineNumber,
+    filepath: filepath
   });
 }
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,6 +2,7 @@ const { parallel } = require('gulp');
 
 const templates = require('./conf/gulp-tasks/templates.gulpfile.js');
 const library = require('./conf/gulp-tasks/library.gulpfile.js');
+const extractTranslations = require('./conf/gulp-tasks/extracttranslations.gulpfile.js');
 
 exports.default = exports.build = parallel(
   templates.default,
@@ -11,3 +12,4 @@ exports.dev = parallel(
   templates.dev,
   library.dev
 );
+exports.extractTranslations = extractTranslations;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1681,6 +1681,12 @@
       "integrity": "sha512-wa09itaLE8L705aXd8F80jnFpxz3Y1/KRHfKsYL2bPc0XF+wEWu8sR9n5bmeu8Ba1N9z2GRNzm/YdHcghLkLKg==",
       "dev": true
     },
+    "@types/parse5": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-5.0.3.tgz",
+      "integrity": "sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==",
+      "dev": true
+    },
     "@types/q": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
@@ -2635,6 +2641,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
       "dev": true
     },
     "atob": {
@@ -5300,6 +5312,12 @@
       "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==",
       "dev": true
     },
+    "css-selector-parser": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-1.4.1.tgz",
+      "integrity": "sha512-HYPSb7y/Z7BNDCOrakL4raGO2zltZkbeXyAd6Tg9obzix6QhzxCotdBl6VT0Dv4vZfJGVz3WL/xaEI9Ly3ul0g==",
+      "dev": true
+    },
     "css-selector-tokenizer": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.1.tgz",
@@ -7558,6 +7576,26 @@
         "readable-stream": "^2.0.0"
       }
     },
+    "fs-extra": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+      "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+      "dev": true,
+      "requires": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^1.0.0"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+          "dev": true
+        }
+      }
+    },
     "fs-mkdirp-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
@@ -7818,6 +7856,29 @@
       "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
+      }
+    },
+    "gettext-extractor": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/gettext-extractor/-/gettext-extractor-3.5.2.tgz",
+      "integrity": "sha512-4fJViJvAkWBUV8BHwAaY2T1oirsIEAYgYfYm/+x/gF2xWxOXgn4f7Cjsdq+xuuoA9HZga+fx2PIDP+07zbmP6g==",
+      "dev": true,
+      "requires": {
+        "@types/glob": "5 - 7",
+        "@types/parse5": "^5",
+        "css-selector-parser": "^1.3",
+        "glob": "5 - 7",
+        "parse5": "^5",
+        "pofile": "1.0.x",
+        "typescript": "2 - 3"
+      },
+      "dependencies": {
+        "parse5": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+          "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+          "dev": true
+        }
       }
     },
     "gettext-parser": {
@@ -10531,6 +10592,16 @@
         "minimist": "^1.2.0"
       }
     },
+    "jsonfile": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+      "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^1.0.0"
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -12826,6 +12897,12 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
       "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
+      "dev": true
+    },
+    "pofile": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pofile/-/pofile-1.0.11.tgz",
+      "integrity": "sha512-Vy9eH1dRD9wHjYt/QqXcTz+RnX/zg53xK+KljFSX30PvdDMb2z+c6uDUeblUGqqJgz3QFsdlA0IJvHziPmWtQg==",
       "dev": true
     },
     "posix-character-classes": {
@@ -17453,6 +17530,12 @@
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "through2-filter": "^3.0.0"
       }
+    },
+    "universalify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+      "dev": true
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "cssnano": "^4.1.10",
     "del": "^5.1.0",
     "enzyme": "^3.11.0",
+    "fs-extra": "^9.0.1",
+    "gettext-extractor": "^3.5.2",
     "gulp": "^4.0.1",
     "gulp-concat": "^2.6.1",
     "gulp-declare": "^0.3.0",
@@ -69,7 +71,8 @@
     "test": "semistandard && jest",
     "acceptance": "testcafe safari,chrome tests/acceptance/acceptancesuite.js",
     "size": "size-limit",
-    "fix": "semistandard --fix"
+    "fix": "semistandard --fix",
+    "extract-translations": "gulp extractTranslations"
   },
   "jest": {
     "bail": 0,


### PR DESCRIPTION
This commit adds the npm script extract-translations, which
extracts sdk translations to a .pot file. Under the hood, gulp is used
to stream source files to an extractor class, which extracts messages
to an instance of gettext-extractor, which manages creation of the
actual .pot file. Also tweaked the js regex to allow for **most** punctuation
(for some reason colons still do not work)

TEST=manual

tested plain translation, translation with interpolation, translation with context, 
and plural translation with context for both js and hbs
