### PR TITLE
Switch the build process from parallelized to serialized

### DIFF
--- a/conf/gulp-tasks/library.gulpfile.js
+++ b/conf/gulp-tasks/library.gulpfile.js
@@ -28,7 +28,7 @@ exports.dev = function devJSBundle () {
 };
 
 /**
- * Creates a build task per locale, and combines them into a parallel task.
+ * Creates a build task per locale, and combines them into a series task.
  * @returns {Promise<Function>}
  */
 exports.default = function defaultJSBundle () {
@@ -38,7 +38,7 @@ exports.default = function defaultJSBundle () {
       .then(bundleTaskFactory => createBundles(bundleTaskFactory, minifyTaskFactory));
   });
   return Promise.all(localizedTaskPromises).then(localizedTasks => {
-    return new Promise(resolve => parallel(compileCSS, ...localizedTasks)(resolve));
+    return new Promise(resolve => series(compileCSS, ...localizedTasks)(resolve));
   });
 };
 

--- a/conf/gulp-tasks/templates.gulpfile.js
+++ b/conf/gulp-tasks/templates.gulpfile.js
@@ -80,7 +80,7 @@ function createDefaultTask (locale, translator) {
 }
 
 /**
- * Creates a build task per locale, and combines them into a parallel task.
+ * Creates a build task per locale, and combines them into a series task.
  *
  * @returns {Promise<Function>}
  */
@@ -90,7 +90,7 @@ async function defaultTemplates () {
     return createDefaultTask(locale, translator);
   });
   const localizedTasks = await Promise.all(localizedTaskPromises);
-  return new Promise(resolve => parallel(...localizedTasks)(resolve));
+  return new Promise(resolve => series(...localizedTasks)(resolve));
 }
 
 exports.default = defaultTemplates;


### PR DESCRIPTION
Switch the SDK build process from parallelized to serialized

NodeJS runs out of memory when trying to build the localized versions of answers.js in paralllel. Switching the builds to run in serial solves this problem.

J=None
TEST=manual

Run a build with 5 languages and observe it complete successfully