### PR TITLE
AlternativeVerticals: add :focus styling to links

### DIFF
--- a/src/ui/sass/modules/_AlternativeVerticals.scss
+++ b/src/ui/sass/modules/_AlternativeVerticals.scss
@@ -70,11 +70,6 @@ $alternative-verticals-emphasized-font-weight: var(--yxt-font-weight-medium) !de
     }
   }
 
-  &-suggestionLink:focus, &-universalLink:focus {
-    color: var(--yxt-color-brand-primary);
-    text-decoration: underline; 
-  }
-
   &-suggestionLink {
     display: flex;
     text-decoration: none;
@@ -83,7 +78,7 @@ $alternative-verticals-emphasized-font-weight: var(--yxt-font-weight-medium) !de
       margin-right: 5px;
     }
 
-    &:hover {
+    &:hover, &:focus {
       .yxt-AlternativeVerticals-suggestionLink--copy {
         text-decoration: underline;
       }
@@ -110,7 +105,7 @@ $alternative-verticals-emphasized-font-weight: var(--yxt-font-weight-medium) !de
   &-universalLink {
     text-decoration: none;
 
-    &:hover {
+    &:hover, &:focus {
       text-decoration: underline;
     }
   }

--- a/src/ui/sass/modules/_AlternativeVerticals.scss
+++ b/src/ui/sass/modules/_AlternativeVerticals.scss
@@ -70,6 +70,11 @@ $alternative-verticals-emphasized-font-weight: var(--yxt-font-weight-medium) !de
     }
   }
 
+  &-suggestionLink:focus, &-universalLink:focus {
+    color: var(--yxt-color-brand-primary);
+    text-decoration: underline; 
+  }
+
   &-suggestionLink {
     display: flex;
     text-decoration: none;


### PR DESCRIPTION
This commit adds default :focus styling to the vertical
and universal links in AlternativeVerticals aka NoResults.

J=SLAP-588
TEST=manual

Check that I can tab over to the links, and they will show the new
styling when tabbed over to.

test that if I change the focus color to pink, the pink takes priority
over the regular text color