### PR TITLE
Add the Stylelint-Scss plugin.

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,10 +1,16 @@
 {
+    "plugins": [
+        "stylelint-scss"
+    ],
     "rules": {
         "color-no-invalid-hex": true,
         "function-calc-no-invalid": true,
         "unit-no-unknown": true,
         "property-no-unknown": true,
         "declaration-block-no-duplicate-properties": true,
-        "no-duplicate-selectors": true
+        "no-duplicate-selectors": true,
+        "scss/dollar-variable-default": [true, { "ignore": "local" }],
+        "scss/at-import-no-partial-leading-underscore": true,
+        "scss/at-import-partial-extension": "never"
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9134,8 +9134,7 @@
     "indexes-of": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
-      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
-      "dev": true
+      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
     },
     "indexof": {
       "version": "0.0.1",
@@ -11339,8 +11338,7 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -13475,8 +13473,7 @@
     "postcss-media-query-parser": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
-      "integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ=",
-      "dev": true
+      "integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ="
     },
     "postcss-merge-longhand": {
       "version": "4.0.11",
@@ -13821,8 +13818,7 @@
     "postcss-resolve-nested-selector": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
-      "integrity": "sha1-Kcy8fDfe36wwTp//C/FZaz9qDk4=",
-      "dev": true
+      "integrity": "sha1-Kcy8fDfe36wwTp//C/FZaz9qDk4="
     },
     "postcss-safe-parser": {
       "version": "4.0.2",
@@ -17214,6 +17210,40 @@
         }
       }
     },
+    "stylelint-scss": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.18.0.tgz",
+      "integrity": "sha512-LD7+hv/6/ApNGt7+nR/50ft7cezKP2HM5rI8avIdGaUWre3xlHfV4jKO/DRZhscfuN+Ewy9FMhcTq0CcS0C/SA==",
+      "requires": {
+        "lodash": "^4.17.15",
+        "postcss-media-query-parser": "^0.2.3",
+        "postcss-resolve-nested-selector": "^0.1.1",
+        "postcss-selector-parser": "^6.0.2",
+        "postcss-value-parser": "^4.1.0"
+      },
+      "dependencies": {
+        "cssesc": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+          "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
+        },
+        "postcss-selector-parser": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
+          "integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
+          "requires": {
+            "cssesc": "^3.0.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        },
+        "postcss-value-parser": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
+          "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ=="
+        }
+      }
+    },
     "sugarss": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/sugarss/-/sugarss-2.0.0.tgz",
@@ -18954,8 +18984,7 @@
     "uniq": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
-      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
-      "dev": true
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
     },
     "uniqs": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lodash.clonedeep": "^4.5.0",
     "markdown-it-for-inline": "^0.1.1",
     "plural-forms": "^0.5.1",
+    "stylelint-scss": "^3.18.0",
     "template-helpers": "^1.0.1"
   },
   "devDependencies": {

--- a/src/ui/sass/modules/_StandardCard.scss
+++ b/src/ui/sass/modules/_StandardCard.scss
@@ -6,7 +6,7 @@ $standard-card-link-color: var(--yxt-color-brand-primary) !default;
 $standard-card-subtitle-color: var(--yxt-color-text-secondary) !default;
 $standard-card-link-hover-color: var(--yxt-color-brand-hover) !default;
 
-$standard-card-text-min-width: calc(8 * var(--yxt-standard-card-base-spacing));
+$standard-card-text-min-width: calc(8 * var(--yxt-standard-card-base-spacing)) !default;
 
 $standard-card-cta-width: calc(8 * var(--yxt-standard-card-base-spacing)) !default;
 $standard-card-wrapper-width: calc(10 * var(--yxt-standard-card-base-spacing)) !default;


### PR DESCRIPTION
This PR adds the Stylelin-Scss plugin and registers it with Stylelint. By
default, Stylelint's rules pertain to standard CSS. It can parse SCSS to ensure
that these rules are being followed. But, it has no rules specific to SCSS
syntax. That's what the Stylelint-Scss plugin allows for. I've selected a few
SCSS rules provided by the plugin:

- dollar-variable-default: This enforces that all $-variable declrations
  include !default.
- at-import-no-partial-leading-underscore: This disallows leading underscores
  in partial names for all @impor statements.
- at-import-partial-extension: This enforces that all @import statements leave
  out the extension.

There was one violation of the dollar-variable-default which I fixed.

J=SLAP-131
TEST=auto

Made sure stylelint checks passed.