### PR TITLE
translationprocessor: ie11 fix for regexp constructor

### DIFF
--- a/src/core/i18n/translationprocessor.js
+++ b/src/core/i18n/translationprocessor.js
@@ -45,7 +45,7 @@ export default class TranslationProcessor {
   }
 
   static _interpolate (stringToInterpolate, interpolationParams) {
-    const interpolationRegex = new RegExp(/\[\[([a-zA-Z0-9]+)\]\]/, 'g');
+    const interpolationRegex = /\[\[([a-zA-Z0-9]+)\]\]/g;
 
     return stringToInterpolate.replace(interpolationRegex, (match, interpolationKey) => {
       return interpolationParams[interpolationKey];


### PR DESCRIPTION
IE11 does not allow you to use a regex literal as the first
argument to the RegExp constructor. I tried targeting ie11
in bundle.js's legacyBundle babel config, but that didn't
seem to fix the issue (didn't spend much time investigating
our babel stuff).

J=SLAP-709
TEST=manual

Test that I can load a page that with components that use
translations (e.g. VerticalResutlsCount) again