### PR TITLE
Dist from filter sept regression

### DIFF
--- a/src/core/models/result.js
+++ b/src/core/models/result.js
@@ -95,5 +95,10 @@ export default class Result {
      * @type {number}
      */
     this.distance = data.distance || null;
+    
+    /**
+     * @type {number}
+     */
+    this.distanceFromFilter = data.distanceFromFilter || null;
   }
 }

--- a/src/core/models/result.js
+++ b/src/core/models/result.js
@@ -95,7 +95,7 @@ export default class Result {
      * @type {number}
      */
     this.distance = data.distance || null;
-    
+
     /**
      * @type {number}
      */

--- a/src/core/models/resultfactory.js
+++ b/src/core/models/resultfactory.js
@@ -21,6 +21,7 @@ export default class ResultFactory {
     for (let i = 0; i < resultsData.length; i++) {
       const data = resultsData[i].data || resultsData[i];
       const distance = resultsData[i].distance;
+      const distanceFromFilter = resultsData[i].distanceFromFilter;
 
       switch (source) {
         case 'GOOGLE_CSE':
@@ -39,7 +40,7 @@ export default class ResultFactory {
           const highlightedFields = resultsData[i].highlightedFields || {};
 
           results.push(ResultFactory.fromKnowledgeManager(
-            data, formatters, verticalId, highlightedFields, i, distance));
+            data, formatters, verticalId, highlightedFields, i, distance, distanceFromFilter));
           break;
         default:
           results.push(ResultFactory.fromGeneric(data, i));
@@ -166,8 +167,9 @@ export default class ResultFactory {
    * @param {number} index
    * @param {number} distance
    * @returns {Result}
+   * @param {number} distanceFromFilter
    */
-  static fromKnowledgeManager (data, formatters, verticalId, highlightedFields, index, distance) {
+  static fromKnowledgeManager (data, formatters, verticalId, highlightedFields, index, distance, distanceFromFilter) {
     // compute highlighted entity profile data
     let highlightedEntityProfileData = ResultFactory.computeHighlightedData(data, highlightedFields);
     // compute formatted entity profile data
@@ -193,7 +195,8 @@ export default class ResultFactory {
       link: data.website,
       id: data.id,
       ordinal: index + 1,
-      distance: distance
+      distance: distance,
+      distanceFromFilter: distanceFromFilter
     });
   }
 

--- a/src/core/models/resultfactory.js
+++ b/src/core/models/resultfactory.js
@@ -166,8 +166,8 @@ export default class ResultFactory {
    * @param {Object} highlightedFields
    * @param {number} index
    * @param {number} distance
-   * @returns {Result}
    * @param {number} distanceFromFilter
+   * @returns {Result}
    */
   static fromKnowledgeManager (data, formatters, verticalId, highlightedFields, index, distance, distanceFromFilter) {
     // compute highlighted entity profile data


### PR DESCRIPTION
Copied this PR from alexis exactly:

https://github.com/yext/answers/commit/c095e439bbaa86f9f103ba7d2fd9a8b6a39b0a16

tested on a jambo site
https://32643ee2livepreview.landingpagespreview.com/?query=virginia&referrerPageUrl=https%3A%2F%2Fwww.yext.com%2F

added `distance: Formatter.toMiles(profile, 'd_distanceFromFilter')` to the card and verified distanceFromFilter was correctly showing