### PR TITLE
Revert search.hbs changes and change ambiguous autocomplete text

### DIFF
--- a/src/ui/templates/search/autocomplete.hbs
+++ b/src/ui/templates/search/autocomplete.hbs
@@ -11,7 +11,7 @@
       {{/if}}
       {{#each sections}}
         <span class="yxt-AutoComplete-resultsCount sr-only" aria-live="assertive">
-          {{resultsCount}} results found
+          {{resultsCount}} autocomplete options found
         </span>
         <ul role="listbox"
             class="yxt-AutoComplete-results"

--- a/src/ui/templates/search/search.hbs
+++ b/src/ui/templates/search/search.hbs
@@ -126,6 +126,6 @@
         </button>
       </div>
     {{/if}}
-    <div id="{{autocompleteContainerIdName}}" class="yxt-SearchBar-autocomplete yxt-AutoComplete-wrapper js-yxt-AutoComplete-wrapper"></div>
+    <div id="{{autocompleteContainerIdName}}" class="yxt-SearchBar-autocomplete"></div>
   </div>
 </div>


### PR DESCRIPTION
For some reason, class changes in search.hbs were reverted in a hotfix
merge unintentionally. Change this back.

Change here: https://github.com/yext/answers/commit/a9725df52c10b17ea6db0c2ddd40d95f3e41a03d#diff-9f173943e930639d5f15593e82df2676R17
Reverted here: https://github.com/yext/answers/commit/7b78776ed427d9394a50da14d1d789c46e25d761#diff-9f173943e930639d5f15593e82df2676R107

Change ambiguous text

J=None
TEST=manual

Test that the text says "autocomplete options" now instead of "results"
Test that there is no "yxt-AutoComplete-wrapper" class on the same level
as a "yxt-SearchBar" class