### PR TITLE
acceptance tests: Replace unavailable filter on search

### DIFF
--- a/tests/acceptance/acceptancesuite.js
+++ b/tests/acceptance/acceptancesuite.js
@@ -92,9 +92,9 @@ test(`Facets load on the page, and can affect the search`, async t => {
   await t.expect(actualResultsCount).eql(expectedResultsCount);
 
   // Check that selecting multiple FilterOptions works
-  const brands = await filterBox.getFilterOptions('Brands');
-  await brands.toggleOption('E');
-  expectedResultsCount = await brands.getOptionCount('E');
+  const brands = await filterBox.getFilterOptions('Puppy Preference');
+  await brands.toggleOption('Frodo');
+  expectedResultsCount = await brands.getOptionCount('Frodo');
   await filterBox.applyFilters();
   actualResultsCount = await verticalResultsComponent.getResultsCountTotal();
   await t.expect(actualResultsCount).eql(expectedResultsCount);


### PR DESCRIPTION
We previously tried to verify filter options by clicking on 'Brands'
with the option 'E' but the Brands filter is no longer returned in the
specific search we try. Replace with a filter option that exists (Puppy
Preference).

J=None
TEST=acceptance