### PR TITLE
Compile CSS only once in gulp build task

### DIFF
--- a/conf/gulp-tasks/library.gulpfile.js
+++ b/conf/gulp-tasks/library.gulpfile.js
@@ -37,7 +37,7 @@ exports.default = function defaultJSBundle () {
       .then(bundleTaskFactory => createBundles(bundleTaskFactory, minifyTaskFactory));
   });
   return Promise.all(localizedTaskPromises).then(localizedTasks => {
-    return new Promise(resolve => parallel(...localizedTasks)(resolve));
+    return new Promise(resolve => parallel(compileCSS, ...localizedTasks)(resolve));
   });
 };
 
@@ -60,8 +60,7 @@ function createBundles (bundleTaskFactory, minifyTaskFactory) {
     series(
       bundleTaskFactory.create(BundleType.LEGACY_UMD),
       minifyTaskFactory.minify(BundleType.LEGACY_UMD)
-    ),
-    series(compileCSS)
+    )
   );
 }
 


### PR DESCRIPTION
Previously we were re-compiling the CSS for every localized bundle. Since the CSS doesn't change on a per-locale basis, update to compile the CSS only once.

TEST=manual

Run npm run build with three locales: en, fr, es, and see answer.css built.