### PR TITLE
Unescape backticks and single quotes in parsed translation placeholders

### DIFF
--- a/conf/i18n/translatecallparser.js
+++ b/conf/i18n/translatecallparser.js
@@ -64,10 +64,13 @@ class TranslateCallParser {
         const paramOperands = params.split(/:(.+)/);
         const paramName = paramOperands[0];
 
-        // Strip the wrapper quotes (" ' or `) for string params
+        // Strip the wrapper quotes (" ' or `) for string params and unescape any other
+        // single quotes and backticks
         const paramValue = paramOperands[1] && paramOperands[1]
           .trim()
-          .replace(/(^['"`])|(['"`]$)/g, '');
+          .replace(/(^['"`])|(['"`]$)/g, '')
+          .replace('\\\'', '\'')
+          .replace('\`', '`');
         accumulator[paramName] = paramValue;
         return accumulator;
       }, {});

--- a/conf/i18n/translatecallparser.js
+++ b/conf/i18n/translatecallparser.js
@@ -70,7 +70,7 @@ class TranslateCallParser {
           .trim()
           .replace(/(^['"`])|(['"`]$)/g, '')
           .replace('\\\'', '\'')
-          .replace('\`', '`');
+          .replace('\\`', '`');
         accumulator[paramName] = paramValue;
         return accumulator;
       }, {});


### PR DESCRIPTION
Since we're parsing Javascript src and our convention is to wrap our strings in single quotes (rather than backticks or quotation marks), some of our translation placeholder phrases had backslashes before single quotes/apostrophes. For example:
```
#: src/ui/components/questions/questionsubmissioncomponent.js:87
msgid "Can\'t find what you\'re looking for? Ask a question below."
msgstr ""
```
or 
```js
ANSWERS.translateJS("Can\'t find what you\'re looking for? Ask a question below. [[interpolation]]", {interpolation:val}, undefined);
```

These backslashes aren't necessary for single quotes or backticks (' or `); but we would like to preserve them for quotation marks since that is standard in .po files and we are using quotation marks to wrap translated values. 

TEST=manual
J=none

Run `npm run build` and see the quotation marks and backticks show up without backslashes in the output [bundleName].js file. Run `npm run extract-translations` and see the the same in the messages.pot file.