### PR TITLE
AutoComplete: add unique id to each li option

### DIFF
--- a/src/ui/templates/search/autocomplete.hbs
+++ b/src/ui/templates/search/autocomplete.hbs
@@ -1,3 +1,4 @@
+{{log this}}
 <div class="yxt-AutoComplete-wrapper js-yxt-AutoComplete-wrapper" aria-expanded="{{hasResults}}">
   {{#if hasResults}}
     <div class="yxt-AutoComplete">
@@ -29,6 +30,7 @@
               data-eventtype="AUTO_COMPLETE_SELECTION"
               data-eventoptions='{"suggestedSearchText": "{{value}}"}'
               role="option"
+              id="yxt-AutoComplete-option-{{../../_config.name}}-{{@../index}}-{{@index}}"
           >
               {{highlightValue this true}}
           </li>

--- a/src/ui/templates/search/autocomplete.hbs
+++ b/src/ui/templates/search/autocomplete.hbs
@@ -1,4 +1,3 @@
-{{log this}}
 <div class="yxt-AutoComplete-wrapper js-yxt-AutoComplete-wrapper" aria-expanded="{{hasResults}}">
   {{#if hasResults}}
     <div class="yxt-AutoComplete">


### PR DESCRIPTION
This commit adds a unique id to each autocomplete li option.
Because the autocomplete component has areDuplicateNamesAllowed
set to false (the default), _config.name should always be unique.
Html ids should not have spaces in them, which is not a restriction
set on component names, but we also use component instance names
in other html ids (see controls/date.hbs and controls/filteroptions.hbs)

J=SLAP-665
TEST=manual

on a universal and also vertical page, checked that each li option
in the searchbar autocomplete has an id that includes both name,
section index, and results index