### PR TITLE
SearchBar: add onSearchComplete hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,9 @@ ANSWERS.addComponent('SearchBar', {
     enabled: false,
     // Optional, the message in the alert. Defaults to the below
     message: "We are unable to determine your location"
-  }
+  },
+  // Optional, a callback function that runs after the searchbar completes a search.
+  onSearchComplete: function () { console.log('a search was complete!'); }
 })
 ```
 


### PR DESCRIPTION
This commit adds the onSearchComplete hook to the SearchBar component.
This allows users to add a callback after ONLY searches made by
the searchbar are completed.
The preexisting callback, onVerticalSearch, occurs after any searches
are made, and does not have context as to whether that search is made
by a filter component, pagination, or the search bar. This removes
the need to manually calculate whether a search originated from the
searchbar.

TEST=manual

used in http://engblog.yext.com/collapsible-filters-prototype/people.html
used to hide the filters panel ONLY when a search is made with the searchbar