### PR TITLE
FilterOptions: add data-label attribute

### DIFF
--- a/src/ui/templates/controls/filteroptions.hbs
+++ b/src/ui/templates/controls/filteroptions.hbs
@@ -1,4 +1,4 @@
-<fieldset class="yxt-FilterOptions-fieldSet">
+<fieldset class="yxt-FilterOptions-fieldSet" data-label="{{label}}">
   <legend class="yxt-FilterOptions-legend">
     <div class="yxt-FilterOptions-legendLabel">
       {{#if showExpand}}


### PR DESCRIPTION
This commit exposes the label for a given filter options
as a data attribute, as opposed to requiring ugly and potentially
expensive DOM traversal to find a specific filter options.
Instead, you can now call element.querySelector with the data-label
to get the correct filter options element.

TEST=manual

used in http://engblog.yext.com/collapsible-filters-prototype/people.html
for scroll magic