### PR TITLE
Escape parentheses before translator key lookup

### DIFF
--- a/conf/i18n/translator.js
+++ b/conf/i18n/translator.js
@@ -55,7 +55,7 @@ class Translator {
    *   https://www.gnu.org/software/gettext/manual/html_node/Plural-forms.html
    */
   translatePlural (phrase, pluralForm) {
-    const escapedPhrase = this._escapeInterpolationBrackets(phrase);
+    const escapedPhrase = this._escapeBracketsAndParentheses(phrase);
     const pluralKeyRegex = new RegExp(`${escapedPhrase}_([0-9]+|plural)`);
     const i18nextOptions = this._i18next.options;
 
@@ -86,7 +86,7 @@ class Translator {
    *   https://www.gnu.org/software/gettext/manual/html_node/Plural-forms.html
    */
   translatePluralWithContext (phrase, pluralForm, context) {
-    const escapedPhrase = this._escapeInterpolationBrackets(phrase);
+    const escapedPhrase = this._escapeBracketsAndParentheses(phrase);
     const pluralWithContextKeyRegex = new RegExp(
       `${escapedPhrase}_${context}_([0-9]+|plural)`);
     const i18nextOptions = this._i18next.options;
@@ -150,15 +150,17 @@ class Translator {
   }
 
   /**
-   * Escapes the interpolation brackets in a phrase
+   * Escapes the interpolation brackets and parentheses in a phrase
    *
    * @param {string} phrase
    * @returns {string}
    */
-  _escapeInterpolationBrackets (phrase) {
+  _escapeBracketsAndParentheses (phrase) {
     return phrase
       .replace(/\[\[/g, '\\[\\[')
-      .replace(/\]\]/g, '\\]\\]');
+      .replace(/\]\]/g, '\\]\\]')
+      .replace(/\(/g, '\\(')
+      .replace(/\)/g, '\\)');
   }
 
   /**


### PR DESCRIPTION
Escape parentheses before passing the key regex to `_findLocaleWithTranslationKey` inside the translator.

There was a bug where the following translation was not being translated during the SDK build step:
`msgid "([[resultsCount]] result)"
msgid_plural "([[resultsCount]] results)"
msgstr[0] "[[resultsCount]] resultado"
msgstr[1] "[[resultsCount]] resultados"`

The translation was failing due to the open and closing parentheses being interpreted as a regex capture group during the key lookup. This was because we manually check translation keys inside i18next with a regex test for plural translations. Escape parentheses before key lookup to solve this issue.

All the translations needed for 1.6 are valid, however I will put an item in the backlog to investigate if other regex characters might cause problems and if we need to change our key-lookup approach for plural translations.

J=none
Test=manual

Run an internationalized jambo build and observe the proper translation inside of es-answers.js. View the working translation on the local test page.