### PR TITLE
Use translated templates in jest tests instead of raw templates

### DIFF
--- a/tests/setup/managermocker.js
+++ b/tests/setup/managermocker.js
@@ -1,26 +1,11 @@
 /** @module ManagerMocker */
 
-import fs from 'fs';
-import path from 'path';
-
-import HandlebarsRenderer from '../../src/ui/rendering/handlebarsrenderer';
-import Handlebars from 'handlebars/dist/handlebars.min.js';
 import MockComponentManager from './mockcomponentmanager';
-import IconComponent from '../../src/ui/components/icons/iconcomponent';
 /**
  * Generates a MockComponentManager with templates from the passed in template paths.
  * TODO(oshi): better module/method names
  */
-export default function mockManager (mockedCore, ...templatePaths) {
-  const rendererOpts = {
-    '_hb': Handlebars,
-    [IconComponent.defaultTemplateName()]: Handlebars.compile(loadTemplate(IconComponent.defaultTemplateName()))
-  };
-
-  for (let i = 0; i < templatePaths.length; i++) {
-    const templatePath = templatePaths[i];
-    rendererOpts[templatePath] = Handlebars.compile(loadTemplate(templatePath));
-  }
+export default function mockManager (mockedCore) {
   const core = {
     globalStorage: {
       getState: () => null,
@@ -35,17 +20,11 @@ export default function mockManager (mockedCore, ...templatePaths) {
     },
     ...mockedCore
   };
-  const RENDERER = new HandlebarsRenderer(rendererOpts);
   const COMPONENT_MANAGER = new MockComponentManager(core);
-  COMPONENT_MANAGER.setRenderer(RENDERER);
 
   const mockAnalyticsReporter = {
     report: jest.fn(() => Promise.resolve())
   };
   COMPONENT_MANAGER.setAnalyticsReporter(mockAnalyticsReporter);
   return COMPONENT_MANAGER;
-}
-
-function loadTemplate (templatePath) {
-  return fs.readFileSync(path.join(__dirname, '../../src/ui/templates/', templatePath + '.hbs'), 'utf8');
 }

--- a/tests/setup/mockcomponentmanager.js
+++ b/tests/setup/mockcomponentmanager.js
@@ -17,7 +17,7 @@ export default class MockComponentManager {
     this.core = mockCore;
 
     this.renderer = new Renderers.Handlebars();
-    this.renderer.init(templates);
+    this.renderer.init(templates, 'en');
   }
 
   /**

--- a/tests/ui/components/filters/daterangecomponent.js
+++ b/tests/ui/components/filters/daterangecomponent.js
@@ -1,7 +1,6 @@
 import DOM from 'src/ui/dom/dom';
 import { mount } from 'enzyme';
 import mockManager from '../../../setup/managermocker';
-import DateRangeFilterComponent from 'src/ui/components/filters/daterangefiltercomponent';
 import Filter from 'src/core/models/filter';
 import FilterMetadata from '../../../../src/core/filters/filtermetadata';
 
@@ -31,10 +30,7 @@ describe('date range filter component', () => {
       }
     };
 
-    COMPONENT_MANAGER = mockManager(
-      mockCore,
-      DateRangeFilterComponent.defaultTemplateName()
-    );
+    COMPONENT_MANAGER = mockManager(mockCore);
 
     defaultConfig = {
       container: '#test-component'

--- a/tests/ui/components/filters/filterboxcomponent.js
+++ b/tests/ui/components/filters/filterboxcomponent.js
@@ -1,10 +1,8 @@
 import DOM from 'src/ui/dom/dom';
 import { mount } from 'enzyme';
 import mockManager from '../../../setup/managermocker';
-import FilterBoxComponent from 'src/ui/components/filters/filterboxcomponent';
 import FilterNodeFactory from 'src/core/filters/filternodefactory';
 import Filter from 'src/core/models/filter';
-import FilterOptionsComponent from 'src/ui/components/filters/filteroptionscomponent';
 import FilterCombinators from 'src/core/filters/filtercombinators';
 import FilterType from 'src/core/filters/filtertype';
 import PersistentStorage from 'src/ui/storage/persistentstorage';
@@ -81,11 +79,7 @@ describe('filter box component', () => {
       persistentStorage: new PersistentStorage()
     };
 
-    COMPONENT_MANAGER = mockManager(
-      mockCore,
-      FilterBoxComponent.defaultTemplateName(),
-      FilterOptionsComponent.defaultTemplateName()
-    );
+    COMPONENT_MANAGER = mockManager(mockCore);
 
     defaultConfig = {
       container: '#test-component',
@@ -324,11 +318,7 @@ describe('dynamic filterbox component', () => {
       }
     };
 
-    COMPONENT_MANAGER = mockManager(
-      mockCore,
-      FilterBoxComponent.defaultTemplateName(),
-      FilterOptionsComponent.defaultTemplateName()
-    );
+    COMPONENT_MANAGER = mockManager(mockCore);
 
     defaultConfig = {
       container: '#test-component',
@@ -504,11 +494,7 @@ describe('FilterBox reset button', () => {
     DOM.empty(bodyEl);
     DOM.append(bodyEl, DOM.createEl('div', { id: 'test-component' }));
 
-    COMPONENT_MANAGER = mockManager(
-      {},
-      FilterBoxComponent.defaultTemplateName(),
-      FilterOptionsComponent.defaultTemplateName()
-    );
+    COMPONENT_MANAGER = mockManager();
 
     defaultConfig = {
       container: '#test-component',

--- a/tests/ui/components/filters/filteroptionscomponent.js
+++ b/tests/ui/components/filters/filteroptionscomponent.js
@@ -1,7 +1,6 @@
 import DOM from 'src/ui/dom/dom';
 import { mount } from 'enzyme';
 import mockManager from '../../../setup/managermocker';
-import FilterOptionsComponent from 'src/ui/components/filters/filteroptionscomponent';
 import FilterNodeFactory from 'src/core/filters/filternodefactory';
 import Filter from 'src/core/models/filter';
 import FilterMetadata from 'src/core/filters/filtermetadata';
@@ -85,10 +84,7 @@ describe('filter options component', () => {
       persistentStorage: new PersistentStorage()
     };
 
-    COMPONENT_MANAGER = mockManager(
-      mockCore,
-      FilterOptionsComponent.defaultTemplateName()
-    );
+    COMPONENT_MANAGER = mockManager(mockCore);
 
     defaultConfig = {
       container: '#test-component',
@@ -402,20 +398,17 @@ describe('filter options component', () => {
       DOM.empty(bodyEl);
       DOM.append(bodyEl, DOM.createEl('div', { id: 'test-component' }));
 
-      COMPONENT_MANAGER = mockManager(
-        {
-          globalStorage: {
-            getState: key => {
-              if (key === 'test-previous-options') {
-                return ['label1', 'label2'];
-              }
-            },
-            delete: () => { }
+      COMPONENT_MANAGER = mockManager({
+        globalStorage: {
+          getState: key => {
+            if (key === 'test-previous-options') {
+              return ['label1', 'label2'];
+            }
           },
-          setStaticFilterNodes: () => { }
+          delete: () => { }
         },
-        FilterOptionsComponent.defaultTemplateName()
-      );
+        setStaticFilterNodes: () => { }
+      });
 
       defaultConfig = {
         container: '#test-component',
@@ -547,21 +540,18 @@ describe('filter options component', () => {
       setLocationRadiusFilterNode = jest.fn();
       setStaticFilterNodes = jest.fn();
 
-      COMPONENT_MANAGER = mockManager(
-        {
-          globalStorage: {
-            getState: () => { },
-            delete: () => { }
-          },
-          persistentStorage: {
-            set: () => { },
-            get: () => { }
-          },
-          setLocationRadiusFilterNode,
-          setStaticFilterNodes
+      COMPONENT_MANAGER = mockManager({
+        globalStorage: {
+          getState: () => { },
+          delete: () => { }
         },
-        FilterOptionsComponent.defaultTemplateName()
-      );
+        persistentStorage: {
+          set: () => { },
+          get: () => { }
+        },
+        setLocationRadiusFilterNode,
+        setStaticFilterNodes
+      });
 
       defaultConfig = {
         container: '#test-component',

--- a/tests/ui/components/filters/filtersearchcomponent.js
+++ b/tests/ui/components/filters/filtersearchcomponent.js
@@ -1,14 +1,10 @@
-import FilterSearchComponent from 'src/ui/components/search/filtersearchcomponent';
 import mockManager from '../../../setup/managermocker';
 import FilterNodeFactory from 'src/core/filters/filternodefactory';
 
 describe('FilterSearch', () => {
-  const COMPONENT_MANAGER = mockManager(
-    {
-      setStaticFilterNodes: () => {}
-    },
-    FilterSearchComponent.defaultTemplateName()
-  );
+  const COMPONENT_MANAGER = mockManager({
+    setStaticFilterNodes: () => {}
+  });
 
   it('builds FilterNodes correctly', () => {
     const title = 'abcdefg';

--- a/tests/ui/components/filters/geolocationcomponent.js
+++ b/tests/ui/components/filters/geolocationcomponent.js
@@ -1,4 +1,3 @@
-import GeolocationComponent from 'src/ui/components/filters/geolocationcomponent';
 import mockManager from '../../../setup/managermocker';
 import FilterNodeFactory from 'src/core/filters/filternodefactory';
 import Filter from 'src/core/models/filter';
@@ -10,10 +9,7 @@ describe('GeoLocationFilter', () => {
   beforeEach(() => {
     setStaticFilterNodes = jest.fn();
     getCurrentPosition = jest.fn();
-    COMPONENT_MANAGER = mockManager(
-      { setStaticFilterNodes },
-      GeolocationComponent.defaultTemplateName()
-    );
+    COMPONENT_MANAGER = mockManager({ setStaticFilterNodes });
 
     const mockGeolocation = { getCurrentPosition };
     global.navigator.geolocation = mockGeolocation;

--- a/tests/ui/components/filters/rangefiltercomponent.js
+++ b/tests/ui/components/filters/rangefiltercomponent.js
@@ -1,7 +1,6 @@
 import DOM from 'src/ui/dom/dom';
 import { mount } from 'enzyme';
 import mockManager from '../../../setup/managermocker';
-import RangeFilterComponent from 'src/ui/components/filters/rangefiltercomponent';
 import Filter from 'src/core/models/filter';
 import FilterMetadata from '../../../../src/core/filters/filtermetadata';
 
@@ -28,10 +27,7 @@ describe('range filter component', () => {
       }
     };
 
-    COMPONENT_MANAGER = mockManager(
-      mockCore,
-      RangeFilterComponent.defaultTemplateName()
-    );
+    COMPONENT_MANAGER = mockManager(mockCore);
 
     defaultConfig = {
       container: '#test-component'

--- a/tests/ui/components/filters/sortoptionscomponent.js
+++ b/tests/ui/components/filters/sortoptionscomponent.js
@@ -37,10 +37,7 @@ const mockedCore = () => {
 
 DOM.setup(document, new DOMParser());
 
-const COMPONENT_MANAGER = mockManager(
-  mockedCore(),
-  SortOptionsComponent.defaultTemplateName()
-);
+const COMPONENT_MANAGER = mockManager(mockedCore());
 
 describe('sort options component', () => {
   const systemConfig = { core: mockedCore() };

--- a/tests/ui/components/results/paginationcomponent.js
+++ b/tests/ui/components/results/paginationcomponent.js
@@ -3,7 +3,6 @@ import { mount } from 'enzyme';
 import DOM from '../../../../src/ui/dom/dom';
 import mockManager from '../../../setup/managermocker';
 import StorageKeys from '../../../../src/core/storage/storagekeys';
-import PaginationComponent from '../../../../src/ui/components/results/paginationcomponent';
 
 const mockedCore = () => {
   // pagination will hide itself if there are no results, so we fake the relevant global storage.
@@ -37,10 +36,7 @@ const mockedCore = () => {
 
 DOM.setup(document, new DOMParser());
 
-const COMPONENT_MANAGER = mockManager(
-  mockedCore(),
-  PaginationComponent.defaultTemplateName()
-);
+const COMPONENT_MANAGER = mockManager(mockedCore());
 
 describe('rendering the arrows', () => {
   let defaultConfig;

--- a/tests/ui/components/results/resultsheadercomponent.js
+++ b/tests/ui/components/results/resultsheadercomponent.js
@@ -1,6 +1,5 @@
 /* eslint camelcase: 0 */
 
-import ResultsHeaderComponent from 'src/ui/components/results/resultsheadercomponent';
 import mockManager from '../../../setup/managermocker';
 import FilterNodeFactory from '../../../../src/core/filters/filternodefactory';
 import Filter from '../../../../src/core/models/filter';
@@ -11,14 +10,11 @@ describe('ResultsHeaderComponent\'s applied filters', () => {
   let resultsHeaderComponent;
   let node_f0_v0, node_f0_v1, node_f1_v0, node_f1_v1;
   let remove_f0_v0_fn, remove_f0_v1_fn, remove_f1_v0_fn, remove_f1_v1_fn;
-  let COMPONENT_MANAGER = mockManager(
-    {
-      filterRegistry: {
-        getAllFilterNodes: () => []
-      }
-    },
-    ResultsHeaderComponent.defaultTemplateName()
-  );
+  let COMPONENT_MANAGER = mockManager({
+    filterRegistry: {
+      getAllFilterNodes: () => []
+    }
+  });
 
   beforeEach(() => {
     resultsHeaderComponent = COMPONENT_MANAGER.create('ResultsHeader', {});
@@ -161,15 +157,12 @@ describe('ResultsHeaderComponent\'s applied filters', () => {
 
     // Mock src/core.js functionality
     const verticalSearchFn = jest.fn();
-    COMPONENT_MANAGER = mockManager(
-      {
-        verticalSearch: verticalSearchFn,
-        filterRegistry: {
-          getAllFilterNodes: () => [ node_f0_v0, node_f0_v1, node_f1_v0 ]
-        }
-      },
-      ResultsHeaderComponent.defaultTemplateName()
-    );
+    COMPONENT_MANAGER = mockManager({
+      verticalSearch: verticalSearchFn,
+      filterRegistry: {
+        getAllFilterNodes: () => [ node_f0_v0, node_f0_v1, node_f1_v0 ]
+      }
+    });
 
     // Initialize and mount component
     resultsHeaderComponent = COMPONENT_MANAGER.create('ResultsHeader', {

--- a/tests/ui/components/results/verticalresultscomponent.js
+++ b/tests/ui/components/results/verticalresultscomponent.js
@@ -29,10 +29,7 @@ const mockCore = {
 
 DOM.setup(document, new DOMParser());
 
-const COMPONENT_MANAGER = mockManager(
-  mockCore,
-  VerticalResultsComponent.defaultTemplateName()
-);
+const COMPONENT_MANAGER = mockManager(mockCore);
 COMPONENT_MANAGER.getComponentNamesForComponentTypes = () => {
   return [];
 };

--- a/tests/ui/components/results/verticalresultscountcomponent.js
+++ b/tests/ui/components/results/verticalresultscountcomponent.js
@@ -35,7 +35,6 @@ describe('results count component', () => {
       resultsCount: 100
     });
     const wrapper = mount(component);
-    console.log(wrapper.debug());
     expect(wrapper.find('.yxt-VerticalResultsCount-start').text()).toEqual('1');
     expect(wrapper.find('.yxt-VerticalResultsCount-end').text()).toEqual('20');
     expect(wrapper.find('.yxt-VerticalResultsCount-total').text()).toEqual('100');
@@ -59,7 +58,6 @@ describe('results count component', () => {
       resultsCount: 200
     });
     const wrapper = mount(component);
-    console.log(wrapper.debug());
     expect(wrapper.find('.yxt-VerticalResultsCount-start').text()).toEqual('41');
     expect(wrapper.find('.yxt-VerticalResultsCount-end').text()).toEqual('50');
     expect(wrapper.find('.yxt-VerticalResultsCount-total').text()).toEqual('200');

--- a/tests/ui/components/results/verticalresultscountcomponent.js
+++ b/tests/ui/components/results/verticalresultscountcomponent.js
@@ -21,52 +21,45 @@ describe('results count component', () => {
   });
 
   it('does not render before a search is made', () => {
-    const COMPONENT_MANAGER = mockManager(
-      {},
-      VerticalResultsCountComponent.defaultTemplateName()
-    );
+    const COMPONENT_MANAGER = mockManager();
     const component = COMPONENT_MANAGER.create(VerticalResultsCountComponent.type, defaultConfig);
     const wrapper = mount(component);
     expect(wrapper.exists('.yxt-VerticalResultsCount')).toBeFalsy();
   });
 
   it('renders the current results count', () => {
-    const COMPONENT_MANAGER = mockManager(
-      {},
-      VerticalResultsCountComponent.defaultTemplateName()
-    );
+    const COMPONENT_MANAGER = mockManager();
     const component = COMPONENT_MANAGER.create(VerticalResultsCountComponent.type, defaultConfig);
     component.setState({
       results: new Array(20),
       resultsCount: 100
     });
     const wrapper = mount(component);
+    console.log(wrapper.debug());
     expect(wrapper.find('.yxt-VerticalResultsCount-start').text()).toEqual('1');
     expect(wrapper.find('.yxt-VerticalResultsCount-end').text()).toEqual('20');
     expect(wrapper.find('.yxt-VerticalResultsCount-total').text()).toEqual('100');
   });
 
   it('works with search offset', () => {
-    const COMPONENT_MANAGER = mockManager(
-      {
-        globalStorage: {
-          on: () => {},
-          getState: key => {
-            if (key === StorageKeys.SEARCH_OFFSET) {
-              return 40;
-            }
-            return null;
+    const COMPONENT_MANAGER = mockManager({
+      globalStorage: {
+        on: () => {},
+        getState: key => {
+          if (key === StorageKeys.SEARCH_OFFSET) {
+            return 40;
           }
+          return null;
         }
-      },
-      VerticalResultsCountComponent.defaultTemplateName()
-    );
+      }
+    });
     const component = COMPONENT_MANAGER.create(VerticalResultsCountComponent.type, defaultConfig);
     component.setState({
       results: new Array(10),
       resultsCount: 200
     });
     const wrapper = mount(component);
+    console.log(wrapper.debug());
     expect(wrapper.find('.yxt-VerticalResultsCount-start').text()).toEqual('41');
     expect(wrapper.find('.yxt-VerticalResultsCount-end').text()).toEqual('50');
     expect(wrapper.find('.yxt-VerticalResultsCount-total').text()).toEqual('200');


### PR DESCRIPTION
I noticed that my unit tests on a separate pr were breaking, and for
some reason were using the raw component template (found by
adding an implementation for the {{translate}} helper) rather than
using the translated template bundle which uses {{processTranslation}}

This commit updates our jest tests to use the translated templates
inside dist/, rather than manually loading in the raw templates.
This simplifies our unit tests, but also makes it a requirement
to rebundle the templates to run a unit test (which is now
the case with the localized-assets changes anyways).

TEST=auto

re ran unit tests