### PR TITLE
Remove indents from the translate call

### DIFF
--- a/src/ui/templates/results/verticalresultscount.hbs
+++ b/src/ui/templates/results/verticalresultscount.hbs
@@ -4,11 +4,11 @@
     <div aria-hidden="true">
       {{translate
         phrase=
-         '<span class="yxt-VerticalResultsCount-start">[[start]]</span>
-          <span class="yxt-VerticalResultsCount-dash">-</span>
-          <span class="yxt-VerticalResultsCount-end">[[end]]</span>
-          <span class="yxt-VerticalResultsCount-of">of</span>
-          <span class="yxt-VerticalResultsCount-total">[[resultsCount]]</span>'
+'<span class="yxt-VerticalResultsCount-start">[[start]]</span>
+<span class="yxt-VerticalResultsCount-dash">-</span>
+<span class="yxt-VerticalResultsCount-end">[[end]]</span>
+<span class="yxt-VerticalResultsCount-of">of</span>
+<span class="yxt-VerticalResultsCount-total">[[resultsCount]]</span>'
         context='Example: 1-10 of 50'
         start=pageStart
         end=pageEnd


### PR DESCRIPTION
Remove indents from the translate call

Remove indents to improve the formatting of the POT file the extractor produces

J=none
TEST=manual

Run an extraction and confirm POT file is valid