### PR TITLE
Map: add shouldFreezeMap config function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1847,6 +1847,8 @@ ANSWERS.addComponent('Map', {
   // Optional, determines if an empty map should be shown when there are no results. Defaults to false.
   showEmptyMap: false,
   // Optional, callback to invoke when a pin is clicked. The clicked item(s) are passed to the callback
+  shouldFreezeMap: function() {},
+  // Optional, when this function returns true, the map will not update when new searches are made. When this returns false, it will not have any impact on the map's behavior.
   onPinClick: null,
   // Optional, callback to invoke when a pin is hovered. The clicked item(s) are passed to the callback
   onPinMouseOver: null,

--- a/README.md
+++ b/README.md
@@ -1847,9 +1847,9 @@ ANSWERS.addComponent('Map', {
   // Optional, determines if an empty map should be shown when there are no results. Defaults to false.
   showEmptyMap: false,
   // Optional, callback to invoke when a pin is clicked. The clicked item(s) are passed to the callback
-  shouldFreezeMap: function() {},
-  // Optional, when this function returns true, the map will not update when new searches are made. When this returns false, it will not have any impact on the map's behavior.
   onPinClick: null,
+  // Optional, when this function returns true, the map will not update when new searches are made. When this returns false, it will not have any impact on the map's behavior.
+  shouldFreezeMap: function() {},
   // Optional, callback to invoke when a pin is hovered. The clicked item(s) are passed to the callback
   onPinMouseOver: null,
   // Optional, callback to invoke when a pin is no longer hovered after being hovered. The clicked item(s) are passed to the callback

--- a/src/ui/components/map/mapcomponent.js
+++ b/src/ui/components/map/mapcomponent.js
@@ -46,6 +46,12 @@ export default class MapComponent extends Component {
      * @type {MapProvider}
      */
     this._map = null;
+
+    /**
+     * A configurable method for criteria to not update the map.
+     * @type {Function}
+     */
+    this._shouldFreezeMap = opts.shouldFreezeMap || (() => {});
   }
 
   static get type () {
@@ -82,7 +88,7 @@ export default class MapComponent extends Component {
   }
 
   setState (data, val) {
-    if (Object.keys(data).length === 0) {
+    if (Object.keys(data).length === 0 || this._shouldFreezeMap()) {
       return this;
     }
 


### PR DESCRIPTION
This commit adds the shouldFreezeMap config function, which
allows the user to specify a criteria when the map should not update.

TEST=manual

this is used at http://engblog.yext.com/collapsible-filters-prototype/people.html
to not update the map on mobile phones (since it is hidden in those cases)
Otherwise, for low-end phones, we noticed there was a chance to crash the
page if a user made too many searches too quickly. It also just helps
performance a lot