### PR TITLE
Ensure all styling in the SDK is self contained.

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,8 +312,8 @@ Every component has the same base configuration options.
     container: 'container',
     // Optional, a unique name for the component
     name: 'name',
-    // Optional, an additional, custom HTML classname for the component. The component will also have a
-    // classname of 'yxt-Answers-component' applied.
+    // Optional, an additional, custom HTML classname for the component. The component will also 
+    // have a classname of 'yxt-Answers-component' applied.
     class: 'class',
     // Optional, handlebars template or HTML to override built-in handlebars template for the component
     template: 'template',

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ Every component has the same base configuration options.
     container: 'container',
     // Optional, a unique name for the component
     name: 'name',
-    // Optional, an additional, custom HTML classname for the component. The component will already have a
+    // Optional, an additional, custom HTML classname for the component. The component will also have a
     // classname of 'component' applied.
     class: 'class',
     // Optional, handlebars template or HTML to override built-in handlebars template for the component

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ Every component has the same base configuration options.
     // Optional, a unique name for the component
     name: 'name',
     // Optional, an additional, custom HTML classname for the component. The component will also have a
-    // classname of 'component' applied.
+    // classname of 'yxt-Answers-component' applied.
     class: 'class',
     // Optional, handlebars template or HTML to override built-in handlebars template for the component
     template: 'template',

--- a/README.md
+++ b/README.md
@@ -312,7 +312,8 @@ Every component has the same base configuration options.
     container: 'container',
     // Optional, a unique name for the component
     name: 'name',
-    // Optional, a custom HTML classname for the component
+    // Optional, an additional, custom HTML classname for the component. The component will already have a
+    // classname of 'component' applied.
     class: 'class',
     // Optional, handlebars template or HTML to override built-in handlebars template for the component
     template: 'template',

--- a/src/ui/components/component.js
+++ b/src/ui/components/component.js
@@ -109,10 +109,11 @@ export default class Component {
     }
 
     /**
-     * A custom class to be applied to {this._container} node
+     * A custom class to be applied to {this._container} node. Note that the class
+     * 'component' will be included already.
      * @type {string}
      */
-    this._className = config.class || 'component';
+    this._className = config.class;
 
     /**
      * A custom render function to be used instead of using the default renderer
@@ -237,7 +238,8 @@ export default class Component {
       }
     });
 
-    DOM.addClass(this._container, this._className);
+    this._className && DOM.addClass(this._container, this._className);
+    DOM.addClass(this._container, 'component');
     return this;
   }
 

--- a/src/ui/components/component.js
+++ b/src/ui/components/component.js
@@ -110,7 +110,7 @@ export default class Component {
 
     /**
      * A custom class to be applied to {this._container} node. Note that the class
-     * 'component' will be included already.
+     * 'component' will be included also.
      * @type {string}
      */
     this._className = config.class;

--- a/src/ui/components/component.js
+++ b/src/ui/components/component.js
@@ -110,10 +110,10 @@ export default class Component {
 
     /**
      * A custom class to be applied to {this._container} node. Note that the class
-     * 'component' will be included also.
+     * 'yxt-Answers-component' will be included as well.
      * @type {string}
      */
-    this._className = config.class;
+    this._className = config.class || 'component';
 
     /**
      * A custom render function to be used instead of using the default renderer
@@ -238,8 +238,8 @@ export default class Component {
       }
     });
 
-    this._className && DOM.addClass(this._container, this._className);
-    DOM.addClass(this._container, 'component');
+    DOM.addClass(this._container, this._className);
+    DOM.addClass(this._container, 'yxt-Answers-component');
     return this;
   }
 

--- a/src/ui/sass/_base.scss
+++ b/src/ui/sass/_base.scss
@@ -1,15 +1,14 @@
-*:focus
-{
-  outline: none;
-}
+.component {
+  *:focus
+  {
+    outline: none;
+  }
 
-input[type='checkbox']:focus
-{
-  outline: black solid 1px;
-}
+  input[type='checkbox']:focus
+  {
+    outline: black solid 1px;
+  }
 
-body
-{
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/src/ui/sass/_base.scss
+++ b/src/ui/sass/_base.scss
@@ -1,4 +1,4 @@
-.component {
+.yxt-Answers-component {
   *:focus
   {
     outline: none;

--- a/src/ui/sass/modules/_Pagination.scss
+++ b/src/ui/sass/modules/_Pagination.scss
@@ -90,16 +90,16 @@ $pagination-color-hover: var(--yxt-color-text-secondary) !default;
   {
     display: flex;
   }
-}
 
-@media (max-width: $breakpoint-mobile-max) {
-  .mobile-hidden {
-    display: none;
+  @media (max-width: $breakpoint-mobile-max) {
+    .mobile-hidden {
+      display: none;
+    }
   }
-}
-
-@media (min-width: $breakpoint-mobile-max) {
-  .desktop-hidden {
-    display: none;
+  
+  @media (min-width: $breakpoint-mobile-max) {
+    .desktop-hidden {
+      display: none;
+    }
   }
 }


### PR DESCRIPTION
The SDK's styling should affect only the components on the page and nothing else. Unfortunately, we had some global CSS resets that were applied to an entire page, not just the Answers components. This PR corrects that. In order to scope these resets, we added a CSS class name that will be applied to all component containers. The class name chosen was 'yxt-Answers-component'. I also correctly scoped some styling for the Pagination component.

In the future, we should add a CSS linter to the SDK. We should add a linting rule that will detect any styling not scoped to the components.

J=SLAP-571
TEST=manual

Ensured that the CSS resets were still applied to all components. Verified that I could override a reset within a component's styling.