### PR TITLE
Build SDK assets for KG locales

### DIFF
--- a/conf/gulp-tasks/library.gulpfile.js
+++ b/conf/gulp-tasks/library.gulpfile.js
@@ -5,7 +5,7 @@ const sass = require('gulp-sass');
 
 const getLibraryVersion = require('./utils/libversion');
 const { BundleType, BundleTaskFactory } = require('./bundle/bundletaskfactory');
-const { DEFAULT_LOCALES, ALL_LANGUAGES } = require('../i18n/constants');
+const { DEFAULT_LOCALE, ALL_LANGUAGES } = require('../i18n/constants');
 const { copyAssetsForLocales } = require('../i18n/localebuildutils');
 const LocalFileParser = require('../i18n/localfileparser');
 const MinifyTaskFactory = require('./bundle/minifytaskfactory');
@@ -18,7 +18,7 @@ const { generateProcessTranslationJsCall } = require('../i18n/runtimecallgenerat
  * @returns {Promise<Function>}
  */
 exports.dev = function devJSBundle () {
-  return createBundleTaskFactory(DEFAULT_LOCALES[0]).then(devTaskFactory => {
+  return createBundleTaskFactory(DEFAULT_LOCALE).then(devTaskFactory => {
     return new Promise(resolve => {
       return parallel(
         series(devTaskFactory.create(BundleType.LEGACY_IIFE), getWatchJSTask(devTaskFactory)),
@@ -46,8 +46,8 @@ function createJSBundlesForLanguages (languages) {
   });
 }
 
-exports.default = function defaultJSBundles () {
-  return createJSBundlesForLanguages(DEFAULT_LOCALES);
+exports.default = function defaultLanguageJSBundle () {
+  return createJSBundlesForLanguages([DEFAULT_LOCALE]);
 };
 
 exports.buildLanguages = function allLanguageJSBundles () {

--- a/conf/gulp-tasks/library.gulpfile.js
+++ b/conf/gulp-tasks/library.gulpfile.js
@@ -46,7 +46,7 @@ function createJSBundlesForLanguages (languages) {
   });
 }
 
-exports.default = function defaultLanguageJSBundle () {
+exports.default = function defaultLanguageJSBundles () {
   return createJSBundlesForLanguages([DEFAULT_LOCALE]);
 };
 

--- a/conf/gulp-tasks/templates.gulpfile.js
+++ b/conf/gulp-tasks/templates.gulpfile.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 const LocalFileParser = require('../i18n/localfileparser');
 const Translator = require('../i18n/translator');
-const { DEFAULT_LOCALES, ALL_LANGUAGES } = require('../i18n/constants');
+const { DEFAULT_LOCALE, ALL_LANGUAGES } = require('../i18n/constants');
 const { copyAssetsForLocales } = require('../i18n/localebuildutils');
 
 const TemplateType = require('./template/templatetype');
@@ -27,10 +27,10 @@ async function createTranslator (locale) {
  */
 async function devTemplates () {
   const bundleTemplatesUMD =
-    new BundleTemplatesTaskFactory(DEFAULT_LOCALES[0]).create(TemplateType.UMD);
-  const cleanFiles = createCleanFilesTask(DEFAULT_LOCALES[0]);
-  const translator = await createTranslator(DEFAULT_LOCALES[0]);
-  const precompileTemplates = createPrecompileTemplatesTask(DEFAULT_LOCALES[0], translator);
+    new BundleTemplatesTaskFactory(DEFAULT_LOCALE).create(TemplateType.UMD);
+  const cleanFiles = createCleanFilesTask(DEFAULT_LOCALE);
+  const translator = await createTranslator(DEFAULT_LOCALE);
+  const precompileTemplates = createPrecompileTemplatesTask(DEFAULT_LOCALE, translator);
 
   function watchTemplates () {
     return watch(['./src/ui/templates/**/*.hbs'], {
@@ -97,7 +97,7 @@ async function createTemplatesForLanguages (languages) {
 }
 
 exports.default = function defaultTemplates () {
-  return createTemplatesForLanguages(DEFAULT_LOCALES);
+  return createTemplatesForLanguages([DEFAULT_LOCALE]);
 };
 
 exports.buildLanguages = function allLanguageTemplates () {

--- a/conf/i18n/constants.js
+++ b/conf/i18n/constants.js
@@ -1,5 +1,110 @@
+exports.TRANSLATION_FLAGGER_REGEX = /TranslationFlagger.flag\((\s)*\{[^;]+?\}(\s)*\)/g;
+
 exports.DEV_LOCALE = 'en';
 
-exports.BUILD_LOCALES = ['en', 'es', 'fr', 'de', 'it', 'ja'];
+exports.DEFAULT_LOCALES = ['en'];
 
-exports.TRANSLATION_FLAGGER_REGEX = /TranslationFlagger.flag\((\s)*\{[^;]+?\}(\s)*\)/g;
+exports.ALL_LOCALES = {
+  'en': [
+    'en_AE',
+    'en_AI',
+    'en_AS',
+    'en_AT',
+    'en_AU',
+    'en_BE',
+    'en_BG',
+    'en_BH',
+    'en_CA',
+    'en_CH',
+    'en_CO',
+    'en_CR',
+    'en_CY',
+    'en_CZ',
+    'en_DE',
+    'en_DK',
+    'en_EE',
+    'en_ES',
+    'en_EU',
+    'en_FI',
+    'en_FR',
+    'en_GB',
+    'en_GD',
+    'en_GR',
+    'en_GT',
+    'en_HI',
+    'en_HK',
+    'en_HR',
+    'en_HU',
+    'en_IE',
+    'en_IL',
+    'en_IT',
+    'en_JM',
+    'en_JP',
+    'en_KR',
+    'en_KW',
+    'en_LC',
+    'en_LT',
+    'en_LU',
+    'en_LV',
+    'en_MS',
+    'en_MT',
+    'en_NL',
+    'en_NO',
+    'en_OM',
+    'en_PL',
+    'en_PS',
+    'en_PT',
+    'en_QA',
+    'en_RE',
+    'en_RO',
+    'en_SA',
+    'en_SE',
+    'en_SG',
+    'en_SH',
+    'en_SI',
+    'en_SK',
+    'en_UA',
+    'en_US',
+    'en_ZA'
+  ],
+  'es': [
+    'es_BO',
+    'es_CO',
+    'es_CU',
+    'es_ES',
+    'es_EU',
+    'es_GT',
+    'es_HN',
+    'es_MX',
+    'es_NI',
+    'es_US'
+  ],
+  'fr': [
+    'fr_BE',
+    'fr_BL',
+    'fr_CA',
+    'fr_CH',
+    'fr_EU',
+    'fr_FR',
+    'fr_IT',
+    'fr_LU',
+    'fr_MC',
+    'fr_RE'
+  ],
+  'it': [
+    'it_CH',
+    'it_IT'
+  ],
+  'de': [
+    'de_AT',
+    'de_CH',
+    'de_DE',
+    'de_EU',
+    'de_LU'
+  ],
+  'ja': [
+    'ja_JP'
+  ]
+};
+
+exports.ALL_LANGUAGES = Object.keys(this.ALL_LOCALES);

--- a/conf/i18n/constants.js
+++ b/conf/i18n/constants.js
@@ -1,10 +1,8 @@
 exports.TRANSLATION_FLAGGER_REGEX = /TranslationFlagger.flag\((\s)*\{[^;]+?\}(\s)*\)/g;
 
-exports.DEV_LOCALE = 'en';
-
 exports.DEFAULT_LOCALES = ['en'];
 
-exports.ALL_LOCALES = {
+exports.LANGUAGES_TO_LOCALES = {
   'en': [
     'en_AE',
     'en_AI',
@@ -107,4 +105,4 @@ exports.ALL_LOCALES = {
   ]
 };
 
-exports.ALL_LANGUAGES = Object.keys(this.ALL_LOCALES);
+exports.ALL_LANGUAGES = Object.keys(this.LANGUAGES_TO_LOCALES);

--- a/conf/i18n/constants.js
+++ b/conf/i18n/constants.js
@@ -1,6 +1,6 @@
 exports.TRANSLATION_FLAGGER_REGEX = /TranslationFlagger.flag\((\s)*\{[^;]+?\}(\s)*\)/g;
 
-exports.DEFAULT_LOCALES = ['en'];
+exports.DEFAULT_LOCALE = 'en';
 
 exports.LANGUAGES_TO_LOCALES = {
   'en': [

--- a/conf/i18n/localebuildutils.js
+++ b/conf/i18n/localebuildutils.js
@@ -2,8 +2,9 @@ const { LANGUAGES_TO_LOCALES, ALL_LANGUAGES } = require('./constants');
 const fs = require('fs');
 
 /**
- * Iterate through SDK language build files and create copies for each locale defined in
- * LANGUAGES_TO_LOCALES.
+ * Iterate through SDK language build files and create symlinks for each locale defined
+ * in LANGUAGES_TO_LOCALES. If the symlink already exists, delete it before creating a
+ * new one.
  *
  * For example, if assetNames includes 'answers.js' and LANGUAGES_TO_LOCALES includes
  * 'fr_CA' and 'fr_FR' for the language 'fr', the file 'fr-answers.js' will be copied to
@@ -20,8 +21,10 @@ function copyAssetsForLocales (assetNames) {
         : `${assetName}`;
       LANGUAGES_TO_LOCALES[language].forEach((locale) => {
         const localeBundleName = `${locale}-${assetName}`;
-        fs.symlinkSync(`./${languageBundleName}`,
-          `./dist/${localeBundleName}`);
+        if (fs.existsSync(`./dist/${localeBundleName}`)) {
+          fs.unlinkSync(`./dist/${localeBundleName}`);
+        }
+        fs.symlinkSync(`./${languageBundleName}`, `./dist/${localeBundleName}`);
       });
     });
   });

--- a/conf/i18n/localebuildutils.js
+++ b/conf/i18n/localebuildutils.js
@@ -1,0 +1,32 @@
+const { ALL_LOCALES } = require('./constants');
+const { src, dest } = require('gulp');
+const rename = require('gulp-rename');
+
+/**
+ * Iterate through SDK language build files and create copies for each locale defined in
+ * ALL_LOCALES.
+ *
+ * For example, if baseFileNames includes 'answers.js' and ALL_LOCALES includes 'fr_CA'
+ * and 'fr_FR' for the language 'fr', the file 'fr-answers.js' will be copied to
+ * 'fr_CA-answers.js' and 'fr_FR-answers.js'. Builds for each language must be created
+ * before this function is run.
+ *
+ * @param {Array<string>} baseFileNames File names used for iteration and file generation
+ */
+function createLocaleFilesPerLanguage (baseFileNames) {
+  Object.keys(ALL_LOCALES).forEach((language) => {
+    baseFileNames.forEach((baseFileName) => {
+      const languageBundleName = language !== 'en'
+        ? `${language}-${baseFileName}`
+        : `${baseFileName}`;
+      ALL_LOCALES[language].forEach((locale) => {
+        const localeBundleName = `${locale}-${baseFileName}`;
+        src(`./dist/${languageBundleName}`)
+          .pipe(rename(localeBundleName))
+          .pipe(dest('./dist/'));
+      });
+    });
+  });
+}
+
+exports.createLocaleFilesPerLanguage = createLocaleFilesPerLanguage;

--- a/conf/i18n/localebuildutils.js
+++ b/conf/i18n/localebuildutils.js
@@ -1,26 +1,26 @@
-const { ALL_LOCALES } = require('./constants');
+const { LANGUAGES_TO_LOCALES, ALL_LANGUAGES } = require('./constants');
 const { src, dest } = require('gulp');
 const rename = require('gulp-rename');
 
 /**
  * Iterate through SDK language build files and create copies for each locale defined in
- * ALL_LOCALES.
+ * LANGUAGES_TO_LOCALES.
  *
- * For example, if baseFileNames includes 'answers.js' and ALL_LOCALES includes 'fr_CA'
- * and 'fr_FR' for the language 'fr', the file 'fr-answers.js' will be copied to
+ * For example, if assetNames includes 'answers.js' and LANGUAGES_TO_LOCALES includes
+ * 'fr_CA' and 'fr_FR' for the language 'fr', the file 'fr-answers.js' will be copied to
  * 'fr_CA-answers.js' and 'fr_FR-answers.js'. Builds for each language must be created
  * before this function is run.
  *
- * @param {Array<string>} baseFileNames File names used for iteration and file generation
+ * @param {Array<string>} assetNames File names used for iteration and file generation
  */
-function createLocaleFilesPerLanguage (baseFileNames) {
-  Object.keys(ALL_LOCALES).forEach((language) => {
-    baseFileNames.forEach((baseFileName) => {
+function copyAssetsForLocales (assetNames) {
+  ALL_LANGUAGES.forEach((language) => {
+    assetNames.forEach((assetName) => {
       const languageBundleName = language !== 'en'
-        ? `${language}-${baseFileName}`
-        : `${baseFileName}`;
-      ALL_LOCALES[language].forEach((locale) => {
-        const localeBundleName = `${locale}-${baseFileName}`;
+        ? `${language}-${assetName}`
+        : `${assetName}`;
+      LANGUAGES_TO_LOCALES[language].forEach((locale) => {
+        const localeBundleName = `${locale}-${assetName}`;
         src(`./dist/${languageBundleName}`)
           .pipe(rename(localeBundleName))
           .pipe(dest('./dist/'));
@@ -29,4 +29,4 @@ function createLocaleFilesPerLanguage (baseFileNames) {
   });
 }
 
-exports.createLocaleFilesPerLanguage = createLocaleFilesPerLanguage;
+exports.copyAssetsForLocales = copyAssetsForLocales;

--- a/conf/i18n/localebuildutils.js
+++ b/conf/i18n/localebuildutils.js
@@ -7,9 +7,9 @@ const fs = require('fs');
  * new one.
  *
  * For example, if assetNames includes 'answers.js' and LANGUAGES_TO_LOCALES includes
- * 'fr_CA' and 'fr_FR' for the language 'fr', the file 'fr-answers.js' will be copied to
- * 'fr_CA-answers.js' and 'fr_FR-answers.js'. Builds for each language must be created
- * before this function is run.
+ * 'fr_CA' and 'fr_FR' for the language 'fr', symlinks named 'fr_CA-answers.js' and
+ * 'fr_FR-answers.js' will be created which point to 'fr-answers.js'. Builds for each
+ * language must be created before this function is run.
  *
  * @param {Array<string>} assetNames File names used for iteration and file generation
  */

--- a/conf/i18n/localebuildutils.js
+++ b/conf/i18n/localebuildutils.js
@@ -1,6 +1,5 @@
 const { LANGUAGES_TO_LOCALES, ALL_LANGUAGES } = require('./constants');
-const { src, dest } = require('gulp');
-const rename = require('gulp-rename');
+const fs = require('fs');
 
 /**
  * Iterate through SDK language build files and create copies for each locale defined in
@@ -21,9 +20,8 @@ function copyAssetsForLocales (assetNames) {
         : `${assetName}`;
       LANGUAGES_TO_LOCALES[language].forEach((locale) => {
         const localeBundleName = `${locale}-${assetName}`;
-        src(`./dist/${languageBundleName}`)
-          .pipe(rename(localeBundleName))
-          .pipe(dest('./dist/'));
+        fs.symlinkSync(`./${languageBundleName}`,
+          `./dist/${localeBundleName}`);
       });
     });
   });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,4 +12,12 @@ exports.dev = parallel(
   templates.dev,
   library.dev
 );
+exports.buildLanguages = parallel(
+  templates.buildLanguages,
+  library.buildLanguages
+);
+exports.buildLocales = parallel(
+  library.buildLocales,
+  templates.buildLocales
+);
 exports.extractTranslations = extractTranslations;

--- a/package.json
+++ b/package.json
@@ -67,6 +67,8 @@
   },
   "scripts": {
     "build": "gulp && size-limit",
+    "build-languages": "gulp buildLanguages && size-limit",
+    "build-locales": "gulp buildLocales && size-limit",
     "dev": "gulp dev",
     "docs": "jsdoc -R README.md -d docs/ -r src/",
     "lint": "semistandard",


### PR DESCRIPTION
Build SDK assets for locales in the KG

Add build-languages and build-locales commands to package.json scripts. The command build-languages creates a build for each language defined in `LANGUAGES_TO_LOCALES` in conf/i18n/constants.js. The command build-locales creates SDK build files for each locale defined in `LANGUAGES_TO_LOCALES`. It does this by creating symlinks to the language builds files for all defined locales. For example, if ALL_LOCALES is defined like this:

`exports.ALL_LOCALES = {
  'en': [
    'en_US'
  ],
  'fr': [
    'fr_CA',
    'fr_FR'
  ]
};`

Localized builds for answers.js will be created with the names en_US-answers.js, fr-answers.js, fr_CA-answers.js, and fr_FR-answers.js. The files answers.js and fr-answers.js will be regular files and the rest will be symlinks to their corresponding language build.

J=SLAP-704
TEST=manual

Run `npm run build-languages` and `npm run build-locales` and confirm the builds are correct. Build an internationalized jambo site and use these new SDK builds. Create a jambo build with the locale fr_CA and confirm that the site works.