### PR TITLE
performance: Add performance marks at major events

### DIFF
--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -288,11 +288,11 @@ class Answers {
 
     const handleFulfilledMasterSwitch = (isDisabled) => {
       window.performance.mark('yext.answers.statusEnd');
-      !isDisabled && this._onReady();
+      return !isDisabled && this._onReady();
     };
     const handleRejectedMasterSwitch = () => {
       window.performance.mark('yext.answers.statusEnd');
-      this._onReady();
+      return this._onReady();
     };
     this._masterSwitchApi.isDisabled()
       .then(handleFulfilledMasterSwitch, handleRejectedMasterSwitch);

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -152,6 +152,7 @@ class Answers {
    *                            experience's Answers Status page.
    */
   init (config, statusPage) {
+    window.performance.mark('yext.answers.initStart');
     const parsedConfig = this.parseConfig(config);
     this.validateConfig(parsedConfig);
 
@@ -283,8 +284,18 @@ class Answers {
    * disabled, onReady is not called.
    */
   _invokeOnReady () {
+    window.performance.mark('yext.answers.statusStart');
+
+    const handleFulfilledMasterSwitch = (isDisabled) => {
+      window.performance.mark('yext.answers.statusEnd');
+      !isDisabled && this._onReady();
+    };
+    const handleRejectedMasterSwitch = () => {
+      window.performance.mark('yext.answers.statusEnd');
+      this._onReady();
+    };
     this._masterSwitchApi.isDisabled()
-      .then(isDisabled => !isDisabled && this._onReady(), () => this._onReady());
+      .then(handleFulfilledMasterSwitch, handleRejectedMasterSwitch);
   }
 
   /**
@@ -294,13 +305,16 @@ class Answers {
    * @param callback {Function} always called after function
    */
   _handlePonyfillCssVariables (ponyfillDisabled, callback) {
+    window.performance.mark('yext.answers.ponyfillStart');
     if (!ponyfillDisabled) {
       this.ponyfillCssVariables({
         onFinally: () => {
+          window.performance.mark('yext.answers.ponyfillEnd');
           callback();
         }
       });
     } else {
+      window.performance.mark('yext.answers.ponyfillEnd');
       callback();
     }
   }

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -135,6 +135,7 @@ export default class Core {
    * @param {boolean} query.append If true, adds the results of this query to the end of the current results, defaults false
    */
   verticalSearch (verticalKey, options = {}, query = {}) {
+    window.performance.mark('yext.answers.queryStart');
     if (!query.append) {
       this.globalStorage.set(StorageKeys.VERTICAL_RESULTS, VerticalResults.searchLoading());
       this.globalStorage.set(StorageKeys.SPELL_CHECK, {});
@@ -232,6 +233,7 @@ export default class Core {
         if (typeof analyticsEvent === 'object') {
           this._analyticsReporter.report(AnalyticsEvent.fromData(analyticsEvent));
         }
+        window.performance.mark('yext.answers.queryResponseRendered');
       });
   }
 
@@ -264,6 +266,7 @@ export default class Core {
   }
 
   search (queryString, urls, options = {}) {
+    window.performance.mark('yext.answers.queryStart');
     const { setQueryParams } = options;
     const context = this.globalStorage.getState(StorageKeys.API_CONTEXT);
     const referrerPageUrl = this.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL);
@@ -315,6 +318,7 @@ export default class Core {
         if (typeof analyticsEvent === 'object') {
           this._analyticsReporter.report(AnalyticsEvent.fromData(analyticsEvent));
         }
+        window.performance.mark('yext.answers.queryResponseRendered');
       });
   }
 

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -135,7 +135,7 @@ export default class Core {
    * @param {boolean} query.append If true, adds the results of this query to the end of the current results, defaults false
    */
   verticalSearch (verticalKey, options = {}, query = {}) {
-    window.performance.mark('yext.answers.queryStart');
+    window.performance.mark('yext.answers.verticalQueryStart');
     if (!query.append) {
       this.globalStorage.set(StorageKeys.VERTICAL_RESULTS, VerticalResults.searchLoading());
       this.globalStorage.set(StorageKeys.SPELL_CHECK, {});
@@ -233,7 +233,7 @@ export default class Core {
         if (typeof analyticsEvent === 'object') {
           this._analyticsReporter.report(AnalyticsEvent.fromData(analyticsEvent));
         }
-        window.performance.mark('yext.answers.queryResponseRendered');
+        window.performance.mark('yext.answers.verticalQueryResponseRendered');
       });
   }
 
@@ -266,7 +266,7 @@ export default class Core {
   }
 
   search (queryString, urls, options = {}) {
-    window.performance.mark('yext.answers.queryStart');
+    window.performance.mark('yext.answers.universalQueryStart');
     const { setQueryParams } = options;
     const context = this.globalStorage.getState(StorageKeys.API_CONTEXT);
     const referrerPageUrl = this.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL);
@@ -318,7 +318,7 @@ export default class Core {
         if (typeof analyticsEvent === 'object') {
           this._analyticsReporter.report(AnalyticsEvent.fromData(analyticsEvent));
         }
-        window.performance.mark('yext.answers.queryResponseRendered');
+        window.performance.mark('yext.answers.universalQueryResponseRendered');
       });
   }
 

--- a/src/core/search/searchapi.js
+++ b/src/core/search/searchapi.js
@@ -99,8 +99,12 @@ export default class SearchApi {
     };
     let request = new ApiRequest(requestConfig, { getState: () => sessionTrackingEnabled });
 
+    window.performance.mark('yext.answers.querySent');
     return request.get()
-      .then(response => response.json());
+      .then(response => {
+        window.performance.mark('yext.answers.queryResponseReceived');
+        return response.json();
+      });
   }
 
   /** @inheritdoc */
@@ -124,7 +128,11 @@ export default class SearchApi {
     };
     let request = new ApiRequest(requestConfig, { getState: () => params.sessionTrackingEnabled });
 
+    window.performance.mark('yext.answers.querySent');
     return request.get()
-      .then(response => response.json());
+      .then(response => {
+        window.performance.mark('yext.answers.queryResponseReceived');
+        return response.json();
+      });
   }
 }

--- a/src/core/search/searchapi.js
+++ b/src/core/search/searchapi.js
@@ -99,10 +99,10 @@ export default class SearchApi {
     };
     let request = new ApiRequest(requestConfig, { getState: () => sessionTrackingEnabled });
 
-    window.performance.mark('yext.answers.querySent');
+    window.performance.mark('yext.answers.verticalQuerySent');
     return request.get()
       .then(response => {
-        window.performance.mark('yext.answers.queryResponseReceived');
+        window.performance.mark('yext.answers.verticalQueryResponseReceived');
         return response.json();
       });
   }
@@ -128,10 +128,10 @@ export default class SearchApi {
     };
     let request = new ApiRequest(requestConfig, { getState: () => params.sessionTrackingEnabled });
 
-    window.performance.mark('yext.answers.querySent');
+    window.performance.mark('yext.answers.universalQuerySent');
     return request.get()
       .then(response => {
-        window.performance.mark('yext.answers.queryResponseReceived');
+        window.performance.mark('yext.answers.universalQueryResponseReceived');
         return response.json();
       });
   }

--- a/tests/core/search/searchapi.js
+++ b/tests/core/search/searchapi.js
@@ -10,6 +10,10 @@ describe('vertical searching', () => {
   let searchApi;
 
   beforeEach(() => {
+    delete global.window.performance;
+    global.window.performance = {
+      mark: () => {}
+    };
     mockedRequest.mockClear();
     HttpRequester.mockImplementation(() => {
       return {


### PR DESCRIPTION
We add performance marks for better metrics into the time between the
initialization of answers and the subsequent major events like the first
query request sent or the query response rendering.

J=None
TEST=manual

Test that on a page load you see all nine performance marks in the
console window.performance.entries() (page with query, depends
on whether you are searching on a vertical or a universal for the
four query marks)

yext.answers.initStart
yext.answers.statusStart
yext.answers.statusEnd
yext.answers.ponyfillStart
yext.answers.ponyfillend
yext.answers.verticalQueryStart
yext.answers.verticalQuerySent
yext.answers.verticalQueryResponseReceived
yext.answers.verticalQueryResponseRendered
yext.answers.universalQueryStart
yext.answers.universalQuerySent
yext.answers.universalQueryResponseReceived
yext.answers.universalQueryResponseRendered