### PR TITLE
performance: Add performance marks at major events (#1065)

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -135,6 +135,7 @@ export default class Core {
    * @param {boolean} query.append If true, adds the results of this query to the end of the current results, defaults false
    */
   verticalSearch (verticalKey, options = {}, query = {}) {
+    window.performance.mark('yext.answers.verticalQueryStart');
     if (!query.append) {
       this.globalStorage.set(StorageKeys.VERTICAL_RESULTS, VerticalResults.searchLoading());
       this.globalStorage.set(StorageKeys.SPELL_CHECK, {});
@@ -232,6 +233,7 @@ export default class Core {
         if (typeof analyticsEvent === 'object') {
           this._analyticsReporter.report(AnalyticsEvent.fromData(analyticsEvent));
         }
+        window.performance.mark('yext.answers.verticalQueryResponseRendered');
       });
   }
 
@@ -264,6 +266,7 @@ export default class Core {
   }
 
   search (queryString, urls, options = {}) {
+    window.performance.mark('yext.answers.universalQueryStart');
     const { setQueryParams } = options;
     const context = this.globalStorage.getState(StorageKeys.API_CONTEXT);
     const referrerPageUrl = this.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL);
@@ -314,6 +317,7 @@ export default class Core {
         if (typeof analyticsEvent === 'object') {
           this._analyticsReporter.report(AnalyticsEvent.fromData(analyticsEvent));
         }
+        window.performance.mark('yext.answers.universalQueryResponseRendered');
       });
   }
 

--- a/src/core/search/searchapi.js
+++ b/src/core/search/searchapi.js
@@ -102,8 +102,12 @@ export default class SearchApi {
     };
     const request = new ApiRequest(requestConfig, { getState });
 
+    window.performance.mark('yext.answers.verticalQuerySent');
     return request.get()
-      .then(response => response.json());
+      .then(response => {
+        window.performance.mark('yext.answers.verticalQueryResponseReceived');
+        return response.json();
+      });
   }
 
   /** @inheritdoc */
@@ -130,7 +134,11 @@ export default class SearchApi {
     };
     const request = new ApiRequest(requestConfig, { getState });
 
+    window.performance.mark('yext.answers.universalQuerySent');
     return request.get()
-      .then(response => response.json());
+      .then(response => {
+        window.performance.mark('yext.answers.universalQueryResponseReceived');
+        return response.json();
+      });
   }
 }

--- a/tests/acceptance/acceptancesuite.js
+++ b/tests/acceptance/acceptancesuite.js
@@ -180,3 +180,37 @@ test('Facets, pagination, and filters do not persist accross experience links', 
   await t.expect(viewAllLink).contains('referrerPageUrl');
   await verifyCleanLink(viewAllLink);
 });
+
+fixture`Performance marks on search`
+  .before(setupServer)
+  .after(shutdownServer)
+  .page`http://localhost:9999/tests/acceptance/fixtures/html/facets`;
+
+test('window.performance calls are marked for a normal search', async t => {
+  const marksToCheck = [
+    'yext.answers.initStart',
+    'yext.answers.statusStart',
+    'yext.answers.statusEnd',
+    'yext.answers.ponyfillStart',
+    'yext.answers.ponyfillEnd',
+    'yext.answers.verticalQueryStart',
+    'yext.answers.verticalQuerySent',
+    'yext.answers.verticalQueryResponseReceived',
+    'yext.answers.verticalQueryResponseRendered'
+  ];
+  const searchComponent = FacetsPage.getSearchComponent();
+  await searchComponent.submitQuery();
+
+  // Wait for Results to be rendered
+  const resultsSelector = await Selector('.yxt-Results');
+  await resultsSelector.with({ visibilityCheck: true })();
+
+  // All performance marks should be called at least once with a search
+  for (let i = 0; i < marksToCheck.length; i++) {
+    const markName = marksToCheck[i];
+    const marksFoundWithName = await t.eval(() => {
+      return JSON.stringify(window.performance.getEntriesByName(markName));
+    }, { dependencies: { markName } });
+    await t.expect(JSON.parse(marksFoundWithName).length > 0).eql(true);
+  }
+});

--- a/tests/acceptance/acceptancesuite.js
+++ b/tests/acceptance/acceptancesuite.js
@@ -211,6 +211,6 @@ test('window.performance calls are marked for a normal search', async t => {
     const marksFoundWithName = await t.eval(() => {
       return JSON.stringify(window.performance.getEntriesByName(markName));
     }, { dependencies: { markName } });
-    await t.expect(JSON.parse(marksFoundWithName).length > 0).eql(true);
+    await t.expect(JSON.parse(marksFoundWithName.length)).gt(0);
   }
 });

--- a/tests/core/search/searchapi.js
+++ b/tests/core/search/searchapi.js
@@ -10,6 +10,10 @@ describe('vertical searching', () => {
   let searchApi;
 
   beforeEach(() => {
+    delete global.window.performance;
+    global.window.performance = {
+      mark: () => {}
+    };
     mockedRequest.mockClear();
     HttpRequester.mockImplementation(() => {
       return {


### PR DESCRIPTION
We add performance marks for better metrics into the time between the
initialization of answers and the subsequent major events like the first
query request sent or the query response rendering. Cherry-picked from
`feature/sept-regression-fixes`

J=SLAP-632
TEST=manual

Test that on a page load you see all nine performance marks in the
console window.performance.entries() (page with query, depends
on whether you are searching on a vertical or a universal for the
four query marks)

yext.answers.initStart
yext.answers.statusStart
yext.answers.statusEnd
yext.answers.ponyfillStart
yext.answers.ponyfillend
yext.answers.verticalQueryStart
yext.answers.verticalQuerySent
yext.answers.verticalQueryResponseReceived
yext.answers.verticalQueryResponseRendered
yext.answers.universalQueryStart
yext.answers.universalQuerySent
yext.answers.universalQueryResponseReceived
yext.answers.universalQueryResponseRendered