### PR TITLE
Add a resultsCountByVertical entry to the onUniversalSearch input.

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,16 @@ function (searchParams) => {
      */
     const sectionsCount = searchParams.sectionsCount;
 
+    /**
+     * A map containing entries of the form:
+     * { totalResultsCount: 150, displayedResultsCount: 10}
+     * for each returned vertical. The totalResultsCount indicates how many results
+     * are present in the vertical. The displayResultsCount indicates how many of
+     * those results are actually displayed.
+     * @type {Object<string,Object>}
+     */
+    const resultsCountByVertical = searchParams.resultsCountByVertical;
+
     let analyticsEvent = new ANSWERS.AnalyticsEvent('ANALYTICS_EVENT_TYPE');
     analyticsEvent.addOptions({
       type: 'ANALYTICS_EVENT_TYPE',

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -15,7 +15,6 @@ import QueryTriggers from './models/querytriggers';
 import StorageKeys from './storage/storagekeys';
 import AnalyticsEvent from './analytics/analyticsevent';
 import FilterRegistry from './filters/filterregistry';
-import Section from './models/section';
 
 /** @typedef {import('./services/searchservice').default} SearchService */
 /** @typedef {import('./services/autocompleteservice').default} AutoCompleteService */
@@ -309,7 +308,7 @@ export default class Core {
         this.globalStorage.delete(StorageKeys.QUERY_TRIGGER);
 
         const exposedParams = this._getOnUniversalSearchParams(
-          data[StorageKeys.UNIVERSAL_RESULTS].sections, 
+          data[StorageKeys.UNIVERSAL_RESULTS].sections,
           queryString);
         const analyticsEvent = this.onUniversalSearch(exposedParams);
         if (typeof analyticsEvent === 'object') {
@@ -321,12 +320,12 @@ export default class Core {
   /**
    * Builds the object passed as a parameter to onUniversalSearch. This object
    * contains information about the universal search's query and result counts.
-   * 
+   *
    * @param {Array<Section>} sections The sections of results.
-   * @param {string} queryString The search query. 
+   * @param {string} queryString The search query.
    * @return {Object<string, ?>}
    */
-  _getOnUniversalSearchParams(sections, queryString) {
+  _getOnUniversalSearchParams (sections, queryString) {
     const resultsCountByVertical = sections.reduce(
       (resultsCountMap, section) => {
         const { verticalConfigId, resultsCount, results } = section;

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -15,6 +15,7 @@ import QueryTriggers from './models/querytriggers';
 import StorageKeys from './storage/storagekeys';
 import AnalyticsEvent from './analytics/analyticsevent';
 import FilterRegistry from './filters/filterregistry';
+import Section from './models/section';
 
 /** @typedef {import('./services/searchservice').default} SearchService */
 /** @typedef {import('./services/autocompleteservice').default} AutoCompleteService */
@@ -307,28 +308,42 @@ export default class Core {
         this.globalStorage.delete('skipSpellCheck');
         this.globalStorage.delete(StorageKeys.QUERY_TRIGGER);
 
-        const universalSections = data[StorageKeys.UNIVERSAL_RESULTS].sections;
-        const resultsCountByVertical = universalSections.reduce(
-          (resultsCountMap, section) => {
-            const { verticalConfigId, resultsCount, results } = section;
-            resultsCountMap[verticalConfigId] = {
-              totalResultsCount: resultsCount,
-              displayedResultsCount: results.length
-            };
-            return resultsCountMap;
-          },
-          {});
-
-        const exposedParams = {
-          queryString,
-          sectionsCount: universalSections.length,
-          resultsCountByVertical
-        };
+        const exposedParams = this._getOnUniversalSearchParams(
+          data[StorageKeys.UNIVERSAL_RESULTS].sections, 
+          queryString);
         const analyticsEvent = this.onUniversalSearch(exposedParams);
         if (typeof analyticsEvent === 'object') {
           this._analyticsReporter.report(AnalyticsEvent.fromData(analyticsEvent));
         }
       });
+  }
+
+  /**
+   * Builds the object passed as a parameter to onUniversalSearch. This object
+   * contains information about the universal search's query and result counts.
+   * 
+   * @param {Array<Section>} sections The sections of results.
+   * @param {string} queryString The search query. 
+   * @return {Object<string, ?>}
+   */
+  _getOnUniversalSearchParams(sections, queryString) {
+    const resultsCountByVertical = sections.reduce(
+      (resultsCountMap, section) => {
+        const { verticalConfigId, resultsCount, results } = section;
+        resultsCountMap[verticalConfigId] = {
+          totalResultsCount: resultsCount,
+          displayedResultsCount: results.length
+        };
+        return resultsCountMap;
+      },
+      {});
+    const exposedParams = {
+      queryString,
+      sectionsCount: sections.length,
+      resultsCountByVertical
+    };
+
+    return exposedParams;
   }
 
   /**

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -307,9 +307,22 @@ export default class Core {
         this.globalStorage.delete('skipSpellCheck');
         this.globalStorage.delete(StorageKeys.QUERY_TRIGGER);
 
+        const universalSections = data[StorageKeys.UNIVERSAL_RESULTS].sections;
+        const resultsCountByVertical = universalSections.reduce(
+          (resultsCountMap, section) => {
+            const { verticalConfigId, resultsCount, results } = section;
+            resultsCountMap[verticalConfigId] = {
+              totalResultsCount: resultsCount,
+              displayedResultsCount: results.length
+            };
+            return resultsCountMap;
+          },
+          {});
+
         const exposedParams = {
-          queryString: queryString,
-          sectionsCount: data[StorageKeys.UNIVERSAL_RESULTS].sections.length
+          queryString,
+          sectionsCount: universalSections.length,
+          resultsCountByVertical
         };
         const analyticsEvent = this.onUniversalSearch(exposedParams);
         if (typeof analyticsEvent === 'object') {


### PR DESCRIPTION
This PR adds a new entry to the Object passed to onUniversalSearch. This entry,
called resultsCountByVertical, is an Object with values of the form:

{ totalResultsCount: 150, displayedResultsCount: 10}

for each returned vertical. The totalResults count indicates how many results
were found for that vertical. The displayedResultsCount indicates how many
of those results are actually displayed. This additional info was requested
by Mercy. But, it seemed generally useful, so we're adding it to the SDK
officially.

J=SLAP-648
TEST=manual

On a local test site, logged the param passed to onUniversalSearch. I verified
that the resultsCountByVertical was correct by comparing it against the
LiveAPI response.