### PR TITLE
FilterOptions: replace new Event() with DOM.trigger()

### DIFF
--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -360,10 +360,7 @@ export default class FilterOptionsComponent extends Component {
       if (clearSearchEl && searchInputEl) {
         DOM.on(clearSearchEl, 'click', event => {
           searchInputEl.value = '';
-          searchInputEl.dispatchEvent(new Event('input', {
-            'bubbles': true,
-            'cancelable': true
-          }));
+          DOM.trigger(searchInputEl, 'input');
           searchInputEl.focus();
         });
       }


### PR DESCRIPTION
The event constructor does not work in ie11, but we have an
ie11 compliant implementation with DOM.trigger()

T=https://yextops.zendesk.com/agent/tickets/348126
TEST=manual

Test that before, in browserstack ie11,
 clicking the X button in a searchable facet has console error

With code change, no console error

and that it still clears the facet search input on chrome + ie11