### PR TITLE
autocomplete: add wcag attributes to hbs

### DIFF
--- a/src/core/models/autocompletedata.js
+++ b/src/core/models/autocompletedata.js
@@ -13,10 +13,14 @@ export default class AutoCompleteData {
     if (response.sections) {
       sections = response.sections.map(s => ({
         label: s.label,
-        results: s.results.map(r => new AutoCompleteResult(r))
+        results: s.results.map(r => new AutoCompleteResult(r)),
+        resultsCount: s.results.length
       }));
     } else {
-      sections = [{ results: response.results.map(r => new AutoCompleteResult(r)) }];
+      sections = [{
+        results: response.results.map(r => new AutoCompleteResult(r)),
+        resultsCount: response.results.length
+      }];
     }
     let inputIntents = response.input ? response.input.queryIntents : [];
     return new AutoCompleteData({

--- a/src/ui/components/search/autocompletecomponent.js
+++ b/src/ui/components/search/autocompletecomponent.js
@@ -106,6 +106,12 @@ export default class AutoCompleteComponent extends Component {
     this._onChange = opts.onChange || function () {};
 
     this._searchParameters = opts.searchParameters || null;
+
+    /**
+     * HTML id for the aria-labelledby in the autocomplete list
+     * @type {string}
+     */
+    this.listLabelIdName = opts.listLabelIdName || 'yxt-SearchBar-listLabel--SearchBar';
   }
 
   /**
@@ -139,7 +145,8 @@ export default class AutoCompleteComponent extends Component {
       hasResults: this.hasResults(data),
       sectionIndex: this._sectionIndex,
       resultIndex: this._resultIndex,
-      promptHeader: this._originalQuery.length === 0 ? this.promptHeader : null
+      promptHeader: this._originalQuery.length === 0 ? this.promptHeader : null,
+      listLabelIdName: this.listLabelIdName
     }));
   }
 

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -197,6 +197,24 @@ export default class SearchComponent extends Component {
       message: 'We are unable to determine your location',
       ...config.geolocationTimeoutAlert
     };
+
+    /**
+     * The unique HTML id name for the autocomplete container
+     * @type {string}
+     */
+    this.autocompleteContainerIdName = `yxt-SearchBar-autocomplete--${this.name}`;
+
+    /**
+     * The unique HTML id name for the search input label
+     * @type {string}
+     */
+    this.inputLabelIdName = `yxt-SearchBar-inputLabel--${this.name}`;
+
+    /**
+     * The unique HTML id name for the search input
+     * @type {string}
+     */
+    this.inputIdName = `yxt-SearchBar-input--${this.name}`;
   }
 
   static get type () {
@@ -470,6 +488,7 @@ export default class SearchComponent extends Component {
       promptHeader: this.promptHeader,
       originalQuery: this.query,
       inputEl: inputSelector,
+      listLabelIdName: this.inputLabelIdName,
       onSubmit: () => {
         if (this._useForm) {
           DOM.trigger(DOM.query(this._container, this._formEl), 'submit');
@@ -646,7 +665,9 @@ export default class SearchComponent extends Component {
     };
     return super.setState(Object.assign({
       title: this.title,
+      inputIdName: this.inputIdName,
       labelText: this.labelText,
+      inputLabelIdName: this.inputLabelIdName,
       submitIcon: this.submitIcon,
       submitText: this.submitText,
       clearText: this.clearText,
@@ -657,7 +678,8 @@ export default class SearchComponent extends Component {
       forwardIconOpts: forwardIconOpts,
       reverseIconOpts: reverseIconOpts,
       autoFocus: this.autoFocus && !this.query,
-      useForm: this._useForm
+      useForm: this._useForm,
+      autocompleteContainerIdName: this.autocompleteContainerIdName
     }, data));
   }
 

--- a/src/ui/templates/search/autocomplete.hbs
+++ b/src/ui/templates/search/autocomplete.hbs
@@ -29,6 +29,7 @@
               data-eventtype="AUTO_COMPLETE_SELECTION"
               data-eventoptions='{"suggestedSearchText": "{{value}}"}'
               role="option"
+              id="yxt-AutoComplete-option-{{../../_config.name}}-{{@../index}}-{{@index}}"
           >
               {{highlightValue this true}}
           </li>

--- a/src/ui/templates/search/autocomplete.hbs
+++ b/src/ui/templates/search/autocomplete.hbs
@@ -10,7 +10,13 @@
         </ul>
       {{/if}}
       {{#each sections}}
-        <ul class="yxt-AutoComplete-results">
+        <span class="yxt-AutoComplete-resultsCount sr-only" aria-live="assertive">
+          {{resultsCount}} results found
+        </span>
+        <ul role="listbox"
+            class="yxt-AutoComplete-results"
+            aria-labelledby="{{../listLabelIdName}}"
+        >
         {{#if label}}
           <li class="yxt-AutoComplete-resultHeader">{{label}}</li>
         {{/if}}
@@ -22,6 +28,7 @@
               data-filter='{{json filter}}'
               data-eventtype="AUTO_COMPLETE_SELECTION"
               data-eventoptions='{"suggestedSearchText": "{{value}}"}'
+              role="option"
           >
               {{highlightValue this true}}
           </li>

--- a/src/ui/templates/search/search.hbs
+++ b/src/ui/templates/search/search.hbs
@@ -14,17 +14,28 @@
         {{> inputAndButtons}}
       </div>
     {{/if}}
-    <div class="yxt-SearchBar-autocomplete"></div>
+    <div id="{{autocompleteContainerIdName}}" class="yxt-SearchBar-autocomplete"></div>
   </div>
 </div>
 
 {{#*inline "inputAndButtons"}}
+  <label class="sr-only" 
+         for="{{inputIdName}}"
+         id="{{inputLabelIdName}}"
+  >
+    {{labelText}}
+  </label>
   <input class="js-yext-query yxt-SearchBar-input"
+          id="{{inputIdName}}"
           type="text"
           name="query"
           value="{{query}}"
           {{#if _config.placeholderText}}placeholder="{{_config.placeholderText}}"{{/if}}
-          aria-label="{{labelText}}">
+          aria-label="{{labelText}}"
+          aria-autocomplete="list"
+          aria-controls="{{autocompleteContainerIdName}}"
+          aria-haspopup="listbox"
+  >
   <button type="button"
           class="js-yxt-SearchBar-clear yxt-SearchBar-clear yxt-SearchBar--hidden"
           data-eventtype="SEARCH_CLEAR_BUTTON"


### PR DESCRIPTION
Previously in #1034 for 1.4. Have pivoted to have these changes in
develop (minor version) release instead.

For the autocomplete list, we add a variety of labels and roles to
better support screen reader identification.

We add a results count to the autocomplete with an aria-live="assertive"
so this attribute is called as updates are given.

J=SLAP-537
TEST=manual

Test on a local Jambo HH Theme repository with one searchbar.
Test that autocomplete items have unique IDs
Test that autocomplete total number of results is present in the DOM and
is accurate as you change the autocomplete results.