### PR TITLE
ResultFactory: Expose 'distanceFromFilter' property of result

### DIFF
--- a/src/core/models/result.js
+++ b/src/core/models/result.js
@@ -95,5 +95,10 @@ export default class Result {
      * @type {number}
      */
     this.distance = data.distance || null;
+
+    /**
+     * @type {number}
+     */
+    this.distanceFromFilter = data.distanceFromFilter || null;
   }
 }

--- a/src/core/models/resultfactory.js
+++ b/src/core/models/resultfactory.js
@@ -21,6 +21,7 @@ export default class ResultFactory {
     for (let i = 0; i < resultsData.length; i++) {
       const data = resultsData[i].data || resultsData[i];
       const distance = resultsData[i].distance;
+      const distanceFromFilter = resultsData[i].distanceFromFilter;
 
       switch (source) {
         case 'GOOGLE_CSE':
@@ -39,7 +40,7 @@ export default class ResultFactory {
           const highlightedFields = resultsData[i].highlightedFields || {};
 
           results.push(ResultFactory.fromKnowledgeManager(
-            data, formatters, verticalId, highlightedFields, i, distance));
+            data, formatters, verticalId, highlightedFields, i, distance, distanceFromFilter));
           break;
         default:
           results.push(ResultFactory.fromGeneric(data, i));
@@ -165,9 +166,11 @@ export default class ResultFactory {
    * @param {Object} highlightedFields
    * @param {number} index
    * @param {number} distance
+   * @param {number} distanceFromFilter
    * @returns {Result}
    */
-  static fromKnowledgeManager (data, formatters, verticalId, highlightedFields, index, distance) {
+  static fromKnowledgeManager (
+    data, formatters, verticalId, highlightedFields, index, distance, distanceFromFilter) {
     // compute highlighted entity profile data
     let highlightedEntityProfileData = ResultFactory.computeHighlightedData(data, highlightedFields);
     // compute formatted entity profile data
@@ -193,7 +196,8 @@ export default class ResultFactory {
       link: data.website,
       id: data.id,
       ordinal: index + 1,
-      distance: distance
+      distance: distance,
+      distanceFromFilter: distanceFromFilter
     });
   }
 


### PR DESCRIPTION
This item is extremely similar to the work we did to expose the "distance" property of the result in https://github.com/yext/answers/pull/581. 

TEST=manual
J=SLAP-583

Test on a Jambo site, using the new field `Formatter.toMiles(profile, 'd_distanceFromFilter')` in place of current usage `Formatter.toMiles(profile)`; see the distance displayed and also test by logging the entire result object in the console. Before this change, field would not appear. After the change, the distanceFromFilter appears if the search response has the property populated ([example query](https://liveapi.yext.com/v2/accounts/me/answers/vertical/query?v=20190101&api_key=df4b24f4075800e5e9705090c54c6c13&jsLibVersion=v1.5.4-25-g87493130&sessionTrackingEnabled=true&input=new%20york&experienceKey=rosetest&version=STAGING&filters=%7B%7D&facetFilters=%7B%7D&verticalKey=KM&limit=20&offset=0&locale=en&referrerPageUrl=)).