### PR TITLE
Update translation helper interfaces

### DIFF
--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -514,8 +514,10 @@ class Answers {
   }
 
   /**
-   * Processes a translation which includes performing interpolation, pluralization, or both
-   * @param {string} translations The translations, or a stringified JSON of possible translations
+   * Processes a translation which includes performing interpolation, pluralization, or
+   * both
+   * @param {string | Object} translations The translation, or an object containing
+   * translated plural forms
    * @param {Object} interpolationParams Params to use during interpolation
    * @param {number} count The count associated with the pluralization
    * @returns {string} The translation with any interpolation or pluralization applied

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -273,13 +273,13 @@ class Answers {
 
     if (parsedConfig.useTemplates === false || parsedConfig.templateBundle) {
       if (parsedConfig.templateBundle) {
-        this.renderer.init(parsedConfig.templateBundle, parsedConfig.locale);
+        this.renderer.init(parsedConfig.templateBundle, this._getInitLocale());
       }
     } else {
       // Templates are currently downloaded separately from the CORE and UI bundle.
       // Future enhancement is to ship the components with templates in a separate bundle.
       this.templates = new DefaultTemplatesLoader(templates => {
-        this.renderer.init(templates, parsedConfig.locale);
+        this.renderer.init(templates, this._getInitLocale());
       });
     }
 
@@ -524,10 +524,19 @@ class Answers {
    * @returns {string} The translation with any interpolation or pluralization applied
    */
   processTranslation (translations, interpolationParams, count, language) {
-    const initLocale = this.core.globalStorage.getState(StorageKeys.LOCALE);
+    const initLocale = this._getInitLocale();
     language = language || initLocale.substring(0, 2);
 
     return TranslationProcessor.process(translations, interpolationParams, count, language);
+  }
+
+  /**
+   * Gets the locale that ANSWERS was initialized to. Defaults to 'en'
+   *
+   * @returns {string}
+   */
+  _getInitLocale () {
+    return this.core.globalStorage.getState(StorageKeys.LOCALE) || 'en';
   }
 }
 

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -524,7 +524,7 @@ class Answers {
    * @returns {string} The translation with any interpolation or pluralization applied
    */
   processTranslation (translations, interpolationParams, count, language) {
-    const initLocale = this.core.globalStorage.get(StorageKeys.LOCALE);
+    const initLocale = this.core.globalStorage.getState(StorageKeys.LOCALE);
     language = language || initLocale.substring(0, 2);
 
     return TranslationProcessor.process(translations, interpolationParams, count, language);

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -273,13 +273,13 @@ class Answers {
 
     if (parsedConfig.useTemplates === false || parsedConfig.templateBundle) {
       if (parsedConfig.templateBundle) {
-        this.renderer.init(parsedConfig.templateBundle);
+        this.renderer.init(parsedConfig.templateBundle, parsedConfig.locale);
       }
     } else {
       // Templates are currently downloaded separately from the CORE and UI bundle.
       // Future enhancement is to ship the components with templates in a separate bundle.
       this.templates = new DefaultTemplatesLoader(templates => {
-        this.renderer.init(templates);
+        this.renderer.init(templates, parsedConfig.locale);
       });
     }
 
@@ -520,10 +520,14 @@ class Answers {
    * translated plural forms
    * @param {Object} interpolationParams Params to use during interpolation
    * @param {number} count The count associated with the pluralization
+   * @param {string} language The langauge associated with the pluralization
    * @returns {string} The translation with any interpolation or pluralization applied
    */
-  processTranslation (translations, interpolationParams, count) {
-    return TranslationProcessor.process(translations, interpolationParams, count);
+  processTranslation (translations, interpolationParams, count, language) {
+    const initLocale = this.core.globalStorage.get(StorageKeys.LOCALE);
+    language = language || initLocale.substring(0, 2);
+
+    return TranslationProcessor.process(translations, interpolationParams, count, language);
   }
 }
 

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -531,12 +531,12 @@ class Answers {
   }
 
   /**
-   * Gets the locale that ANSWERS was initialized to. Defaults to 'en'
+   * Gets the locale that ANSWERS was initialized to
    *
    * @returns {string}
    */
   _getInitLocale () {
-    return this.core.globalStorage.getState(StorageKeys.LOCALE) || 'en';
+    return this.core.globalStorage.getState(StorageKeys.LOCALE);
   }
 }
 

--- a/src/core/i18n/translationprocessor.js
+++ b/src/core/i18n/translationprocessor.js
@@ -2,10 +2,13 @@ import { getNPlurals, getPluralFunc, hasLang } from 'plural-forms/dist/minimal';
 
 export default class TranslationProcessor {
   /**
-   * Processes a translation which includes performing interpolation, pluralization, or both
-   * @param {string} translations The translations, or a stringified JSON of possible translations
+   * Processes a translation which includes performing interpolation, pluralization, or
+   * both
+   * @param {string | Object} translations The translation, or an object containing
+   * translated plural forms
    * @param {Object} interpolationParams Params to use during interpolation
    * @param {number} count The count associated with the pluralization
+   * @returns {string} The translation with any interpolation or pluralization applied
    */
   static process (translations, interpolationParams, count) {
     const stringToInterpolate = this._selectStringToInterpolate(translations, count);
@@ -13,35 +16,34 @@ export default class TranslationProcessor {
   }
 
   /**
-   * If translations is json, parse it and choose the correct plural form.
-   * Otherwise just return the non-interpolated translation string.
-   * @param {string} translations
+   * If translations is a string, return it
+   * Otherwise select the correct plural form based on count
+   * @param {string | Object } translations
    * @param {number} count
    * @returns {string}
    */
   static _selectStringToInterpolate (translations, count) {
-    try {
-      translations = JSON.parse(translations);
-    } catch (e) {
+    if (typeof translations === 'string') {
       return translations;
     }
+
     return this._selectPluralForm(translations, count);
   }
 
   /**
-   * Returns the correct plural form given a parsed translations object and count.
-   * @param {Object} parsedTranslations
+   * Returns the correct plural form given a translations object and count.
+   * @param {Object} translations
    * @param {number} count
    * @returns {string}
    */
-  static _selectPluralForm (parsedTranslations, count) {
-    let locale = parsedTranslations.locale;
+  static _selectPluralForm (translations, count) {
+    let locale = translations.locale;
     if (!hasLang(locale)) {
       locale = 'en';
     }
     const oneToNArray = this._generateArrayOneToN(locale);
     const pluralFormIndex = getPluralFunc(locale)(count, oneToNArray);
-    return parsedTranslations[pluralFormIndex];
+    return translations[pluralFormIndex];
   }
 
   /**

--- a/src/core/i18n/translationprocessor.js
+++ b/src/core/i18n/translationprocessor.js
@@ -8,14 +8,10 @@ export default class TranslationProcessor {
    * translated plural forms
    * @param {Object} interpolationParams Params to use during interpolation
    * @param {number} count The count associated with the pluralization
-   * @param {string} locale The locale associated with the pluralization
+   * @param {string} language The langauge associated with the pluralization
    * @returns {string} The translation with any interpolation or pluralization applied
    */
-  static process (translations, interpolationParams, count, locale) {
-    const localeFromInit = 'en';
-    locale = locale || localeFromInit;
-    const language = locale.substring(0, 2);
-
+  static process (translations, interpolationParams, count, language) {
     const stringToInterpolate = (typeof translations === 'string')
       ? translations
       : this._selectPluralForm(translations, count, language);
@@ -30,7 +26,7 @@ export default class TranslationProcessor {
    * @param {string} language
    * @returns {string}
    */
-  static _selectPluralForm (translations, count, language = 'en') {
+  static _selectPluralForm (translations, count, language) {
     if (!hasLang(language)) {
       language = 'en';
     }

--- a/src/core/i18n/translationprocessor.js
+++ b/src/core/i18n/translationprocessor.js
@@ -8,12 +8,17 @@ export default class TranslationProcessor {
    * translated plural forms
    * @param {Object} interpolationParams Params to use during interpolation
    * @param {number} count The count associated with the pluralization
+   * @param {string} locale The locale associated with the pluralization
    * @returns {string} The translation with any interpolation or pluralization applied
    */
-  static process (translations, interpolationParams, count) {
+  static process (translations, interpolationParams, count, locale) {
+    const localeFromInit = 'en';
+    locale = locale || localeFromInit;
+    const language = locale.substring(0, 2);
+
     const stringToInterpolate = (typeof translations === 'string')
       ? translations
-      : this._selectPluralForm(translations, count);
+      : this._selectPluralForm(translations, count, language);
 
     return this._interpolate(stringToInterpolate, interpolationParams);
   }
@@ -22,24 +27,24 @@ export default class TranslationProcessor {
    * Returns the correct plural form given a translations object and count.
    * @param {Object} translations
    * @param {number} count
+   * @param {string} language
    * @returns {string}
    */
-  static _selectPluralForm (translations, count) {
-    let locale = translations.locale;
-    if (!hasLang(locale)) {
-      locale = 'en';
+  static _selectPluralForm (translations, count, language = 'en') {
+    if (!hasLang(language)) {
+      language = 'en';
     }
-    const oneToNArray = this._generateArrayOneToN(locale);
-    const pluralFormIndex = getPluralFunc(locale)(count, oneToNArray);
+    const oneToNArray = this._generateArrayOneToN(language);
+    const pluralFormIndex = getPluralFunc(language)(count, oneToNArray);
     return translations[pluralFormIndex];
   }
 
   /**
-   * @param {string} locale
+   * @param {string} language
    * @returns {Array} an array of the form [0, 1, 2, ..., nPluralForms]
    */
-  static _generateArrayOneToN (locale) {
-    const numberOfPluralForms = getNPlurals(locale);
+  static _generateArrayOneToN (language) {
+    const numberOfPluralForms = getNPlurals(language);
     return Array.from((new Array(numberOfPluralForms)).keys());
   }
 

--- a/src/core/i18n/translationprocessor.js
+++ b/src/core/i18n/translationprocessor.js
@@ -11,23 +11,11 @@ export default class TranslationProcessor {
    * @returns {string} The translation with any interpolation or pluralization applied
    */
   static process (translations, interpolationParams, count) {
-    const stringToInterpolate = this._selectStringToInterpolate(translations, count);
+    const stringToInterpolate = (typeof translations === 'string')
+      ? translations
+      : this._selectPluralForm(translations, count);
+
     return this._interpolate(stringToInterpolate, interpolationParams);
-  }
-
-  /**
-   * If translations is a string, return it
-   * Otherwise select the correct plural form based on count
-   * @param {string | Object } translations
-   * @param {number} count
-   * @returns {string}
-   */
-  static _selectStringToInterpolate (translations, count) {
-    if (typeof translations === 'string') {
-      return translations;
-    }
-
-    return this._selectPluralForm(translations, count);
   }
 
   /**

--- a/src/ui/rendering/handlebarsrenderer.js
+++ b/src/ui/rendering/handlebarsrenderer.js
@@ -199,19 +199,22 @@ export default class HandlebarsRenderer extends Renderer {
       let { phrase, count } = options.hash;
 
       Object.entries(options.hash).forEach(([key, value]) => {
+        const isPluralFormParam = key.length > 10 && key.substring(0, 10) === 'pluralForm';
         if (key === 'locale') {
           pluralizationInfo['locale'] = value;
-        } else if (key.length > 10 && key.substring(0, 10) === 'pluralForm') {
-          const pluralFormNum = parseInt(key.substring(10));
-          pluralizationInfo[pluralFormNum] = value;
+        } else if (isPluralFormParam) {
+          const pluralFormIndex = parseInt(key.substring(10));
+          pluralizationInfo[pluralFormIndex] = value;
         } else {
           interpolationParams[key] = value;
         }
       });
 
-      return typeof phrase === 'string'
-        ? TranslationProcessor.process(phrase, interpolationParams, count)
-        : TranslationProcessor.process(pluralizationInfo, interpolationParams, count);
+      const isUsingPluralization = (typeof phrase !== 'string');
+
+      return isUsingPluralization
+        ? TranslationProcessor.process(pluralizationInfo, interpolationParams, count)
+        : TranslationProcessor.process(phrase, interpolationParams);
     });
 
     let self = this;

--- a/src/ui/rendering/handlebarsrenderer.js
+++ b/src/ui/rendering/handlebarsrenderer.js
@@ -196,6 +196,8 @@ export default class HandlebarsRenderer extends Renderer {
         : pluralText;
     });
 
+    let self = this;
+
     this.registerHelper('processTranslation', function (options) {
       const pluralizationInfo = {};
       const interpolationParams = {};
@@ -212,7 +214,7 @@ export default class HandlebarsRenderer extends Renderer {
 
       const isUsingPluralization = (typeof phrase !== 'string');
 
-      locale = locale || this._initLocale;
+      locale = locale || self._initLocale;
       const language = locale.substring(0, 2);
 
       return isUsingPluralization
@@ -220,7 +222,6 @@ export default class HandlebarsRenderer extends Renderer {
         : TranslationProcessor.process(phrase, interpolationParams);
     });
 
-    let self = this;
     self.registerHelper('icon', function (name, complexContentsParams, options) {
       let icon = Icons.default;
       if (!Icons[name]) {

--- a/src/ui/rendering/handlebarsrenderer.js
+++ b/src/ui/rendering/handlebarsrenderer.js
@@ -196,12 +196,10 @@ export default class HandlebarsRenderer extends Renderer {
     this.registerHelper('processTranslation', function (options) {
       const pluralizationInfo = {};
       const interpolationParams = {};
-      let { phrase, count } = options.hash;
+      let { phrase, count, locale } = options.hash;
 
       Object.entries(options.hash).forEach(([key, value]) => {
-        if (key === 'locale') {
-          pluralizationInfo['locale'] = value;
-        } else if (key.startsWith('pluralForm')) {
+        if (key.startsWith('pluralForm')) {
           const pluralFormIndex = parseInt(key.substring(10));
           pluralizationInfo[pluralFormIndex] = value;
         } else {
@@ -212,7 +210,7 @@ export default class HandlebarsRenderer extends Renderer {
       const isUsingPluralization = (typeof phrase !== 'string');
 
       return isUsingPluralization
-        ? TranslationProcessor.process(pluralizationInfo, interpolationParams, count)
+        ? TranslationProcessor.process(pluralizationInfo, interpolationParams, count, locale)
         : TranslationProcessor.process(phrase, interpolationParams);
     });
 

--- a/src/ui/rendering/handlebarsrenderer.js
+++ b/src/ui/rendering/handlebarsrenderer.js
@@ -28,11 +28,14 @@ export default class HandlebarsRenderer extends Renderer {
     this._templates = templates || {};
   }
 
-  init (templates) {
+  init (templates, locale) {
     // Assign the handlebars compiler and templates based on
     // information provided from external dep (in default case, it comes from external server request)
     this._handlebars = templates._hb;
     this._templates = templates;
+
+    // Store the locale that ANSWERS was initialized with
+    this._initLocale = locale;
 
     // TODO(billy) Once we re-write templates using the new helpers library
     // we probably don't need these custom helpers anymore
@@ -209,8 +212,11 @@ export default class HandlebarsRenderer extends Renderer {
 
       const isUsingPluralization = (typeof phrase !== 'string');
 
+      locale = locale || this._initLocale;
+      const language = locale.substring(0, 2);
+
       return isUsingPluralization
-        ? TranslationProcessor.process(pluralizationInfo, interpolationParams, count, locale)
+        ? TranslationProcessor.process(pluralizationInfo, interpolationParams, count, language)
         : TranslationProcessor.process(phrase, interpolationParams);
     });
 

--- a/src/ui/rendering/handlebarsrenderer.js
+++ b/src/ui/rendering/handlebarsrenderer.js
@@ -199,10 +199,9 @@ export default class HandlebarsRenderer extends Renderer {
       let { phrase, count } = options.hash;
 
       Object.entries(options.hash).forEach(([key, value]) => {
-        const isPluralFormParam = key.length > 10 && key.substring(0, 10) === 'pluralForm';
         if (key === 'locale') {
           pluralizationInfo['locale'] = value;
-        } else if (isPluralFormParam) {
+        } else if (key.startsWith('pluralForm')) {
           const pluralFormIndex = parseInt(key.substring(10));
           pluralizationInfo[pluralFormIndex] = value;
         } else {

--- a/src/ui/rendering/handlebarsrenderer.js
+++ b/src/ui/rendering/handlebarsrenderer.js
@@ -194,8 +194,24 @@ export default class HandlebarsRenderer extends Renderer {
     });
 
     this.registerHelper('processTranslation', function (options) {
+      const pluralizationInfo = {};
+      const interpolationParams = {};
       let { phrase, count } = options.hash;
-      return TranslationProcessor.process(phrase, options.hash, count);
+
+      Object.entries(options.hash).forEach(([key, value]) => {
+        if (key === 'locale') {
+          pluralizationInfo['locale'] = value;
+        } else if (key.length > 10 && key.substring(0, 10) === 'pluralForm') {
+          const pluralFormNum = parseInt(key.substring(10));
+          pluralizationInfo[pluralFormNum] = value;
+        } else {
+          interpolationParams[key] = value;
+        }
+      });
+
+      return typeof phrase === 'string'
+        ? TranslationProcessor.process(phrase, interpolationParams, count)
+        : TranslationProcessor.process(pluralizationInfo, interpolationParams, count);
     });
 
     let self = this;

--- a/tests/core/i18n/translationprocessor.js
+++ b/tests/core/i18n/translationprocessor.js
@@ -50,31 +50,26 @@ describe('selecting the correct plural form', () => {
   const translations = {
     0: 'Pasirinkta [[count]] tinklalapis',
     1: 'Pasirinkta [[count]] tinklalapiai',
-    2: 'Pasirinkta [[count]] tinklalapių',
-    locale: 'lt-LT'
+    2: 'Pasirinkta [[count]] tinklalapių'
   };
 
   it('uses key_0 when count = 1', () => {
-    const translation = TranslationProcessor.process(translations, { count: 1 }, 1);
+    const translation = TranslationProcessor.process(translations, { count: 1 }, 1, 'lt-LT');
     expect(translation).toEqual('Pasirinkta 1 tinklalapis');
   });
 
   it('uses key_1 when count = 2', () => {
-    const translation = TranslationProcessor.process(translations, { count: 2 }, 2);
+    const translation = TranslationProcessor.process(translations, { count: 2 }, 2, 'lt-LT');
     expect(translation).toEqual('Pasirinkta 2 tinklalapiai');
   });
 
   it('uses key_2 when count = 0', () => {
-    const translation = TranslationProcessor.process(translations, { count: 0 }, 0);
+    const translation = TranslationProcessor.process(translations, { count: 0 }, 0, 'lt-LT');
     expect(translation).toEqual('Pasirinkta 0 tinklalapių');
   });
 
   it('defaults locale to en when given a bogus locale', () => {
-    const bogusTranslations = {
-      ...translations,
-      locale: 'hawaii'
-    };
-    const translation = TranslationProcessor.process(bogusTranslations, { count: 100 }, 100);
+    const translation = TranslationProcessor.process(translations, { count: 100 }, 100, 'hawaii');
     expect(translation).toEqual('Pasirinkta 100 tinklalapiai');
   });
 });

--- a/tests/core/i18n/translationprocessor.js
+++ b/tests/core/i18n/translationprocessor.js
@@ -12,22 +12,22 @@ describe('processTranslation usage', () => {
   });
 
   it('simple pluralization with singular count', () => {
-    const translation = TranslationProcessor.process('{"0":"fleur","1":"fleurs","locale":"fr-FR"}', {}, 1);
+    const translation = TranslationProcessor.process({ 0: 'fleur', 1: 'fleurs', locale: 'fr-FR' }, {}, 1);
     expect(translation).toEqual('fleur');
   });
 
   it('simple pluralization with plural count', () => {
-    const translation = TranslationProcessor.process('{"0":"fleur","1":"fleurs","locale":"fr-FR"}', {}, 2);
+    const translation = TranslationProcessor.process({ 0: 'fleur', 1: 'fleurs', locale: 'fr-FR' }, {}, 2);
     expect(translation).toEqual('fleurs');
   });
 
   it('pluralization with singular count and interpolation', () => {
-    const translation = TranslationProcessor.process('{"0":"Un article [[name]]","1":"Les articles [[name]]","locale":"fr-FR"}', { name: 'de presse' }, 1);
+    const translation = TranslationProcessor.process({ 0: 'Un article [[name]]', 1: 'Les articles [[name]]', locale: 'fr-FR' }, { name: 'de presse' }, 1);
     expect(translation).toEqual('Un article de presse');
   });
 
   it('pluralization with plural count and interpolation', () => {
-    const translation = TranslationProcessor.process('{"0":"Un article [[name]]","1":"Les articles [[name]]","locale":"fr-FR"}', { name: 'de presse' }, 2);
+    const translation = TranslationProcessor.process({ 0: 'Un article [[name]]', 1: 'Les articles [[name]]', locale: 'fr-FR' }, { name: 'de presse' }, 2);
     expect(translation).toEqual('Les articles de presse');
   });
 
@@ -39,7 +39,7 @@ describe('processTranslation usage', () => {
   it('intermixed markdown with pluralization', () => {
     const count = 2;
     const translation = TranslationProcessor.process(
-      '{"0":"<b>Voir notre site web [[name]]</b>","1":"<b>Voir nos sites web [[name]]</b>","locale":"fr-FR"}',
+      { 0: '<b>Voir notre site web [[name]]</b>', 1: '<b>Voir nos sites web [[name]]</b>', locale: 'fr-FR' },
       { name: 'Howard' },
       count);
     expect(translation).toEqual('<b>Voir nos sites web Howard</b>');
@@ -47,13 +47,12 @@ describe('processTranslation usage', () => {
 });
 
 describe('selecting the correct plural form', () => {
-  const phrase = {
+  const translations = {
     0: 'Pasirinkta [[count]] tinklalapis',
     1: 'Pasirinkta [[count]] tinklalapiai',
     2: 'Pasirinkta [[count]] tinklalapių',
     locale: 'lt-LT'
   };
-  const translations = JSON.stringify(phrase);
 
   it('uses key_0 when count = 1', () => {
     const translation = TranslationProcessor.process(translations, { count: 1 }, 1);
@@ -71,10 +70,10 @@ describe('selecting the correct plural form', () => {
   });
 
   it('defaults locale to en when given a bogus locale', () => {
-    const bogusTranslations = JSON.stringify({
-      ...phrase,
+    const bogusTranslations = {
+      ...translations,
       locale: 'hawaii'
-    });
+    };
     const translation = TranslationProcessor.process(bogusTranslations, { count: 100 }, 100);
     expect(translation).toEqual('Pasirinkta 100 tinklalapiai');
   });

--- a/tests/ui/rendering/handlebarsrenderer.js
+++ b/tests/ui/rendering/handlebarsrenderer.js
@@ -12,6 +12,7 @@ describe('the handlebars processTranslation helper', () => {
       phrase='Hello my name is [[firstName]] [[lastName]]'
       firstName=myFirstName
       lastName=myLastName
+      locale='en'
     }}`;
     const data = {
       myFirstName: 'Cat',

--- a/tests/ui/rendering/handlebarsrenderer.js
+++ b/tests/ui/rendering/handlebarsrenderer.js
@@ -5,7 +5,7 @@ describe('the handlebars processTranslation helper', () => {
   const renderer = new HandlebarsRenderer();
   renderer.init({
     '_hb': Handlebars
-  });
+  }, 'en');
 
   it('can translate a string phrase', () => {
     const template = `{{processTranslation
@@ -86,6 +86,47 @@ describe('the handlebars processTranslation helper', () => {
 
     it('uses key_2 when count = 0', () => {
       const translation = renderer.compile(template)({
+        myCount: 0
+      });
+      expect(translation).toEqual('Pasirinkta 0 tinklalapių');
+    });
+  });
+
+  describe('locale fallback behavior works as expected', () => {
+    it('use locale specified in the renderer init', () => {
+      const rendererWithLocale = new HandlebarsRenderer();
+      rendererWithLocale.init({
+        '_hb': Handlebars
+      }, 'lt-LT');
+
+      const template = `{{processTranslation
+        pluralForm0='Pasirinkta [[count]] tinklalapis'
+        pluralForm1='Pasirinkta [[count]] tinklalapiai'
+        pluralForm2='Pasirinkta [[count]] tinklalapių'
+        count=myCount
+      }}`;
+
+      const translation = rendererWithLocale.compile(template)({
+        myCount: 0
+      });
+      expect(translation).toEqual('Pasirinkta 0 tinklalapių');
+    });
+
+    it('locale in the template overrides the one in the init if specified', () => {
+      const rendererWithLocale = new HandlebarsRenderer();
+      rendererWithLocale.init({
+        '_hb': Handlebars
+      }, 'en');
+
+      const template = `{{processTranslation
+        pluralForm0='Pasirinkta [[count]] tinklalapis'
+        pluralForm1='Pasirinkta [[count]] tinklalapiai'
+        pluralForm2='Pasirinkta [[count]] tinklalapių'
+        locale='lt-LT'
+        count=myCount
+      }}`;
+
+      const translation = rendererWithLocale.compile(template)({
         myCount: 0
       });
       expect(translation).toEqual('Pasirinkta 0 tinklalapių');

--- a/tests/ui/rendering/handlebarsrenderer.js
+++ b/tests/ui/rendering/handlebarsrenderer.js
@@ -22,13 +22,10 @@ describe('the handlebars processTranslation helper', () => {
   });
 
   describe('when translating a plural phrase in en', () => {
-    const phrase = {
-      0: 'a [[size]] [[color]] cow tried to make a [[food]]',
-      1: '[[count]] [[size]] [[color]] cows tried to make a [[food]]',
-      locale: 'en'
-    };
     const template = `{{processTranslation
-      phrase='${JSON.stringify(phrase)}'
+      pluralForm0='a [[size]] [[color]] cow tried to make a [[food]]'
+      pluralForm1='[[count]] [[size]] [[color]] cows tried to make a [[food]]'
+      locale='en'
       size=mySize
       color=myColor
       food=myFood
@@ -64,14 +61,11 @@ describe('the handlebars processTranslation helper', () => {
   });
 
   describe('when translating a plural phrase in a locale with multiple plural forms', () => {
-    const phrase = {
-      0: 'Pasirinkta [[count]] tinklalapis',
-      1: 'Pasirinkta [[count]] tinklalapiai',
-      2: 'Pasirinkta [[count]] tinklalapių',
-      locale: 'lt-LT'
-    };
     const template = `{{processTranslation
-      phrase='${JSON.stringify(phrase)}'
+      pluralForm0='Pasirinkta [[count]] tinklalapis'
+      pluralForm1='Pasirinkta [[count]] tinklalapiai'
+      pluralForm2='Pasirinkta [[count]] tinklalapių'
+      locale='lt-LT'
       count=myCount
     }}`;
 


### PR DESCRIPTION
Update the translation helpers to no longer use stringified JSON

Update the TranslationProcessor to expect an object rather than stringified JSON for plural forms. Update the HBS helper to find pluralForm keys and and pass them to the TranslationProcessor in an object as the first parameter. Update fallback behavior surrounding TranslationProcessor by getting the locale if the option is specified and otherwise using the locale from the init. Get the language as first two characters of the locale. If it is supported, use that when selecting plural forms. Otherwise use 'en'.

J=SLAP-638
TEST=auto, manual

Update unit tests and confirm they pass. Run an internationalized jambo build and observe the translations working.