### PR TITLE
Support different map languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1838,6 +1838,8 @@ ANSWERS.addComponent('Map', {
   apiKey: '',
   // Optional, can be used for Google Maps in place of the API key
   clientId: '',
+  // Optional, used to determine the language of the map
+  locale: 'en-US',
   // Optional, determines whether or not to collapse pins at the same lat/lng
   collapsePins: false,
   // Optional, the zoom level of the map, defaults to 14

--- a/README.md
+++ b/README.md
@@ -1838,8 +1838,8 @@ ANSWERS.addComponent('Map', {
   apiKey: '',
   // Optional, can be used for Google Maps in place of the API key
   clientId: '',
-  // Optional, used to determine the language of the map
-  locale: 'en-US',
+  // Optional, used to determine the language of the map. Defaults to the locale specified in the ANSWERS init.
+  locale: 'en',
   // Optional, determines whether or not to collapse pins at the same lat/lng
   collapsePins: false,
   // Optional, the zoom level of the map, defaults to 14

--- a/package-lock.json
+++ b/package-lock.json
@@ -1503,6 +1503,11 @@
         "@types/yargs": "^12.0.9"
       }
     },
+    "@mapbox/mapbox-gl-language": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-language/-/mapbox-gl-language-0.10.1.tgz",
+      "integrity": "sha512-i5+N+FrgR5v8NY4+B+uzFl1Q4gR2OaGoKWgKiayL1bE5715svnx4r4ADTczbZSemI9o426tDKfjAtc3HC2GMCw=="
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Javascript Answers Programming Interface",
   "main": "gulpfile.js",
   "dependencies": {
+    "@mapbox/mapbox-gl-language": "^0.10.1",
     "@yext/rtf-converter": "^1.2.0",
     "css-vars-ponyfill": "^2.3.1",
     "handlebars": "^4.7.2",

--- a/src/ui/components/map/mapcomponent.js
+++ b/src/ui/components/map/mapcomponent.js
@@ -63,12 +63,11 @@ export default class MapComponent extends Component {
 
   // TODO(billy) Make ProviderTypes a factory class
   getProviderInstance (type) {
-    const _config = Object.assign({
-      locale: this.core.globalStorage.getState(StorageKeys.LOCALE)
-    }, {
+    const _config = {
+      locale: this.core.globalStorage.getState(StorageKeys.LOCALE),
       ...this._config,
       noResults: this._noResults
-    });
+    };
 
     return new ProviderTypes[type.toLowerCase()](_config);
   }

--- a/src/ui/components/map/mapcomponent.js
+++ b/src/ui/components/map/mapcomponent.js
@@ -63,11 +63,13 @@ export default class MapComponent extends Component {
 
   // TODO(billy) Make ProviderTypes a factory class
   getProviderInstance (type) {
-    const _config = {
+    const _config = Object.assign({
+      locale: this.core.globalStorage.getState(StorageKeys.LOCALE)
+    }, {
       ...this._config,
-      noResults: this._noResults,
-      initLocale: this.core.globalStorage.getState(StorageKeys.LOCALE)
-    };
+      noResults: this._noResults
+    });
+
     return new ProviderTypes[type.toLowerCase()](_config);
   }
 

--- a/src/ui/components/map/mapcomponent.js
+++ b/src/ui/components/map/mapcomponent.js
@@ -65,7 +65,8 @@ export default class MapComponent extends Component {
   getProviderInstance (type) {
     const _config = {
       ...this._config,
-      noResults: this._noResults
+      noResults: this._noResults,
+      initLocale: this.core.globalStorage.getState(StorageKeys.LOCALE)
     };
     return new ProviderTypes[type.toLowerCase()](_config);
   }

--- a/src/ui/components/map/providers/googlemapprovider.js
+++ b/src/ui/components/map/providers/googlemapprovider.js
@@ -41,16 +41,12 @@ export default class GoogleMapProvider extends MapProvider {
     const googleMapsCustomLanguages =
       ['zh-CN', 'zn-HK', 'zh-TW', 'en-AU', 'en-GB', 'fr-CA', 'pt-BR', 'pt-PT', 'es-419'];
     const locale = localeStr.replace('_', '-');
-    const language = locale.substring(0, 2);
 
     if (googleMapsCustomLanguages.includes(locale)) {
       return locale;
-    } else if (locale.length < 2) {
-      console.error(`Locale '${locale}' must include at least two characters. Falling back to 'en'`);
-      return 'en';
-    } else if (locale.length > 2) {
-      console.warn(`Locale '${locale}' is not supported by Google Maps as a language. Falling back to '${language}'`);
     }
+
+    const language = locale.substring(0, 2);
     return language;
   }
 

--- a/src/ui/components/map/providers/googlemapprovider.js
+++ b/src/ui/components/map/providers/googlemapprovider.js
@@ -56,7 +56,7 @@ export default class GoogleMapProvider extends MapProvider {
         onLoad();
       },
       async: true,
-      src: `https://maps.googleapis.com/maps/api/js?${self.generateCredentials()}&language=${self._locale}`
+      src: `https://maps.googleapis.com/maps/api/js?${self.generateCredentials()}&language=${self._language}`
     });
 
     DOM.append('body', script);

--- a/src/ui/components/map/providers/googlemapprovider.js
+++ b/src/ui/components/map/providers/googlemapprovider.js
@@ -23,6 +23,35 @@ export default class GoogleMapProvider extends MapProvider {
     if (!this.hasValidClientCredentials() && !this._apiKey) {
       throw new Error('GoogleMapsProvider: Missing `apiKey` or {`clientId`, `signature`}');
     }
+
+    /**
+     * Language of the map.
+     * @type {string}
+     */
+    this._language = this.getSupportedLanguage(this._locale);
+  }
+
+  /**
+   * Google Maps supports some langauge codes that are longer than two characters. If the
+   * locale matches one of these edge cases, use it. Otherwise, fallback on the first two
+   * characters of the locale and print a warning.
+   * @param {string} localeStr Unicode locale
+   */
+  getSupportedLanguage (localeStr) {
+    const googleMapsCustomLanguages =
+      ['zh-CN', 'zn-HK', 'zh-TW', 'en-AU', 'en-GB', 'fr-CA', 'pt-BR', 'pt-PT', 'es-419'];
+    const locale = localeStr.replace('_', '-');
+    const language = locale.substring(0, 2);
+
+    if (googleMapsCustomLanguages.includes(locale)) {
+      return locale;
+    } else if (locale.length < 2) {
+      console.error(`Locale '${locale}' must include at least two characters. Falling back to 'en'`);
+      return 'en';
+    } else if (locale.length > 2) {
+      console.warn(`Locale '${locale}' is not supported by Google Maps as a language. Falling back to '${language}'`);
+    }
+    return language;
   }
 
   loadJS () {

--- a/src/ui/components/map/providers/googlemapprovider.js
+++ b/src/ui/components/map/providers/googlemapprovider.js
@@ -28,7 +28,7 @@ export default class GoogleMapProvider extends MapProvider {
      * Language of the map.
      * @type {string}
      */
-    this._language = this.getSupportedLanguage(this._locale);
+    this._language = this.getValidatedLanguage(this._locale);
   }
 
   /**
@@ -37,7 +37,7 @@ export default class GoogleMapProvider extends MapProvider {
    * characters of the locale and print a warning.
    * @param {string} localeStr Unicode locale
    */
-  getSupportedLanguage (localeStr) {
+  getValidatedLanguage (localeStr) {
     const googleMapsCustomLanguages =
       ['zh-CN', 'zn-HK', 'zh-TW', 'en-AU', 'en-GB', 'fr-CA', 'pt-BR', 'pt-PT', 'es-419'];
     const locale = localeStr.replace('_', '-');

--- a/src/ui/components/map/providers/googlemapprovider.js
+++ b/src/ui/components/map/providers/googlemapprovider.js
@@ -56,7 +56,7 @@ export default class GoogleMapProvider extends MapProvider {
         onLoad();
       },
       async: true,
-      src: `https://maps.googleapis.com/maps/api/js?${self.generateCredentials()}`
+      src: `https://maps.googleapis.com/maps/api/js?${self.generateCredentials()}&language=${self._locale}`
     });
 
     DOM.append('body', script);

--- a/src/ui/components/map/providers/googlemapprovider.js
+++ b/src/ui/components/map/providers/googlemapprovider.js
@@ -28,16 +28,16 @@ export default class GoogleMapProvider extends MapProvider {
      * Language of the map.
      * @type {string}
      */
-    this._language = this.getValidatedLanguage(this._locale);
+    this._language = this.getLanguage(this._locale);
   }
 
   /**
    * Google Maps supports some langauge codes that are longer than two characters. If the
    * locale matches one of these edge cases, use it. Otherwise, fallback on the first two
-   * characters of the locale and print a warning.
+   * characters of the locale.
    * @param {string} localeStr Unicode locale
    */
-  getValidatedLanguage (localeStr) {
+  getLanguage (localeStr) {
     const googleMapsCustomLanguages =
       ['zh-CN', 'zn-HK', 'zh-TW', 'en-AU', 'en-GB', 'fr-CA', 'pt-BR', 'pt-PT', 'es-419'];
     const locale = localeStr.replace('_', '-');

--- a/src/ui/components/map/providers/googlemapprovider.js
+++ b/src/ui/components/map/providers/googlemapprovider.js
@@ -32,7 +32,7 @@ export default class GoogleMapProvider extends MapProvider {
   }
 
   /**
-   * Google Maps supports some langauge codes that are longer than two characters. If the
+   * Google Maps supports some language codes that are longer than two characters. If the
    * locale matches one of these edge cases, use it. Otherwise, fallback on the first two
    * characters of the locale.
    * @param {string} localeStr Unicode locale

--- a/src/ui/components/map/providers/mapboxmapprovider.js
+++ b/src/ui/components/map/providers/mapboxmapprovider.js
@@ -5,6 +5,9 @@ import MapboxLanguage from '@mapbox/mapbox-gl-language';
 import MapProvider from './mapprovider';
 import DOM from '../../../dom/dom';
 
+const supportedLanguages =
+      ['en', 'es', 'fr', 'de', 'ar', 'ja', 'ko', 'pt', 'ru', 'zh'];
+
 /* global mapboxgl */
 
 /**
@@ -15,7 +18,12 @@ import DOM from '../../../dom/dom';
 export default class MapBoxMapProvider extends MapProvider {
   constructor (opts = {}, systemOpts = {}) {
     super(opts, systemOpts);
+
+    this._language = supportedLanguages.includes(this._language)
+      ? this._language
+      : this._languageFallback;
   }
+
   /**
    * Load the external JS Library
    * @param {function} onLoad An optional callback to invoke once the JS is loaded.

--- a/src/ui/components/map/providers/mapboxmapprovider.js
+++ b/src/ui/components/map/providers/mapboxmapprovider.js
@@ -3,7 +3,7 @@
 import MapProvider from './mapprovider';
 import DOM from '../../../dom/dom';
 
-/* global mapboxgl */
+/* global mapboxgl, MapboxLanguage */
 
 /**
  * MapBoxMapProvider is an implementation of a MapProvider

--- a/src/ui/components/map/providers/mapboxmapprovider.js
+++ b/src/ui/components/map/providers/mapboxmapprovider.js
@@ -17,10 +17,10 @@ export default class MapBoxMapProvider extends MapProvider {
     super(opts, systemOpts);
 
     /**
-     * Language of the map. Defaults to 'en'
+     * Language of the map.
      * @type {string}
      */
-    this._language = this._locale.substring(0, 2) || 'en';
+    this._language = this._locale.substring(0, 2);
   }
 
   /**

--- a/src/ui/components/map/providers/mapboxmapprovider.js
+++ b/src/ui/components/map/providers/mapboxmapprovider.js
@@ -16,7 +16,11 @@ export default class MapBoxMapProvider extends MapProvider {
   constructor (opts = {}, systemOpts = {}) {
     super(opts, systemOpts);
 
-    this._language = this._language;
+    /**
+     * Language of the map. Defaults to 'en'
+     * @type {string}
+     */
+    this._language = this._locale.substring(0, 2) || 'en';
   }
 
   /**

--- a/src/ui/components/map/providers/mapboxmapprovider.js
+++ b/src/ui/components/map/providers/mapboxmapprovider.js
@@ -85,7 +85,7 @@ export default class MapBoxMapProvider extends MapProvider {
     });
 
     this._map.addControl(new MapboxLanguage({
-      defaultLanguage: this._locale
+      defaultLanguage: this._language
     }));
 
     if (mapData && mapData.mapMarkers.length) {

--- a/src/ui/components/map/providers/mapboxmapprovider.js
+++ b/src/ui/components/map/providers/mapboxmapprovider.js
@@ -1,9 +1,11 @@
 /** @module MapBoxMapProvider */
 
+import MapboxLanguage from '@mapbox/mapbox-gl-language';
+
 import MapProvider from './mapprovider';
 import DOM from '../../../dom/dom';
 
-/* global mapboxgl, MapboxLanguage */
+/* global mapboxgl */
 
 /**
  * MapBoxMapProvider is an implementation of a MapProvider
@@ -13,33 +15,28 @@ import DOM from '../../../dom/dom';
 export default class MapBoxMapProvider extends MapProvider {
   constructor (opts = {}, systemOpts = {}) {
     super(opts, systemOpts);
-
-    this._isMapboxLoaded = false;
-    this._isMapboxLanguageLoaded = false;
   }
   /**
    * Load the external JS Library
    * @param {function} onLoad An optional callback to invoke once the JS is loaded.
    */
   loadJS (onLoad) {
-    let mapboxScript = DOM.createEl('script', {
+    let script = DOM.createEl('script', {
       id: 'yext-map-js',
       onload: () => {
-        this._isMapboxLoaded = true;
-        this._onScriptLoad(onLoad);
+        this._isLoaded = true;
+        mapboxgl.accessToken = this._apiKey;
+
+        if (typeof onLoad === 'function') {
+          onLoad();
+        }
+
+        if (typeof this._onLoaded === 'function') {
+          this._onLoaded();
+        }
       },
       async: true,
       src: 'https://api.mapbox.com/mapbox-gl-js/v0.44.1/mapbox-gl.js'
-    });
-
-    let mapboxLanguageScript = DOM.createEl('script', {
-      id: 'yext-map-language-js',
-      onload: () => {
-        this._isMapboxLanguageLoaded = true;
-        this._onScriptLoad(onLoad);
-      },
-      async: true,
-      src: 'https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-language/v0.10.1/mapbox-gl-language.js'
     });
 
     let css = DOM.createEl('link', {
@@ -49,25 +46,7 @@ export default class MapBoxMapProvider extends MapProvider {
     });
 
     DOM.append('body', css);
-    DOM.append('body', mapboxScript);
-    DOM.append('body', mapboxLanguageScript);
-  }
-
-  _onScriptLoad (onLoadCB) {
-    if (!this._isMapboxLoaded || !this._isMapboxLanguageLoaded) {
-      return;
-    }
-
-    this._isLoaded = true;
-    mapboxgl.accessToken = this._apiKey;
-
-    if (typeof onLoad === 'function') {
-      onLoadCB();
-    }
-
-    if (typeof this._onLoaded === 'function') {
-      this._onLoaded();
-    }
+    DOM.append('body', script);
   }
 
   init (el, mapData, resultsContext) {

--- a/src/ui/components/map/providers/mapboxmapprovider.js
+++ b/src/ui/components/map/providers/mapboxmapprovider.js
@@ -5,9 +5,6 @@ import MapboxLanguage from '@mapbox/mapbox-gl-language';
 import MapProvider from './mapprovider';
 import DOM from '../../../dom/dom';
 
-const SUPPORTED_LANGUAGES =
-      ['en', 'es', 'fr', 'de', 'ar', 'ja', 'ko', 'pt', 'ru', 'zh'];
-
 /* global mapboxgl */
 
 /**
@@ -19,9 +16,7 @@ export default class MapBoxMapProvider extends MapProvider {
   constructor (opts = {}, systemOpts = {}) {
     super(opts, systemOpts);
 
-    this._language = SUPPORTED_LANGUAGES.includes(this._language)
-      ? this._language
-      : this._languageFallback;
+    this._language = this._language;
   }
 
   /**

--- a/src/ui/components/map/providers/mapboxmapprovider.js
+++ b/src/ui/components/map/providers/mapboxmapprovider.js
@@ -5,7 +5,7 @@ import MapboxLanguage from '@mapbox/mapbox-gl-language';
 import MapProvider from './mapprovider';
 import DOM from '../../../dom/dom';
 
-const supportedLanguages =
+const SUPPORTED_LANGUAGES =
       ['en', 'es', 'fr', 'de', 'ar', 'ja', 'ko', 'pt', 'ru', 'zh'];
 
 /* global mapboxgl */
@@ -19,7 +19,7 @@ export default class MapBoxMapProvider extends MapProvider {
   constructor (opts = {}, systemOpts = {}) {
     super(opts, systemOpts);
 
-    this._language = supportedLanguages.includes(this._language)
+    this._language = SUPPORTED_LANGUAGES.includes(this._language)
       ? this._language
       : this._languageFallback;
   }

--- a/src/ui/components/map/providers/mapprovider.js
+++ b/src/ui/components/map/providers/mapprovider.js
@@ -92,10 +92,11 @@ export default class MapProvider {
     this._collapsePins = config.collapsePins || false;
 
     /**
-     * Locale of the map. Defaults to the locale specified in ANSWERS.init()
+     * Locale of the map. Defaults to the locale specified in ANSWERS.init() or to 'en'
+     * if a locale is not provided in the init.
      * @type {string}
      */
-    const locale = config.locale || config.initLocale;
+    const locale = config.locale || config.initLocale || 'en';
 
     /**
      * Language of the map. Defaults to 'en'

--- a/src/ui/components/map/providers/mapprovider.js
+++ b/src/ui/components/map/providers/mapprovider.js
@@ -92,23 +92,17 @@ export default class MapProvider {
     this._collapsePins = config.collapsePins || false;
 
     /**
-     * Locale of the map. Defaults to the locale specified in ANSWERS.init() or to 'en'
-     * if a locale is not provided in the init.
+     * Locale of the map. MapComponent supplies the locale specifed by
+     * ANSWERS.init() by default
      * @type {string}
      */
-    const locale = config.locale || config.initLocale || 'en';
+    const locale = config.locale;
 
     /**
      * Language of the map. Defaults to 'en'
      * @type {string}
      */
     this._language = locale.substring(0, 2) || 'en';
-
-    /**
-     * Fallback which is used if _language is not supported
-     * @type {string}
-     */
-    this._languageFallback = 'en';
   }
 
   /**

--- a/src/ui/components/map/providers/mapprovider.js
+++ b/src/ui/components/map/providers/mapprovider.js
@@ -96,7 +96,15 @@ export default class MapProvider {
      * ANSWERS.init() by default
      * @type {string}
      */
-    this._locale = config.locale;
+    this._locale = this._getSupportedLocale(config.locale);
+  }
+
+  _getSupportedLocale (locale) {
+    if (locale.length < 2) {
+      console.error(`Locale '${locale}' must include at least two characters. Falling back to 'en'`);
+      return 'en';
+    }
+    return locale;
   }
 
   /**

--- a/src/ui/components/map/providers/mapprovider.js
+++ b/src/ui/components/map/providers/mapprovider.js
@@ -92,10 +92,16 @@ export default class MapProvider {
     this._collapsePins = config.collapsePins || false;
 
     /**
+     * Locale of the map. Defaults to 'en'
+     * @type {string}
+     */
+    const locale = config.locale || 'en';
+
+    /**
      * Language of the map. Defaults to 'en'
      * @type {string}
      */
-    this._language = config.locale.substring(0, 2) || 'en';
+    this._language = locale.substring(0, 2) || 'en';
 
     /**
      * Fallback which is used if _language is not supported

--- a/src/ui/components/map/providers/mapprovider.js
+++ b/src/ui/components/map/providers/mapprovider.js
@@ -94,6 +94,7 @@ export default class MapProvider {
     /**
      * Locale of the map. Defaults to 'en'
      * @type {string}
+     * TODO(cea2aj) Default to the locale of the bundle
      */
     this._locale = config.locale || 'en';
 

--- a/src/ui/components/map/providers/mapprovider.js
+++ b/src/ui/components/map/providers/mapprovider.js
@@ -96,10 +96,14 @@ export default class MapProvider {
      * ANSWERS.init() by default
      * @type {string}
      */
-    this._locale = this._getSupportedLocale(config.locale);
+    this._locale = this._getValidatedLocale(config.locale);
   }
 
-  _getSupportedLocale (locale) {
+  /**
+   * Returns the locale if it passes validation, otherwise returns 'en'
+   * @param {string} locale
+   */
+  _getValidatedLocale (locale) {
     if (locale.length < 2) {
       console.error(`Locale '${locale}' must include at least two characters. Falling back to 'en'`);
       return 'en';

--- a/src/ui/components/map/providers/mapprovider.js
+++ b/src/ui/components/map/providers/mapprovider.js
@@ -103,6 +103,12 @@ export default class MapProvider {
      * @type {string}
      */
     this._language = this._locale.substring(0, 2) || 'en';
+
+    /**
+     * Fallback which is used if _language is not supported
+     * @type {string}
+     */
+    this._languageFallback = 'en';
   }
 
   /**

--- a/src/ui/components/map/providers/mapprovider.js
+++ b/src/ui/components/map/providers/mapprovider.js
@@ -96,6 +96,12 @@ export default class MapProvider {
      * @type {string}
      */
     this._locale = config.locale || 'en';
+
+    /**
+     * Language of the map. Defaults to 'en'
+     * @type {string}
+     */
+    this._language = this._locale.substring(0, 2) || 'en';
   }
 
   /**

--- a/src/ui/components/map/providers/mapprovider.js
+++ b/src/ui/components/map/providers/mapprovider.js
@@ -90,6 +90,12 @@ export default class MapProvider {
      * @type {boolean}
      */
     this._collapsePins = config.collapsePins || false;
+
+    /**
+     * Locale of the map. Defaults to 'en'
+     * @type {string}
+     */
+    this._locale = config.locale || 'en';
   }
 
   /**

--- a/src/ui/components/map/providers/mapprovider.js
+++ b/src/ui/components/map/providers/mapprovider.js
@@ -92,17 +92,10 @@ export default class MapProvider {
     this._collapsePins = config.collapsePins || false;
 
     /**
-     * Locale of the map. Defaults to 'en'
-     * @type {string}
-     * TODO(cea2aj) Default to the locale of the bundle
-     */
-    this._locale = config.locale || 'en';
-
-    /**
      * Language of the map. Defaults to 'en'
      * @type {string}
      */
-    this._language = this._locale.substring(0, 2) || 'en';
+    this._language = config.locale.substring(0, 2) || 'en';
 
     /**
      * Fallback which is used if _language is not supported

--- a/src/ui/components/map/providers/mapprovider.js
+++ b/src/ui/components/map/providers/mapprovider.js
@@ -92,10 +92,10 @@ export default class MapProvider {
     this._collapsePins = config.collapsePins || false;
 
     /**
-     * Locale of the map. Defaults to 'en'
+     * Locale of the map. Defaults to the locale specified in ANSWERS.init()
      * @type {string}
      */
-    const locale = config.locale || 'en';
+    const locale = config.locale || config.initLocale;
 
     /**
      * Language of the map. Defaults to 'en'

--- a/src/ui/components/map/providers/mapprovider.js
+++ b/src/ui/components/map/providers/mapprovider.js
@@ -96,13 +96,7 @@ export default class MapProvider {
      * ANSWERS.init() by default
      * @type {string}
      */
-    const locale = config.locale;
-
-    /**
-     * Language of the map. Defaults to 'en'
-     * @type {string}
-     */
-    this._language = locale.substring(0, 2) || 'en';
+    this._locale = config.locale;
   }
 
   /**

--- a/tests/ui/components/map/providers/mapprovider.js
+++ b/tests/ui/components/map/providers/mapprovider.js
@@ -24,7 +24,9 @@ describe('collapsing markers', () => {
       }
     ];
 
-    const mapProvider = new MapProvider();
+    const mapProvider = new MapProvider({
+      locale: 'en'
+    });
 
     const collapsedMarkers = mapProvider._collapseMarkers(markers);
 


### PR DESCRIPTION
Support different map languages

Add option to specify a locale in the map component. Get the language from the locale in accordance with the map provider. Mapbox uses [Mapbox GL Language](https://github.com/mapbox/mapbox-gl-language) to set the language. Note: Mapbox does not support Italian. The Map also supports the Google languages that include regions (e.g. en-GB or fr-CA)

J=SLAP-639
TEST=manual

Run an internationalized jambo build and observe properly localized MapBox and Google maps. Test the fallback to the locale provided in the answers init.