### PR TITLE
Remove use-strict from js non modern js bundle

### DIFF
--- a/conf/gulp-tasks/library.gulpfile.js
+++ b/conf/gulp-tasks/library.gulpfile.js
@@ -68,7 +68,8 @@ function legacyBundleIIFE () {
   return legacyBundle({
     format: 'iife',
     name: NAMESPACE,
-    sourcemap: true
+    sourcemap: true,
+    strict: false
   },
   'answers.js'
   );
@@ -79,7 +80,8 @@ function legacyBundleUMD () {
     format: 'umd',
     name: NAMESPACE,
     export: 'default',
-    sourcemap: true
+    sourcemap: true,
+    strict: false
   },
   'answers-umd.js'
   );


### PR DESCRIPTION
By default, rollup bundles js in strict mode.
When regenerator-runtime is included in use-strict
mode, they use a Function() call (which is like
a slightly safer eval()) to initialize things.
Specifically
```js
  Function("r", "regeneratorRuntime = r")(runtime);
```
Removing use-strict mode lets regenerator runtime init
without any unsafe evals. Because strict mode
javascript is a subset of regular javascript, this
should not break any code. AFAIK there is no way
to require a script tag to be in 'use strict' mode.

T=https://yextops.zendesk.com/agent/tickets/347915
TEST=manual

tested with a local apache httpd server
added below line to .htaccess, which sets the CSP to
the same as Syncreon

also test csp with a `<meta>` tag

tested both answers.js and answers.min.js