### PR TITLE
filteroptions: Fix back navigation behavior by applying previous state

### DIFF
--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -51,8 +51,7 @@ class FilterOptionsConfig {
     this.initialOptions = config.options.map(o => ({ ...o }));
 
     /**
-     * The list of filter options to display with checked status,
-     * changing with changes in the persistent storage.
+     * The list of filter options to display.
      * @type {object[]}
      */
     this.options = config.options.map(o => ({ ...o }));
@@ -174,9 +173,9 @@ class FilterOptionsConfig {
    * Returns a list of options with `selected` determined by initialOptions and
    * optionsOverrides. optionsOverrides take precedence over initialOptions. If the
    * control is singleoption and `selected` appears more than once in either
-   * initialOptions or previousOptions then the first instance is used.
+   * initialOptions or optionsOverrides then the first instance is used.
    * @param {Array<Object>} initialOptions Options from the component configuration
-   * @param {Array<string>} optionsOverrides Overrides as they appear in persistentStorage
+   * @param {Array<string>} optionsOverrides Options as they are formatted for persistentStorage
    * @returns {Array<Object>} The options in the same format as initialOptions with updated
    *                          selected values
    */
@@ -283,6 +282,9 @@ export default class FilterOptionsComponent extends Component {
     }
 
     if (!this.config.isDynamic) {
+      // Update listener for when navigating backwards in history. When we back nav, the
+      // globalStorage is updated with the previous URL filter values. We should not update
+      // this.name otherwise, instead opt for this.core.setStaticFilterNodes()
       this.core.globalStorage.on('update', this.name, (data) => {
         try {
           const newOptions = JSON.parse(data);

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -167,20 +167,20 @@ class FilterOptionsConfig {
     }
     // previousOptions will be null if there were no previousOptions in persistentStorage
     const previousOptions = config.previousOptions;
-    this.options = this.setSelectedOptions(this.options, previousOptions);
+    this.options = this.getSelectedOptions(this.options, previousOptions);
   }
 
   /**
    * Returns a list of options with `selected` determined by initialOptions and
-   * optionsOverrides. optionsOverrides take precedence over options. If the
+   * optionsOverrides. optionsOverrides take precedence over initialOptions. If the
    * control is singleoption and `selected` appears more than once in either
-   * options or previousOptions then the first instance is used.
+   * initialOptions or previousOptions then the first instance is used.
    * @param {Array<Object>} initialOptions Options from the component configuration
    * @param {Array<string>} optionsOverrides Overrides as they appear in persistentStorage
-   * @returns {Array<Object>} The options is the same format as initialOptions with updated
+   * @returns {Array<Object>} The options in the same format as initialOptions with updated
    *                          selected values
    */
-  setSelectedOptions (initialOptions, optionsOverrides) {
+  getSelectedOptions (initialOptions, optionsOverrides) {
     const options = initialOptions.map(o => ({ ...o }));
     if (optionsOverrides && this.control === 'singleoption') {
       let hasSeenSelectedOption = false;
@@ -286,7 +286,7 @@ export default class FilterOptionsComponent extends Component {
       this.core.globalStorage.on('update', this.name, (data) => {
         try {
           const newOptions = JSON.parse(data);
-          this.config.options = this.config.setSelectedOptions(
+          this.config.options = this.config.getSelectedOptions(
             this.config.initialOptions,
             newOptions
           );

--- a/src/ui/components/filters/sortoptionscomponent.js
+++ b/src/ui/components/filters/sortoptionscomponent.js
@@ -34,6 +34,11 @@ export default class SortOptionsComponent extends Component {
         this.setState(verticalResults);
       }
     });
+
+    this.core.globalStorage.on('update', this.name, (data) => {
+      this._updateSelectedOption(data);
+      this._sortResults();
+    });
   }
 
   setState (data = {}) {

--- a/src/ui/components/filters/sortoptionscomponent.js
+++ b/src/ui/components/filters/sortoptionscomponent.js
@@ -34,11 +34,6 @@ export default class SortOptionsComponent extends Component {
         this.setState(verticalResults);
       }
     });
-
-    this.core.globalStorage.on('update', this.name, (data) => {
-      this._updateSelectedOption(data);
-      this._sortResults();
-    });
   }
 
   setState (data = {}) {

--- a/tests/ui/components/filters/filteroptionscomponent.js
+++ b/tests/ui/components/filters/filteroptionscomponent.js
@@ -80,7 +80,8 @@ describe('filter options component', () => {
           }
           return null;
         },
-        delete: () => { }
+        delete: () => { },
+        on: () => {}
       },
       persistentStorage: new PersistentStorage()
     };
@@ -410,7 +411,8 @@ describe('filter options component', () => {
                 return ['label1', 'label2'];
               }
             },
-            delete: () => { }
+            delete: () => { },
+            on: () => {}
           },
           setStaticFilterNodes: () => { }
         },
@@ -551,7 +553,8 @@ describe('filter options component', () => {
         {
           globalStorage: {
             getState: () => { },
-            delete: () => { }
+            delete: () => { },
+            on: () => {}
           },
           persistentStorage: {
             set: () => { },


### PR DESCRIPTION
Consider the following answers navigation situation:

In State 1
Search "all"
In State 2
Click on a static filter (e.g. distance "5 miles")
In State 3
Navigate backwards in browser history
In State 4

You would expect state 4 == state 2. However, this is currently not the case.
The results from state 3 still exist in state 4 instead of the results from state 2.
The URL in state 4 reflects the same URL as state 2, however the results are
different. This is because we are not applying the filter changes from the backwards
navigation, even though it is being changed in globalStorage.

This PR aims to update the FilterOptions component when it is updated on a
backwards navigation (ie in globalStorage). We do not fix other static filters like
RangeFilter or DateRangeFilter or SortOptions as that will be part of a bigger rework
aiming to get all Facets/Static Filters manifesting on load/backwards navigation.

J=SLAP-624
TEST=manual

Test on a site using a local SDK dist directly

Test a FilterBox component with RADIUS_FILTER
Test a FilterBox component with STATIC_FILTER
Test a Facet component

Click on a static filter option. Navigate backwards in history. Make sure
the results AND the url reflect correctly in the back nav (that is, the filter
value changes in the URL and the results show the previous state).

Try going from FilterBox.filter0=[[something]] to FilterBox.filter0=[[nothing]]
Try going from FilterBox.filter0=[[something]] to FilterBox.filter0=[[somethingelse]]