### PR TITLE
filteroptions: Explicitly pass replaceHistory based on facet update

### DIFF
--- a/src/ui/components/filters/filterboxcomponent.js
+++ b/src/ui/components/filters/filterboxcomponent.js
@@ -217,7 +217,7 @@ export default class FilterBoxComponent extends Component {
       this._filterComponents.push(component);
       this._filterNodes[i] = component.getFilterNode();
     }
-    this._saveFilterNodesToStorage();
+    this._saveFilterNodesToStorage(true);
 
     // Initialize apply button
     if (!this.config.searchOnChange) {
@@ -225,7 +225,7 @@ export default class FilterBoxComponent extends Component {
 
       if (button) {
         DOM.on(button, 'click', () => {
-          this._saveFilterNodesToStorage();
+          this._saveFilterNodesToStorage(false);
           this._search();
         });
       }
@@ -257,7 +257,7 @@ export default class FilterBoxComponent extends Component {
   onFilterNodeChange (index, filterNode, saveFilterNodes, searchOnChange) {
     this._filterNodes[index] = filterNode;
     if (saveFilterNodes || searchOnChange) {
-      this._saveFilterNodesToStorage();
+      this._saveFilterNodesToStorage(false);
     }
     if (searchOnChange) {
       this._search();
@@ -275,14 +275,16 @@ export default class FilterBoxComponent extends Component {
   /**
    * Save current filters to storage to be used in the next search
    * @private
+   * @param {boolean} replaceHistory Whether we replace or push a new history
+   *                                 state for the associated changes
    */
-  _saveFilterNodesToStorage () {
+  _saveFilterNodesToStorage (replaceHistory) {
     if (this.config.isDynamic) {
       const availableFieldIds = this.config.filterConfigs.map(config => config.fieldId);
       this.core.setFacetFilterNodes(availableFieldIds, this._getValidFilterNodes());
-      this._filterComponents.forEach(fc => fc.saveSelectedToPersistentStorage());
+      this._filterComponents.forEach(fc => fc.saveSelectedToPersistentStorage(replaceHistory));
     } else {
-      this._filterComponents.forEach(fc => fc.apply());
+      this._filterComponents.forEach(fc => fc.apply(replaceHistory));
     }
   }
 

--- a/src/ui/components/filters/filterboxcomponent.js
+++ b/src/ui/components/filters/filterboxcomponent.js
@@ -217,7 +217,7 @@ export default class FilterBoxComponent extends Component {
       this._filterComponents.push(component);
       this._filterNodes[i] = component.getFilterNode();
     }
-    this._saveFilterNodesToStorage(true);
+    this._saveFilterNodesToStorage(this.config.isDynamic);
 
     // Initialize apply button
     if (!this.config.searchOnChange) {

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -269,7 +269,7 @@ export default class FilterOptionsComponent extends Component {
     this.showMoreState = this.config.showMore;
 
     if (this.config.storeOnChange) {
-      this.apply(true);
+      this.apply(this.config.isDynamic);
     }
   }
 
@@ -655,7 +655,7 @@ export default class FilterOptionsComponent extends Component {
     this.core.persistentStorage.set(
       this.name,
       this.config.options.filter(o => o.selected).map(o => o.label),
-      replaceHistory
+      replaceHistory || (this.core.persistentStorage.get(this.name) === null)
     );
   }
 

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -269,7 +269,7 @@ export default class FilterOptionsComponent extends Component {
     this.showMoreState = this.config.showMore;
 
     if (this.config.storeOnChange) {
-      this.apply();
+      this.apply(true);
     }
   }
 
@@ -552,7 +552,7 @@ export default class FilterOptionsComponent extends Component {
   updateListeners (alwaysSaveFilterNodes, blockSearchOnChange) {
     const filterNode = this.getFilterNode();
     if (this.config.storeOnChange) {
-      this.apply();
+      this.apply(false);
     }
 
     this.config.onChange(filterNode, alwaysSaveFilterNodes, blockSearchOnChange);
@@ -571,7 +571,12 @@ export default class FilterOptionsComponent extends Component {
     this.updateListeners();
   }
 
-  apply () {
+  /**
+   * Apply filter changes
+   * @param {boolean} replaceHistory Whether we replace or push a new history
+   *                                 state for the associated changes
+   */
+  apply (replaceHistory) {
     switch (this.config.optionType) {
       case OptionTypes.RADIUS_FILTER:
         this.core.setLocationRadiusFilterNode(this.getLocationRadiusFilterNode());
@@ -583,7 +588,7 @@ export default class FilterOptionsComponent extends Component {
         throw new AnswersComponentError(`Unknown optionType ${this.config.optionType}`, 'FilterOptions');
     }
 
-    this.saveSelectedToPersistentStorage();
+    this.saveSelectedToPersistentStorage(replaceHistory);
   }
 
   floatSelected () {
@@ -643,9 +648,10 @@ export default class FilterOptionsComponent extends Component {
 
   /**
    * Saves selected options to persistent storage
+   * @param {boolean} replaceHistory Whether we replace or push a new history
+   *                                 state for the associated changes
    */
-  saveSelectedToPersistentStorage () {
-    const replaceHistory = (this.core.persistentStorage.get(this.name) === null);
+  saveSelectedToPersistentStorage (replaceHistory) {
     this.core.persistentStorage.set(
       this.name,
       this.config.options.filter(o => o.selected).map(o => o.label),


### PR DESCRIPTION
Consider the following situation

In State 0
Land on a vertical page
In State 1
Search for "all"
In State 2
Select and apply a facet "Product"
In State 3
Search for "people" (any query that will give results)
In State 4
Back nav in Chrome history
In State 5

You would expect state 5 === state 3. That is, you would expect state 5
to have the search "all" and the facet "Product". Instead, state 5 has the search
"people" and the facet "Product". This is a result of how we update
facets. When you are searching for "people", the query is updated and
pushes a state. Then we get the results back from liveapi, get updated
facets, and push /another/ state with the updated facets. (IE we are
pushing two states when we make a search when facets are already being
replaced).

This change makes replaceHistory explicitly set. Whenever a new set of
facets are mounted to the page (e.g. we get new facets from liveapi, we
landed on the page), they we replaceHistory. This is with the knowledge
that a state was already pushed for the search, and we don't want to
push another state for the updated facets.

J=SLAP-612
TEST=manual

Test on a local HH theme site and a local raw site referencing a
local SDK dist

Test the above situation.
Test that applying a facet still pushes a state.
Test that you can apply a facet and then apply another facet and have
two different states.
Test that landing without any facet parameters replaces history when the
facet parameters are added. (ie landing on
http://localhost:5000/public/people.html?query=all). When navigating
back, you should go to the previous page, not the landing page without
parameters.