### PR TITLE
VerticalResults: add hideResultsHeader config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -820,6 +820,8 @@ ANSWERS.addComponent('VerticalResults', {
   resultsCountTemplate: '<div>{{resultsCountStart}} - {{resultsCountEnd}} of {{resultsCount}}</div>',
   // Optional, a modifier that will be appended to a class on the results list like this `yxt-Results--{modifier}`
   modifier: '',
+  // Optional, whether to hide the default results header that VerticalResults provides. Defaults to false.
+  hideResultsHeader: false,
   // Optional, the card used to display each individual result, see the Cards section for more details,
   card: {
     // Optional, The type of card, built-in types are: 'Standard', 'Accordion', and 'Legacy'. Defaults to 'Standard'

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -71,6 +71,13 @@ class VerticalResultsConfig {
     this.resultsCountTemplate = config.resultsCountTemplate || '';
 
     /**
+     * Whether to display the results header (assuming there is something like the results count
+     * or applied filters to display).
+     * @type {boolean}
+     */
+    this.hideResultsHeader = config.hideResultsHeader;
+
+    /**
      * Config for the applied filters in the results header.
      * @type {Object}
      */

--- a/src/ui/templates/results/verticalresults.hbs
+++ b/src/ui/templates/results/verticalresults.hbs
@@ -41,7 +41,9 @@
 {{/inline}}
 
 {{#*inline 'resultsHeader'}}
-  <div data-component="ResultsHeader"></div>
+  {{#unless _config.hideResultsHeader}}
+    <div data-component="ResultsHeader"></div>
+  {{/unless}}
 {{/inline}}
 
 {{#*inline "results"}}


### PR DESCRIPTION
This commit adds the 'hideResultsHeader' config option to
VerticalResults. Previously, to hide the results header,
users would have to display: none it. However, the results
header would still do things like perform applied filters
calculations, having a negative impact on page speed.

TEST=manual

used in http://engblog.yext.com/collapsible-filters-prototype/people.html
the above page uses the separated results count and applied filters components,
instead of the normal results header