### PR TITLE
Add translation wrappers in hbs

### DIFF
--- a/conf/i18n/translatehelpervisitor.js
+++ b/conf/i18n/translatehelpervisitor.js
@@ -36,10 +36,12 @@ class TranslateHelperVisitor {
    * Returning undefined leaves the node unaffected, otherwise it replaces it with the
    * returned value.
    *
-   * @param {hbs.AST.MustacheStatement} statement
-   * @returns {hbs.AST.MustacheStatment|undefined} Either the new node, or undefined to leave the node as is
+   * @param {hbs.AST.MustacheStatement} handlebarsStatement
+   * @returns {hbs.AST.MustacheStatement|undefined} Either the new node, or undefined to leave the node as is
    */
-  _handleMustacheStatement (statement) {
+  _handleMustacheStatement (handlebarsStatement) {
+    const statement = handlebarsStatement;
+    statement.escaped = false;
     const isTranslationHelper = this._validHelpers.includes(statement.path.original);
     if (!isTranslationHelper) {
       return;

--- a/conf/i18n/translatehelpervisitor.js
+++ b/conf/i18n/translatehelpervisitor.js
@@ -44,16 +44,15 @@ class TranslateHelperVisitor {
     if (!isTranslationHelper) {
       return;
     }
-    const translationHelper = statement;
-    translationHelper.escaped = false;
-    const placeholder = fromMustacheStatementNode(translationHelper);
+    statement.escaped = false;
+    const placeholder = fromMustacheStatementNode(statement);
     const translatedPhrase = this._translationResolver.resolve(placeholder);
     const canBeTranslatedStatically =
       typeof translatedPhrase === 'string' && placeholder.hasNoInterpolation();
     if (canBeTranslatedStatically) {
-      return this._replaceHelperWithStaticTranslation(translationHelper, translatedPhrase);
+      return this._replaceHelperWithStaticTranslation(statement, translatedPhrase);
     } else {
-      const renamedStatement = this._renameHelperToRuntimeTranslation(translationHelper);
+      const renamedStatement = this._renameHelperToRuntimeTranslation(statement);
       return this._updateHashPairsForRuntimeTranslations(renamedStatement, translatedPhrase);
     }
   }

--- a/conf/i18n/translatehelpervisitor.js
+++ b/conf/i18n/translatehelpervisitor.js
@@ -36,24 +36,24 @@ class TranslateHelperVisitor {
    * Returning undefined leaves the node unaffected, otherwise it replaces it with the
    * returned value.
    *
-   * @param {hbs.AST.MustacheStatement} handlebarsStatement
+   * @param {hbs.AST.MustacheStatement} statement
    * @returns {hbs.AST.MustacheStatement|undefined} Either the new node, or undefined to leave the node as is
    */
-  _handleMustacheStatement (handlebarsStatement) {
-    const statement = handlebarsStatement;
-    statement.escaped = false;
+  _handleMustacheStatement (statement) {
     const isTranslationHelper = this._validHelpers.includes(statement.path.original);
     if (!isTranslationHelper) {
       return;
     }
-    const placeholder = fromMustacheStatementNode(statement);
+    const translationHelper = statement;
+    translationHelper.escaped = false;
+    const placeholder = fromMustacheStatementNode(translationHelper);
     const translatedPhrase = this._translationResolver.resolve(placeholder);
     const canBeTranslatedStatically =
       typeof translatedPhrase === 'string' && placeholder.hasNoInterpolation();
     if (canBeTranslatedStatically) {
-      return this._replaceHelperWithStaticTranslation(statement, translatedPhrase);
+      return this._replaceHelperWithStaticTranslation(translationHelper, translatedPhrase);
     } else {
-      const renamedStatement = this._renameHelperToRuntimeTranslation(statement);
+      const renamedStatement = this._renameHelperToRuntimeTranslation(translationHelper);
       return this._updateHashPairsForRuntimeTranslations(renamedStatement, translatedPhrase);
     }
   }

--- a/conf/i18n/translator.js
+++ b/conf/i18n/translator.js
@@ -154,6 +154,8 @@ class Translator {
     await i18nextInstance.init({
       lng: locale,
       fallbackLng: fallbacks,
+      nsSeparator: false, // Allow phrases to contain ':'
+      keySeparator: false, // Allow phrases to contain '.'
       resources: translations
     });
     const translator = new Translator(i18nextInstance);

--- a/src/ui/templates/cards/standard.hbs
+++ b/src/ui/templates/cards/standard.hbs
@@ -21,7 +21,7 @@
 
 {{#*inline "image"}}
   {{#if _config.image}}
-    <div class="yxt-StandardCard-img" style="background-image: url('{{_config.image}}');" role="img" aria-label="Image for {{_config.title}}">
+    <div class="yxt-StandardCard-img" style="background-image: url('{{_config.image}}');" role="img" aria-label="{{translate phrase='Image for [[title]]' title=_config.title }}">
       {{#if _config.tagLabel}}
         <div class="yxt-StandardCard-imgTagWrapper">
           <div class="yxt-StandardCard-imgTag">{{_config.tagLabel}}</div>
@@ -51,7 +51,7 @@
       <div class="yxt-StandardCard-title">{{{_config.title}}}</div>
     {{/if}}
   {{/if}}
-  {{#if _config.subtitle}}  
+  {{#if _config.subtitle}}
     <div class="yxt-StandardCard-subtitle">
       {{{_config.subtitle}}}
     </div>
@@ -77,7 +77,7 @@
             {{_config.showMoreText}}
             <span data-component="IconComponent"
               data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseDown" }'></span>
-          {{else}} 
+          {{else}}
             {{_config.showLessText}}
             <span data-component="IconComponent"
               data-opts='{ "iconName": "chevron", "classNames": "Icon--sm Icon-collapseUp" }'></span>

--- a/src/ui/templates/questions/questionsubmission.hbs
+++ b/src/ui/templates/questions/questionsubmission.hbs
@@ -4,7 +4,7 @@
   <button
     class="yxt-QuestionSubmission-titleBar js-content-visibility-toggle"
     tabindex="0"
-    aria-label="expand question form"
+    aria-label="{{translate phrase='expand question form' }}"
     aria-controls="yxt-QuestionSubmission-form-{{name}}"
     aria-expanded="{{#if questionExpanded}}true{{else}}false{{/if}}">
     <div class="yxt-QuestionSubmission-left">

--- a/src/ui/templates/results/alternativeverticals.hbs
+++ b/src/ui/templates/results/alternativeverticals.hbs
@@ -29,7 +29,7 @@
                   {{label}}
                 </span>
                 <span class="yxt-AlternativeVerticals-suggestionLink--copyResults">
-                  {{translate phrase='([[resultsCount]]) result' pluralForm='([[resultsCount]]) results' count=resultsCount resultsCount=resultsCount }}
+                  {{translate phrase='([[resultsCount]] result)' pluralForm='([[resultsCount]] results)' count=resultsCount resultsCount=resultsCount }}
                 </span>
               </div>
               <div class="yxt-AlternativeVerticals-arrowIconWrapper"

--- a/src/ui/templates/results/alternativeverticals.hbs
+++ b/src/ui/templates/results/alternativeverticals.hbs
@@ -29,7 +29,7 @@
                   {{label}}
                 </span>
                 <span class="yxt-AlternativeVerticals-suggestionLink--copyResults">
-                  {{translate phrase='([[resultsCount]]) result' pluralForm='([[resultsCount]]) results' resultsCount=resultsCount }}
+                  {{translate phrase='([[resultsCount]]) result' pluralForm='([[resultsCount]]) results' count=resultsCount resultsCount=resultsCount }}
                 </span>
               </div>
               <div class="yxt-AlternativeVerticals-arrowIconWrapper"

--- a/src/ui/templates/results/alternativeverticals.hbs
+++ b/src/ui/templates/results/alternativeverticals.hbs
@@ -1,6 +1,6 @@
 <div class="yxt-AlternativeVerticals{{#unless isShowingResults}} yxt-AlternativeVerticals--notShowingResults{{/unless}}">
   <div class="yxt-AlternativeVerticals-noResultsInfo">
-    {{translate phrase='<em class="yxt-AlternativeVerticals-noResultsInfo--emphasized">No results found</em>in [[currentVerticalLabel]].' currentVerticalLabel=currentVerticalLabel }}
+    {{translate phrase='<em class="yxt-AlternativeVerticals-noResultsInfo--emphasized">No results found</em> in [[currentVerticalLabel]].' currentVerticalLabel=currentVerticalLabel }}
     {{#if isShowingResults}}
       {{translate phrase='Showing <em class="yxt-AlternativeVerticals-noResultsInfo--emphasized">all [[currentVerticalLabel]]</em> instead.' currentVerticalLabel=currentVerticalLabel }}
     {{/if}}

--- a/src/ui/templates/results/alternativeverticals.hbs
+++ b/src/ui/templates/results/alternativeverticals.hbs
@@ -1,28 +1,14 @@
 <div class="yxt-AlternativeVerticals{{#unless isShowingResults}} yxt-AlternativeVerticals--notShowingResults{{/unless}}">
   <div class="yxt-AlternativeVerticals-noResultsInfo">
-    <em class="yxt-AlternativeVerticals-noResultsInfo--emphasized">
-      No results found
-    </em>
-    in {{currentVerticalLabel}}.
+    {{translate phrase='<em class="yxt-AlternativeVerticals-noResultsInfo--emphasized">No results found</em>in [[currentVerticalLabel]].' currentVerticalLabel=currentVerticalLabel }}
     {{#if isShowingResults}}
-      Showing
-      <em class="yxt-AlternativeVerticals-noResultsInfo--emphasized">
-        all {{currentVerticalLabel}}
-      </em>
-      instead.
+      {{translate phrase='Showing <em class="yxt-AlternativeVerticals-noResultsInfo--emphasized">all [[currentVerticalLabel]]</em> instead.' currentVerticalLabel=currentVerticalLabel }}
     {{/if}}
   </div>
   {{#if verticalSuggestions}}
     <div class="yxt-AlternativeVerticals-suggestionsWrapper">
       <div class="yxt-AlternativeVerticals-details">
-        The following search
-        {{plural verticalSuggestions.length 'category' 'categories'}}
-        yielded results
-        {{#if query}}
-          for
-          <span class="yxt-AlternativeVerticals-details--query">
-            "{{query}}"</span>:
-        {{/if}}
+        {{translate phrase='The following search category yielded results for <span class="yxt-AlternativeVerticals-details--query">[[query]]</span>:' pluralForm='The following search categories yielded results for <span class="yxt-AlternativeVerticals-details--query">[[query]]</span>:' count=verticalSuggestions.length query=query }}
       </div>
       <ul class="yxt-AlternativeVerticals-suggestionsList">
         {{#each verticalSuggestions}}
@@ -43,7 +29,7 @@
                   {{label}}
                 </span>
                 <span class="yxt-AlternativeVerticals-suggestionLink--copyResults">
-                  ({{resultsCount}} {{plural resultsCount 'result' 'results'}})
+                  {{translate phrase='([[resultsCount]]) result' pluralForm='([[resultsCount]]) results' resultsCount=resultsCount }}
                 </span>
               </div>
               <div class="yxt-AlternativeVerticals-arrowIconWrapper"
@@ -58,10 +44,7 @@
       </ul>
       {{#if universalUrl}}
         <div class="yxt-AlternativeVerticals-universalDetails">
-          Alternatively, you can
-          <a class="yxt-AlternativeVerticals-universalLink"
-             href={{universalUrl}}>
-            view results across all search categories</a>.
+          {{translate phrase='Alternatively, you can <a class="yxt-AlternativeVerticals-universalLink" href="[[universalUrl]]"> view results across all search categories</a>.' universalUrl=universalUrl }}
         </div>
       {{/if}}
     </div>

--- a/src/ui/templates/results/directanswer.hbs
+++ b/src/ui/templates/results/directanswer.hbs
@@ -79,7 +79,9 @@
                 {{_config.negativeFeedbackSrText}}
               </span>
             </label>
-            <button type="submit" class="sr-only sr-only-focusable">Send feedback</button>
+            <button type="submit" class="sr-only sr-only-focusable">
+              {{translate phrase='Send feedback' }}
+            </button>
           </form>
         {{/if}}
       </div>

--- a/src/ui/templates/results/noresults.hbs
+++ b/src/ui/templates/results/noresults.hbs
@@ -4,7 +4,7 @@
       {{#if _config.noResultsMessage}}
         {{_config.noResultsMessage}}
       {{else}}
-        Your search - <span class="yxt-NoResults-query">{{query}}</span> - did not match any answers we have.
+        {{translate phrase='Your search - <span class="yxt-NoResults-query">[[query]]</span> - did not match any answers we have.' query=query }}
       {{/if}}
     </p>
     {{#if universalUrl}}
@@ -12,7 +12,7 @@
         {{#if _config.noResultsTryUniversalMessage}}
           {{{_config.noResultsTryUniversalMessage}}}
         {{else}}
-          Try refining your query or <a href="{{universalUrl}}" class="yxt-NoResults-returnLink">search all content.</a>
+          {{translate phrase='Try refining your query or <a href="[[universalUrl]]" class="yxt-NoResults-returnLink">search all content.</a>' universalUrl=universalUrl }}
         {{/if}}
       </p>
     {{/if}}
@@ -21,17 +21,17 @@
         {{#if _config.noResultsSuggestionsTitle}}
           {{_config.noResultsSuggestionsTitle}}
         {{else}}
-          Suggestions:
+          {{translate phrase='Suggestions:' }}
         {{/if}}
       </p>
       <ul class="yxt-NoResults-suggestionsList">
         {{#each _config.noResultsSuggestions}}
           <li class="yxt-NoResults-suggestion">{{this}}</li>
         {{else}}
-          <li class="yxt-NoResults-suggestion">Make sure all words are spelled correctly.</li>
-          <li class="yxt-NoResults-suggestion">Try to ask your question a different way.</li>
-          <li class="yxt-NoResults-suggestion">Try more general words.</li>
-          <li class="yxt-NoResults-suggestion">Try fewer words.</li>
+          <li class="yxt-NoResults-suggestion">{{translate phrase='Make sure all words are spelled correctly.' }}</li>
+          <li class="yxt-NoResults-suggestion">{{translate phrase='Try to ask your question a different way.' }}</li>
+          <li class="yxt-NoResults-suggestion">{{translate phrase='Try more general words.' }}</li>
+          <li class="yxt-NoResults-suggestion">{{translate phrase='Try fewer words.' }}</li>
         {{/each}}
       </ul>
     </div>

--- a/src/ui/templates/results/pagination.hbs
+++ b/src/ui/templates/results/pagination.hbs
@@ -4,7 +4,7 @@
       <a class="yxt-Pagination-link yxt-Pagination-icon js-yxt-Pagination-first {{#unless showFirstPageButton}}yxt-Pagination--hidden{{/unless}}"
         data-eventtype="PAGINATE"
         data-eventoptions='{"currentPage":{{pageNumber}}, "newPage":1, "totalPageCount":{{maxPage}} }'
-        aria-label="Go to the first page of results"
+        aria-label="{{translate phrase='Go to the first page of results' }}"
         tabindex="0"
       >
         {{#unless icons.firstButtonIcon}}
@@ -41,7 +41,7 @@
 
     <a
       class="yxt-Pagination-link js-yxt-Pagination-link{{#unless pinnedNumbers.desktopBack}} desktop-hidden{{/unless}}{{#unless pinnedNumbers.mobileBack}} mobile-hidden{{/unless}}"
-      aria-label="Go to page 1 of results"
+      aria-label="{{translate phrase='Go to page 1 of results' }}"
       data-number="1"
       data-eventtype="PAGINATE"
       data-eventoptions='{"currentPage":{{pageNumber}}, "newPage":1, "totalPageCount":{{maxPage}} }'
@@ -56,12 +56,12 @@
 
     {{#each pageNumbers}}
       {{#if this.active}}
-        <span id="active-page" class="yxt-Pagination-page{{#if this.activeMobile}} yxt-Pagination--activeMobile{{/if}}{{#if this.activeDesktop}} yxt-Pagination--activeDesktop{{/if}}" 
-        aria-label="Currently on page {{../pageNumber}}">{{../pageLabel}} {{../pageNumber}}</span>
+        <span id="active-page" class="yxt-Pagination-page{{#if this.activeMobile}} yxt-Pagination--activeMobile{{/if}}{{#if this.activeDesktop}} yxt-Pagination--activeDesktop{{/if}}"
+        aria-label="{{translate phrase='Currently on page [[pageNumber]]' pageNumber=../pageNumber }}">{{../pageLabel}} {{../pageNumber}}</span>
       {{else}}
-        <a 
+        <a
           class="yxt-Pagination-link js-yxt-Pagination-link{{#if this.desktopHidden}} desktop-hidden{{/if}}{{#if this.mobileHidden}} mobile-hidden{{/if}}"
-          aria-label="Go to page {{this.number}} of results"
+          aria-label="{{translate phrase='Go to page {{pageNumber}} of results' pageNumber=this.number }}"
           data-number="{{this.number}}"
           data-eventtype="PAGINATE"
           data-eventoptions='{"currentPage":{{../pageNumber}}, "newPage":{{this.number}}, "totalPageCount":{{../maxPage}} }'
@@ -78,7 +78,7 @@
 
     <a
       class="yxt-Pagination-link js-yxt-Pagination-link{{#unless pinnedNumbers.desktopFront}} desktop-hidden{{/unless}}{{#unless pinnedNumbers.mobileFront}} mobile-hidden{{/unless}}"
-      aria-label="Go to page {{maxPage}} of results"
+      aria-label="{{translate phrase='Go to page [[maxPage]] of results' maxPage=maxPage }}"
       data-number="{{maxPage}}"
       tabindex="0"
     >
@@ -89,7 +89,7 @@
       {{#unless showNextPageButton}}disabled{{/unless}}
       data-eventtype="PAGINATE"
       data-eventoptions='{"currentPage":{{pageNumber}}, "newPage":{{#add pageNumber 1}}{{/add}}, "totalPageCount":{{maxPage}} }'
-      aria-label="Go to the next page of results"
+      aria-label="{{translate phrase='Go to the next page of results' }}"
       tabindex="0"
     >
       {{#unless icons.nextButtonIcon}}
@@ -106,7 +106,7 @@
       <a class="yxt-Pagination-link yxt-Pagination-icon js-yxt-Pagination-last {{#unless showLastPageButton}}yxt-Pagination--hidden{{/unless}}"
         data-eventtype="PAGINATE"
         data-eventoptions='{"currentPage":{{pageNumber}}, "newPage":{{maxPage}}, "totalPageCount":{{maxPage}} }'
-        aria-label="Go to the last page of results"
+        aria-label="{{translate phrase='Go to the last page of results' }}"
         tabindex="0"
       >
         {{#unless icons.lastButtonIcon}}

--- a/src/ui/templates/results/pagination.hbs
+++ b/src/ui/templates/results/pagination.hbs
@@ -61,7 +61,7 @@
       {{else}}
         <a
           class="yxt-Pagination-link js-yxt-Pagination-link{{#if this.desktopHidden}} desktop-hidden{{/if}}{{#if this.mobileHidden}} mobile-hidden{{/if}}"
-          aria-label="{{translate phrase='Go to page {{pageNumber}} of results' pageNumber=this.number }}"
+          aria-label="{{translate phrase='Go to page [[pageNumber]] of results' pageNumber=this.number }}"
           data-number="{{this.number}}"
           data-eventtype="PAGINATE"
           data-eventoptions='{"currentPage":{{../pageNumber}}, "newPage":{{this.number}}, "totalPageCount":{{../maxPage}} }'

--- a/src/ui/templates/results/resultsheader.hbs
+++ b/src/ui/templates/results/resultsheader.hbs
@@ -16,9 +16,9 @@
       {{{customResultsCount}}}
     {{else}}
       <div class="yxt-ResultsHeader-resultsCount"
-           aria-label="{{translate phrase='{{start}} through {{end}} of {{resultsCount}}' start=resultsCountStart end=resultsCountEnd resultsCount=resultsCount }}">
+           aria-label="{{translate phrase='[[start]] through [[end]] of [[resultsCount]]' start=resultsCountStart end=resultsCountEnd resultsCount=resultsCount }}">
         <div aria-hidden="true">
-          {{translate phrase='<span class="yxt-ResultsHeader-resultsCountStart">{{start}}</span><span class="yxt-ResultsHeader-resultsCountDash">-</span><span class="yxt-ResultsHeader-resultsCountEnd">{{end}}</span><span class="yxt-ResultsHeader-resultsCountOf">of</span><span class="yxt-ResultsHeader-resultsCountTotal">{{resultsCount}}</span>' context='Example: 1-10 of 50' start=resultsCountStart end=resultsCountEnd resultsCount=resultsCount }}
+          {{translate phrase='<span class="yxt-ResultsHeader-resultsCountStart">[[start]]</span><span class="yxt-ResultsHeader-resultsCountDash">-</span><span class="yxt-ResultsHeader-resultsCountEnd">[[end]]</span><span class="yxt-ResultsHeader-resultsCountOf">of</span><span class="yxt-ResultsHeader-resultsCountTotal">[[resultsCount]]</span>' context='Example: 1-10 of 50' start=resultsCountStart end=resultsCountEnd resultsCount=resultsCount }}
         </div>
       </div>
     {{/if}}

--- a/src/ui/templates/results/resultsheader.hbs
+++ b/src/ui/templates/results/resultsheader.hbs
@@ -18,7 +18,7 @@
       <div class="yxt-ResultsHeader-resultsCount"
            aria-label="{{translate phrase='[[start]] through [[end]] of [[resultsCount]]' start=resultsCountStart end=resultsCountEnd resultsCount=resultsCount }}">
         <div aria-hidden="true">
-          {{translate phrase='<span class="yxt-ResultsHeader-resultsCountStart">[[start]]</span><span class="yxt-ResultsHeader-resultsCountDash">-</span><span class="yxt-ResultsHeader-resultsCountEnd">[[end]]</span><span class="yxt-ResultsHeader-resultsCountOf">of</span><span class="yxt-ResultsHeader-resultsCountTotal">[[resultsCount]]</span>' context='Example: 1-10 of 50' start=resultsCountStart end=resultsCountEnd resultsCount=resultsCount }}
+          {{translate phrase='<span class="yxt-ResultsHeader-resultsCountStart">[[start]]</span> <span class="yxt-ResultsHeader-resultsCountDash">-</span> <span class="yxt-ResultsHeader-resultsCountEnd">[[end]]</span> <span class="yxt-ResultsHeader-resultsCountOf">of</span> <span class="yxt-ResultsHeader-resultsCountTotal">[[resultsCount]]</span>' context='Example: 1-10 of 50' start=resultsCountStart end=resultsCountEnd resultsCount=resultsCount }}
         </div>
       </div>
     {{/if}}

--- a/src/ui/templates/results/resultsheader.hbs
+++ b/src/ui/templates/results/resultsheader.hbs
@@ -15,13 +15,10 @@
     {{#if customResultsCount}}
       {{{customResultsCount}}}
     {{else}}
-      <div class="yxt-ResultsHeader-resultsCount" aria-label="{{resultsCountStart}} through {{resultsCountEnd}} of {{resultsCount}}">
+      <div class="yxt-ResultsHeader-resultsCount"
+           aria-label="{{translate phrase='{{start}} through {{end}} of {{resultsCount}}' start=resultsCountStart end=resultsCountEnd resultsCount=resultsCount }}">
         <div aria-hidden="true">
-          <span class="yxt-ResultsHeader-resultsCountStart">{{resultsCountStart}}</span>
-          <span class="yxt-ResultsHeader-resultsCountDash">-</span>
-          <span class="yxt-ResultsHeader-resultsCountEnd">{{resultsCountEnd}}</span>
-          <span class="yxt-ResultsHeader-resultsCountOf">of</span>
-          <span class="yxt-ResultsHeader-resultsCountTotal">{{resultsCount}}</span>
+          {{translate phrase='<span class="yxt-ResultsHeader-resultsCountStart">{{start}}</span><span class="yxt-ResultsHeader-resultsCountDash">-</span><span class="yxt-ResultsHeader-resultsCountEnd">{{end}}</span><span class="yxt-ResultsHeader-resultsCountOf">of</span><span class="yxt-ResultsHeader-resultsCountTotal">{{resultsCount}}</span>' context='Example: 1-10 of 50' start=resultsCountStart end=resultsCountEnd resultsCount=resultsCount }}
         </div>
       </div>
     {{/if}}
@@ -65,7 +62,7 @@
         {{#if _config.changeFiltersText}}
           {{_config.changeFiltersText}}
         {{else}}
-          change filters
+          {{translate phrase='change filters' }}
         {{/if}}
       </a>
     {{/every}}

--- a/src/ui/templates/results/resultsheader.hbs
+++ b/src/ui/templates/results/resultsheader.hbs
@@ -62,7 +62,7 @@
         {{#if _config.changeFiltersText}}
           {{_config.changeFiltersText}}
         {{else}}
-          {{translate phrase='change filters' }}
+          {{translate phrase='change filters' context='Change is a verb, filters are a set of fixed values or criteria that limit results' }}
         {{/if}}
       </a>
     {{/every}}

--- a/src/ui/templates/results/resultssectionheader.hbs
+++ b/src/ui/templates/results/resultssectionheader.hbs
@@ -35,7 +35,11 @@
           data-eventtype="FILTERING_WITHIN_SECTION"
           data-eventoptions='{{eventOptions}}'
         >
-          {{#if _config.changeFiltersText}}{{_config.changeFiltersText}}{{else}}{{translate phrase='change' }}{{/if}}
+          {{#if _config.changeFiltersText}}
+            {{_config.changeFiltersText}}
+          {{else}}
+            {{translate phrase='change' context='Change is a verb. Example: change filtering logic' }}
+          {{/if}}
         </a>
       {{/if}}
     {{/if}}

--- a/src/ui/templates/results/resultssectionheader.hbs
+++ b/src/ui/templates/results/resultssectionheader.hbs
@@ -35,7 +35,7 @@
           data-eventtype="FILTERING_WITHIN_SECTION"
           data-eventoptions='{{eventOptions}}'
         >
-          {{#if _config.changeFiltersText}}{{_config.changeFiltersText}}{{else}}change{{/if}}
+          {{#if _config.changeFiltersText}}{{_config.changeFiltersText}}{{else}}{{translate phrase='change' }}{{/if}}
         </a>
       {{/if}}
     {{/if}}


### PR DESCRIPTION
TEST=manual
J=SLAP-547

Test by adding all usages to the Handlebars partial for one component, then hardcoding example values in the component's `setState` for interpolation and pluralization. This is what the Handlebars file looked like:
```hbs
{{translate phrase='Image for [[title]]' title=_config.title }}
{{translate phrase='expand question form' }}
{{translate phrase='<em class="yxt-AlternativeVerticals-noResultsInfo--emphasized">No results found</em>in [[currentVerticalLabel]].' currentVerticalLabel=currentVerticalLabel }}
{{translate phrase='Showing <em class="yxt-AlternativeVerticals-noResultsInfo--emphasized">all [[currentVerticalLabel]]</em> instead.' currentVerticalLabel=currentVerticalLabel }}
{{translate phrase='The following search category yielded results for <span class="yxt-AlternativeVerticals-details--query">[[query]]</span>:' pluralForm='The following search categories yielded results for <span class="yxt-AlternativeVerticals-details--query">[[query]]</span>:' count=verticalSuggestions.length query=query }}
{{translate phrase='The following search category yielded results for <span class="yxt-AlternativeVerticals-details--query">[[query]]</span>:' pluralForm='The following search categories yielded results for <span class="yxt-AlternativeVerticals-details--query">[[query]]</span>:' count=verticalSuggestionsPlural.length query=query }}
{{translate phrase='([[resultsCount]]) result' pluralForm='([[resultsCount]]) results' count=resultsCount resultsCount=resultsCount }}
{{translate phrase='([[resultsCount]]) result' pluralForm='([[resultsCount]]) results' count=resultsCountPlural resultsCount=resultsCountPlural }}
{{translate phrase='Alternatively, you can <a class="yxt-AlternativeVerticals-universalLink" href="[[universalUrl]]"> view results across all search categories</a>.' universalUrl=universalUrl }}
{{translate phrase='Send feedback' }}
{{translate phrase='Your search - <span class="yxt-NoResults-query">[[query]]</span> - did not match any answers we have.' query=query }}
{{translate phrase='Try refining your query or <a href="[[universalUrl]]" class="yxt-NoResults-returnLink">search all content.</a>' universalUrl=universalUrl }}
{{translate phrase='Suggestions:' }}
{{translate phrase='Make sure all words are spelled correctly.' }}
{{translate phrase='Try to ask your question a different way.' }}
{{translate phrase='Try more general words.' }}
{{translate phrase='Try fewer words.' }}
{{translate phrase='Go to the first page of results' }}
{{translate phrase='Go to page 1 of results' }}
{{translate phrase='Currently on page [[pageNumber]]' pageNumber=pageNumber }}
{{translate phrase='Go to page [[pageNumber]] of results' pageNumber=pageNumber }}
{{translate phrase='Go to page [[maxPage]] of results' maxPage=maxPage }}
{{translate phrase='Go to the next page of results' }}
{{translate phrase='Go to the last page of results' }}
{{translate phrase='[[start]] through [[end]] of [[resultsCount]]' start=resultsCountStart end=resultsCountEnd resultsCount=resultsCount }}
{{translate phrase='<span class="yxt-ResultsHeader-resultsCountStart">[[start]]</span> <span class="yxt-ResultsHeader-resultsCountDash">-</span> <span class="yxt-ResultsHeader-resultsCountEnd">[[end]]</span> <span class="yxt-ResultsHeader-resultsCountOf">of</span> <span class="yxt-ResultsHeader-resultsCountTotal">[[resultsCount]]</span>' context='Example: 1-10 of 50' start=resultsCountStart end=resultsCountEnd resultsCount=resultsCountPlural }}
{{translate phrase='change filters' }}
{{translate phrase='change' }}
```

And this was the example output (same-language translation)
<img width="512" alt="Screen Shot 2020-09-02 at 1 26 52 PM" src="https://user-images.githubusercontent.com/39104038/92016204-fe091a80-ed1f-11ea-973a-19e584dfa5a3.png">
