### PR TITLE
VerticalResultsCount: use VERTICAL_RESULTS storage key

### DIFF
--- a/src/ui/components/results/verticalresultscountcomponent.js
+++ b/src/ui/components/results/verticalresultscountcomponent.js
@@ -1,10 +1,15 @@
 import Component from '../component';
 import StorageKeys from '../../../core/storage/storagekeys';
+import SearchStates from '../../../core/storage/searchstates';
 
 export default class VerticalResultsCountComponent extends Component {
   constructor (config = {}, systemConfig = {}) {
     super(config, systemConfig);
-    this.moduleId = StorageKeys.RESULTS_HEADER;
+    this.core.globalStorage.on('update', StorageKeys.VERTICAL_RESULTS, results => {
+      if (results.searchState === SearchStates.SEARCH_COMPLETE) {
+        this.setState();
+      }
+    });
   }
 
   static areDuplicateNamesAllowed () {

--- a/src/ui/components/results/verticalresultscountcomponent.js
+++ b/src/ui/components/results/verticalresultscountcomponent.js
@@ -5,9 +5,9 @@ import SearchStates from '../../../core/storage/searchstates';
 export default class VerticalResultsCountComponent extends Component {
   constructor (config = {}, systemConfig = {}) {
     super(config, systemConfig);
-    this.core.globalStorage.on('update', StorageKeys.VERTICAL_RESULTS, results => {
-      if (results.searchState === SearchStates.SEARCH_COMPLETE) {
-        this.setState();
+    this.core.globalStorage.on('update', StorageKeys.VERTICAL_RESULTS, verticalResults => {
+      if (verticalResults.searchState === SearchStates.SEARCH_COMPLETE) {
+        this.setState(verticalResults);
       }
     });
   }
@@ -17,7 +17,7 @@ export default class VerticalResultsCountComponent extends Component {
   }
 
   setState (data) {
-    const verticalResults = this.core.globalStorage.getState(StorageKeys.VERTICAL_RESULTS) || {};
+    const verticalResults = data || {};
 
     /**
      * Total number of results.

--- a/tests/ui/components/results/verticalresultscountcomponent.js
+++ b/tests/ui/components/results/verticalresultscountcomponent.js
@@ -34,6 +34,7 @@ describe('results count component', () => {
     const COMPONENT_MANAGER = mockManager(
       {
         globalStorage: {
+          on: () => {},
           getState: key => {
             if (key === StorageKeys.VERTICAL_RESULTS) {
               return {
@@ -58,6 +59,7 @@ describe('results count component', () => {
     const COMPONENT_MANAGER = mockManager(
       {
         globalStorage: {
+          on: () => {},
           getState: key => {
             if (key === StorageKeys.VERTICAL_RESULTS) {
               return {

--- a/tests/ui/components/results/verticalresultscountcomponent.js
+++ b/tests/ui/components/results/verticalresultscountcomponent.js
@@ -32,23 +32,14 @@ describe('results count component', () => {
 
   it('renders the current results count', () => {
     const COMPONENT_MANAGER = mockManager(
-      {
-        globalStorage: {
-          on: () => {},
-          getState: key => {
-            if (key === StorageKeys.VERTICAL_RESULTS) {
-              return {
-                results: new Array(20),
-                resultsCount: 100
-              };
-            }
-            return null;
-          }
-        }
-      },
+      {},
       VerticalResultsCountComponent.defaultTemplateName()
     );
     const component = COMPONENT_MANAGER.create(VerticalResultsCountComponent.type, defaultConfig);
+    component.setState({
+      results: new Array(20),
+      resultsCount: 100
+    });
     const wrapper = mount(component);
     expect(wrapper.find('.yxt-VerticalResultsCount-start').text()).toEqual('1');
     expect(wrapper.find('.yxt-VerticalResultsCount-end').text()).toEqual('20');
@@ -61,12 +52,7 @@ describe('results count component', () => {
         globalStorage: {
           on: () => {},
           getState: key => {
-            if (key === StorageKeys.VERTICAL_RESULTS) {
-              return {
-                results: new Array(10),
-                resultsCount: 200
-              };
-            } else if (key === StorageKeys.SEARCH_OFFSET) {
+            if (key === StorageKeys.SEARCH_OFFSET) {
               return 40;
             }
             return null;
@@ -76,6 +62,10 @@ describe('results count component', () => {
       VerticalResultsCountComponent.defaultTemplateName()
     );
     const component = COMPONENT_MANAGER.create(VerticalResultsCountComponent.type, defaultConfig);
+    component.setState({
+      results: new Array(10),
+      resultsCount: 200
+    });
     const wrapper = mount(component);
     expect(wrapper.find('.yxt-VerticalResultsCount-start').text()).toEqual('41');
     expect(wrapper.find('.yxt-VerticalResultsCount-end').text()).toEqual('50');


### PR DESCRIPTION
VerticalResultsCount cannot use the StorageKeys.RESULTS_HEADER while a
VerticalResults component (that does not have hideResultsHeader: true)
is on the page, because of the bug that when an event listener is unregistered
(as happens with child components like the ResultsHeader inside VerticalResults)
it will unregister all other listeners for that storage key.

TEST=manual

Tested that I can have both a VerticalResults (with its own results header)
and a VerticalResultsCount on the same page, and both will update.