### PR TITLE
Add Applied Filters Component

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Outline:
    - [Facets Component](#facets-component)
    - [FilterSearch Component](#filtersearch-component)
    - [Filter Components](#filter-components)
+   - [Applied Filters Component](#applied-filters-component)
    - [Navigation Component](#navigation-component)
    - [QASubmission Component](#qa-submission-component)
    - [SpellCheck Component](#spell-check-component)
@@ -1623,6 +1624,33 @@ ANSWERS.addComponent('GeoLocationFilter', {
     // Optional, the message in the alert. Defaults to the below
     message: "We are unable to determine your location"
   }
+});
+```
+
+## Applied Filters Component
+
+The Applied Filters Component displays your currently applied filters as a row of text tags, labeled
+by filter display value. If the "removable" config option is set to true, these text tags will instead
+be "removable filters", which, when clicked, will remove the clicked filter from the search.
+Only intended for vertical pages.
+
+```js
+ANSWERS.addComponent('AppliedFilters', {
+  container: '.applied-filters-container',
+  // The vertical key of your search, will default to the vertical key specified in the search config.
+  verticalKey: 'aVerticalKey',
+  // Whether to display the field name of each group of applied filters. e.g. "Location: Virginia, New York" vs just "Virginia, New York". Defaults to false.
+  showFieldNames: false,
+  // This is list of filters that should not be displayed. By default, builtin.entityType will be hidden
+  hiddenFields: ['builtin.entityType'],
+  // Whether or not the displayed filters should be removable filters, or just simple text tags. Defaults to false (text tags).
+  removable: false,
+  // The character that separates each group of filters (grouped by field name). Defaults to '|'
+  delimiter: '|',
+  // The aria-label given to the component. Defaults to 'Filters applied to this search:'.
+  labelText: 'Filters applied to this search:',
+  // The aria-label given to the removable filters.
+  removableLabelText: 'Remove this filter'
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -1637,19 +1637,19 @@ Only intended for vertical pages.
 ```js
 ANSWERS.addComponent('AppliedFilters', {
   container: '.applied-filters-container',
-  // The vertical key of your search, will default to the vertical key specified in the search config.
+  // Optional, The vertical key of your search. Defaults to the vertical key specified in the search config.
   verticalKey: 'aVerticalKey',
-  // Whether to display the field name of each group of applied filters. e.g. "Location: Virginia, New York" vs just "Virginia, New York". Defaults to false.
+  // Optional, Whether to display the field name of each group of applied filters. e.g. "Location: Virginia, New York" vs just "Virginia, New York". Defaults to false.
   showFieldNames: false,
-  // This is list of filters that should not be displayed. By default, builtin.entityType will be hidden
+  // Optional, This is list of filters that should not be displayed. Defaults to hiding ['builtin.entityType'].
   hiddenFields: ['builtin.entityType'],
-  // Whether or not the displayed filters should be removable filters, or just simple text tags. Defaults to false (text tags).
+  // Optional, Whether or not the displayed filters should be removable filters, or just simple text tags. Defaults to false (text tags).
   removable: false,
-  // The character that separates each group of filters (grouped by field name). Defaults to '|'
+  // Optional, The character that separates each group of filters (grouped by field name). Defaults to '|'.
   delimiter: '|',
-  // The aria-label given to the component. Defaults to 'Filters applied to this search:'.
+  // Optional, The aria-label given to the component. Defaults to 'Filters applied to this search:'.
   labelText: 'Filters applied to this search:',
-  // The aria-label given to the removable filters.
+  // Optional, The aria-label given to the removable filters. Defaults to 'Remove this filter'.
   removableLabelText: 'Remove this filter'
 });
 ```

--- a/src/ui/components/registry.js
+++ b/src/ui/components/registry.js
@@ -39,6 +39,7 @@ import CTACollectionComponent from './ctas/ctacollectioncomponent';
 import ResultsHeaderComponent from './results/resultsheadercomponent';
 
 import VerticalResultsCountComponent from './results/verticalresultscountcomponent';
+import AppliedFiltersComponent from './results/appliedfilterscomponent';
 
 const COMPONENT_CLASS_LIST = [
   // Core Component
@@ -86,7 +87,8 @@ const COMPONENT_CLASS_LIST = [
   IconComponent,
   CTAComponent,
   CTACollectionComponent,
-  VerticalResultsCountComponent
+  VerticalResultsCountComponent,
+  AppliedFiltersComponent
 ];
 
 /**

--- a/src/ui/components/results/appliedfilterscomponent.js
+++ b/src/ui/components/results/appliedfilterscomponent.js
@@ -133,11 +133,9 @@ export default class AppliedFiltersComponent extends Component {
 
     this.appliedFilterNodes = this._calculateAppliedFilterNodes();
     const appliedFiltersArray = this._createAppliedFiltersArray();
-    const shouldShowFilters = appliedFiltersArray.length > 0;
 
     return super.setState({
       ...data,
-      shouldShowFilters: shouldShowFilters,
       appliedFiltersArray: appliedFiltersArray
     });
   }

--- a/src/ui/components/results/appliedfilterscomponent.js
+++ b/src/ui/components/results/appliedfilterscomponent.js
@@ -1,0 +1,166 @@
+/** @module AppliedFiltersComponent */
+
+import Component from '../component';
+import StorageKeys from '../../../core/storage/storagekeys';
+import DOM from '../../dom/dom';
+import { groupArray } from '../../../core/utils/arrayutils';
+import {
+  convertNlpFiltersToFilterNodes,
+  flattenFilterNodes,
+  pruneFilterNodes
+} from '../../../core/utils/filternodeutils';
+
+const DEFAULT_CONFIG = {
+  showAppliedFilters: true,
+  showFieldNames: false,
+  verticalURL: undefined,
+  showChangeFilters: false,
+  removable: false,
+  delimiter: '|',
+  isUniversal: false,
+  labelText: 'Filters applied to this search:',
+  removableLabelText: 'Remove this filter',
+  moduleId: StorageKeys.RESULTS_HEADER,
+  hiddenFields: []
+};
+
+export default class AppliedFiltersComponent extends Component {
+  constructor (config = {}, systemConfig = {}) {
+    super({ ...DEFAULT_CONFIG, ...config }, systemConfig);
+
+    /**
+     * TODO (SPR-2455): Ideally, we would be able to set moduleId to DYNAMIC_FILTERS, the actual data
+     * we are listening to changes to, instead of this bespoke RESULTS_HEADER storage key.
+     * The issue is that when two components share a moduleId, if that moduleId listener is ever
+     * unregistered with the off() method, all listeners to that moduleId are unregistered.
+     * With child components, this is something that happens whenever the parent component rerenders.
+     */
+    this.moduleId = this._config.moduleId;
+  }
+
+  static areDuplicateNamesAllowed () {
+    return true;
+  }
+
+  onMount () {
+    const removableFilterTags =
+      DOM.queryAll(this._container, '.js-yxt-AppliedFilters-removableFilterTag');
+    removableFilterTags.forEach(tag => {
+      DOM.on(tag, 'click', () => this._removeFilterTag(tag));
+    });
+  }
+
+  /**
+   * Call remove callback for the {@link FilterNode} corresponding to a specific
+   * removable filter tag.
+   * @param {HTMLElement} tag
+   */
+  _removeFilterTag (tag) {
+    const { filterId } = tag.dataset;
+    const filterNode = this.appliedFilterNodes[filterId];
+    filterNode.remove();
+    this.core.verticalSearch(this._config.verticalKey, {
+      setQueryParams: true,
+      resetPagination: true,
+      useFacets: true
+    });
+  }
+
+  /**
+   * Returns the currently applied nlp filter nodes, with nlp filter nodes that
+   * are duplicates of other filter nodes removed or filter on hiddenFields removed.
+   * @returns {Array<FilterNode>}
+   */
+  _getPrunedNlpFilterNodes () {
+    const duplicatesRemoved = this.nlpFilterNodes.filter(nlpNode => {
+      const isDuplicate = this.appliedFilterNodes.find(appliedNode =>
+        appliedNode.hasSameFilterAs(nlpNode)
+      );
+      return !isDuplicate;
+    });
+    return pruneFilterNodes(duplicatesRemoved, this._config.hiddenFields);
+  }
+
+  /**
+   * Combine all of the applied filters into a format the handlebars
+   * template can work with.
+   * Keys are the fieldName of the filter. Values are an array of objects with a
+   * displayValue and dataFilterId.
+   * TODO (SPR-2350): give every node a unique id, and use that instead of index for
+   * dataFilterId.
+   * @returns {Array<Object>}
+   */
+  _groupAppliedFilters () {
+    const getFieldName = filterNode => filterNode.getMetadata().fieldName;
+    const parseNlpFilterDisplay = filterNode => ({
+      displayValue: filterNode.getMetadata().displayValue
+    });
+    const parseRemovableFilterDisplay = (filterNode, index) => ({
+      displayValue: filterNode.getMetadata().displayValue,
+      dataFilterId: index,
+      removable: this._config.removable
+    });
+    const removableNodes = groupArray(this.appliedFilterNodes, getFieldName, parseRemovableFilterDisplay);
+    const prunedNlpFilterNodes = this._getPrunedNlpFilterNodes();
+    return groupArray(prunedNlpFilterNodes, getFieldName, parseNlpFilterDisplay, removableNodes);
+  }
+
+  /**
+   * Returns an array of object the handlebars can understand and render
+   * the applied filters bar from. Our handlebars can only loop through arrays,
+   * not objects, so we need to reformat the grouped applied filters.
+   * @returns {Array<Object>}
+   */
+  _createAppliedFiltersArray () {
+    const groupedFilters = this._groupAppliedFilters();
+    return Object.keys(groupedFilters).map(label => ({
+      label: label,
+      filterDataArray: groupedFilters[label]
+    }));
+  }
+
+  /**
+   * Pulls applied filter nodes from {@link FilterRegistry}, then retrives an array of
+   * the leaf nodes, and then removes hidden or empty {@link FilterNode}s. Then appends
+   * the currently applied nlp filters.
+   */
+  _calculateAppliedFilterNodes () {
+    const filterNodes = this.core.filterRegistry.getAllFilterNodes();
+    const simpleFilterNodes = flattenFilterNodes(filterNodes);
+    return pruneFilterNodes(simpleFilterNodes, this._config.hiddenFields);
+  }
+
+  setState (data) {
+    const verticalResults = this.core.globalStorage.getState(StorageKeys.VERTICAL_RESULTS) || {};
+    const nlpFilters = verticalResults.appliedQueryFilters || [];
+
+    /**
+     * Array of nlp filters in the search response.
+     * @type {Array<AppliedQueryFilter>}
+     */
+    this.nlpFilterNodes = convertNlpFiltersToFilterNodes(nlpFilters || []);
+
+    this.appliedFilterNodes = this._calculateAppliedFilterNodes();
+    const appliedFiltersArray = this._createAppliedFiltersArray();
+    const shouldShowFilters = appliedFiltersArray.length > 0 && this._config.showAppliedFilters;
+
+    return super.setState({
+      ...data,
+      shouldShowFilters: shouldShowFilters,
+      appliedFiltersArray: appliedFiltersArray
+    });
+  }
+
+  static get type () {
+    return 'AppliedFilters';
+  }
+
+  /**
+   * The template to render
+   * @returns {string}
+   * @override
+   */
+  static defaultTemplateName (config) {
+    return 'results/appliedfilters';
+  }
+}

--- a/src/ui/components/results/appliedfilterscomponent.js
+++ b/src/ui/components/results/appliedfilterscomponent.js
@@ -122,13 +122,14 @@ export default class AppliedFiltersComponent extends Component {
 
   setState (data) {
     const verticalResults = this.core.globalStorage.getState(StorageKeys.VERTICAL_RESULTS) || {};
-    const nlpFilters = verticalResults.appliedQueryFilters || [];
 
     /**
      * Array of nlp filters in the search response.
      * @type {Array<AppliedQueryFilter>}
      */
-    this.nlpFilterNodes = convertNlpFiltersToFilterNodes(nlpFilters || []);
+    const nlpFilters = verticalResults.appliedQueryFilters || [];
+
+    this.nlpFilterNodes = convertNlpFiltersToFilterNodes(nlpFilters);
 
     this.appliedFilterNodes = this._calculateAppliedFilterNodes();
     const appliedFiltersArray = this._createAppliedFiltersArray();

--- a/src/ui/components/results/appliedfilterscomponent.js
+++ b/src/ui/components/results/appliedfilterscomponent.js
@@ -27,7 +27,7 @@ export default class AppliedFiltersComponent extends Component {
     this._verticalKey = this._config.verticalKey ||
       this.core.globalStorage.getState(StorageKeys.SEARCH_CONFIG).verticalKey;
 
-    this.moduleId = StorageKeys.RESULTS_HEADER;
+    this.moduleId = StorageKeys.DYNAMIC_FILTERS;
   }
 
   static areDuplicateNamesAllowed () {

--- a/src/ui/sass/answers.scss
+++ b/src/ui/sass/answers.scss
@@ -33,3 +33,4 @@
 @import "modules/AccordionCard";
 @import "modules/ResultsHeader";
 @import "modules/VerticalResultsCount";
+@import "modules/AppliedFilters";

--- a/src/ui/sass/modules/_AppliedFilters.scss
+++ b/src/ui/sass/modules/_AppliedFilters.scss
@@ -1,0 +1,84 @@
+/** @define AppliedFilter */
+
+.yxt-AppliedFilters
+{
+  margin-right: var(--yxt-base-spacing);
+  border-top: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+
+  &-filterLabel
+  {
+    display: flex;
+    margin-right: calc(var(--yxt-base-spacing) / 4);
+    margin-bottom: 4px;
+    @include Text(
+      $size: var(--yxt-font-size-md),
+      $line-height: var(--yxt-line-height-md),
+      $color: var(--yxt-color-text-secondary),
+    );
+  }
+
+  &-filterValue
+  {
+    margin-right: calc(var(--yxt-base-spacing) / 4);
+    margin-bottom: 4px;
+    display: flex;
+  }
+
+  &-filterValueText,
+  &-filterValueComma
+  {
+    @include Text(
+      $size: var(--yxt-font-size-md),
+      $line-height: var(--yxt-line-height-md),
+      $color: var(--yxt-color-text-secondary),
+      $style: italic
+    );
+  }
+
+  &-filterSeparator
+  {
+    color: var(--yxt-color-text-secondary);
+    margin-right: calc(var(--yxt-base-spacing) / 4);
+    margin-bottom: calc(var(--yxt-base-spacing) / 4);
+    @include Text(
+      $size: var(--yxt-font-size-md),
+      $line-height: var(--yxt-line-height-md),
+      $color: var(--yxt-color-text-secondary),
+    );
+  }
+
+  &-removableFilterTag
+  {
+    background-color: var(--yxt-color-borders);
+    border-radius: 2px;
+    border-width: 0;
+    margin-bottom: 4px;
+    padding-left: 5px;
+    padding-right: 4px;
+    margin-right: calc(var(--yxt-base-spacing) / 2);
+    white-space: nowrap;
+    @include Text(
+      $size: var(--yxt-font-size-sm),
+      $color: var(--yxt-color-text-neutral),
+      $line-height: 20px,
+      $style: italic,
+    );
+
+    &:hover,
+    &:focus
+    {
+      color: var(--yxt-color-brand-white);
+      background-color: var(--yxt-color-text-secondary);
+      cursor: pointer;
+    }
+  }
+
+  &-removableFilterX
+  {
+    font-style: normal;
+  }
+}
+

--- a/src/ui/sass/modules/_AppliedFilters.scss
+++ b/src/ui/sass/modules/_AppliedFilters.scss
@@ -8,46 +8,33 @@
   flex-wrap: wrap;
   align-items: center;
 
-  &-filterLabel
-  {
-    display: flex;
+  &-filterLabel, &-filterValue, &-filterSeparator {
     margin-right: calc(var(--yxt-base-spacing) / 4);
-    margin-bottom: 4px;
-    @include Text(
-      $size: var(--yxt-font-size-md),
-      $line-height: var(--yxt-line-height-md),
-      $color: var(--yxt-color-text-secondary),
-    );
-  }
-
-  &-filterValue
-  {
-    margin-right: calc(var(--yxt-base-spacing) / 4);
-    margin-bottom: 4px;
+    margin-bottom: calc(var(--yxt-base-spacing) / 4);
     display: flex;
   }
 
+  &-filterLabel,
   &-filterValueText,
-  &-filterValueComma
+  &-filterValueComma,
+  &-filterSeparator
   {
     @include Text(
       $size: var(--yxt-font-size-md),
       $line-height: var(--yxt-line-height-md),
       $color: var(--yxt-color-text-secondary),
-      $style: italic
     );
+  }
+
+  
+  &-filterValueText,
+  &-filterValueComma {
+    font-style: italic;
   }
 
   &-filterSeparator
   {
     color: var(--yxt-color-text-secondary);
-    margin-right: calc(var(--yxt-base-spacing) / 4);
-    margin-bottom: calc(var(--yxt-base-spacing) / 4);
-    @include Text(
-      $size: var(--yxt-font-size-md),
-      $line-height: var(--yxt-line-height-md),
-      $color: var(--yxt-color-text-secondary),
-    );
   }
 
   &-removableFilterTag

--- a/src/ui/templates/results/appliedfilters.hbs
+++ b/src/ui/templates/results/appliedfilters.hbs
@@ -1,0 +1,27 @@
+<div class="yxt-AppliedFilters" aria-label="{{_config.labelText}}">
+  {{#each appliedFiltersArray}}
+    {{#if ../_config.showFieldNames}}
+      <div class="yxt-AppliedFilters-filterLabel">
+        <span class="yxt-AppliedFilters-filterLabelText">{{this.label}}</span>
+        <span class="yxt-AppliedFilters-filterLabelColon">:</span>
+      </div>
+    {{/if}}
+    {{#each filterDataArray}}
+      {{#if removable}}
+        <button class="yxt-AppliedFilters-removableFilterTag js-yxt-AppliedFilters-removableFilterTag"
+          data-filter-id={{dataFilterId}} tabindex="0" aria-label="{{../../_config.removableLabelText}}">
+          <span class="yxt-AppliedFilters-removableFilterValue">{{displayValue}}</span>
+          <span class="yxt-AppliedFilters-removableFilterX">&times;</span>
+        </button>
+      {{else}}
+        <div class="yxt-AppliedFilters-filterValue">
+          <span class="yxt-AppliedFilters-filterValueText">{{displayValue}}</span>
+          {{#unless @last}}<span class="yxt-AppliedFilters-filterValueComma">,</span>{{/unless}}
+        </div>
+      {{/if}}
+    {{/each}}
+    {{#unless @last}}
+      <div class="yxt-AppliedFilters-filterSeparator">{{../_config.delimiter}}</div>
+    {{/unless}}
+  {{/each}}
+</div>


### PR DESCRIPTION
Add Applied Filters Component

This is a factoring out of the applied filters portion of the results header
component. Separating this out allows for basic yet priorly
exhausting combinations. In the past, even wanting to just flip
the order of the results count and applied filters, or insert
simple content in between them, would require a full override
of the results header template.

We can't use this component inside the results header component,
because the SDK is bad at nesting components. Specifically, when
a component is removed (which happens every time a child component
is rerendered) it will remove its moduleId event listener, which has the
side effect of removing all other listeners on that same moduleId.

TEST=manual

This is used in the collapsible filters page
See http://engblog.yext.com/collapsible-filters-prototype/people.html

also added it to a standalone page, and saw that it was the removable filters worked, and it updated at the end of every search