### PR TITLE
FilterOptions: add max-height css var for options list

### DIFF
--- a/src/ui/sass/modules/_FilterOptions.scss
+++ b/src/ui/sass/modules/_FilterOptions.scss
@@ -2,10 +2,12 @@
 
   $filter-options-checkmark-color: $color-brand-primary !default;
   $filter-options-checkbox-focus-color: black !default;
+  $filter-options-options-max-height: none !default;
 
   :root {
     --yxt-filter-options-checkmark-color: #{$filter-options-checkmark-color};
     --yxt-filter-options-checkbox-focus-color: #{$filter-options-checkbox-focus-color};
+    --yxt-filter-options-options-max-height: #{$filter-options-options-max-height};
   }
 
   .yxt-FilterOptions {
@@ -104,6 +106,8 @@
     &-options {
       margin: 12px 0;
       padding-left: 0;
+      max-height: var(--yxt-filter-options-options-max-height);
+      overflow-y: auto;
     }
 
   &-search {
@@ -149,11 +153,11 @@
     &::before {
       content: '';
       position: absolute;
-      top: 50%;
+      bottom: 50%;
       left: -22px;
       height: 12px;
       width: 12px;
-      transform: translateY(-50%);
+      transform: translateY(50%);
       border: $border-default;
       border-radius: 2px;
     }


### PR DESCRIPTION
FilterOptions: add max-height css var for options list

This commit adds the --yxt-filter-options-options-max-height
css variable, and also overflow-y: auto, to the
yxt-FilterOptions-options. The overflow-y is necessary
to get the vertical scrollbar to appear when the options exceed
the max-height, without this the excess options overlap with other content.

In order for this change to work in ie11, the
yxt-FilterOptions-optionLabel::before styling (i.e. the checkbox)
had to be changed to not use top: 50% + translateY(-50%).
Otherwise, ie11 would always say that the options list is overflowing,
even when the height of the list is less than the specified max height.

My guess is that ie11 does not take into account transform styling
when calculating overflow, so it thought that the ::before was
overflowing the bottom of the page, even though the translateY would
bring it back up to a point where it wasn't overflowing anymore. Changing
this to use bottom instead of top, and flipping the translateY
seems to fix things. This is because overflow:auto only gives you scroll
bars when you overflow the bottom of the page (TIL), and not
the top (tested on both chrome and ie11). That is if I set say
top: 900px or bottom: -900px (pushing the element down 900px), 
I will get scrollbars, but if I do top: -900px or bottom: 900px 
(pulling the element up instead) I don't get any scrollbars. Another
option would just to have been to remove the top/bottom styling and
just have translateY(3px) (which is the current net change) but that
seemed more brittle.

The ::after styling (the checkmark) was not changed because it was not
causing issues unless you changed the size of the checkmark, which would
mess up the styling either way.

J=SLAP-587
TEST=manual

in both chrome and ie11:
- I can specify the new css variable,
and the filteroptions options lists will scroll vertically if they
exceed that max height.
- I can change the font size of the optionLabel text, or the size of the
checkbox, and the checkbox + checkmark  will still be centered.