### PR TITLE
Update .circleci/config.yml for i18n builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ workflows:
   build_and_deploy:
     jobs:
       - build:
-        filters:
+          filters:
             branches:
               ignore:
                 - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,47 +133,10 @@ workflows:
   version: 2
   build_and_deploy:
     jobs:
-      - build:
-          filters:
-            branches:
-              ignore:
-                - master
-                - /^support.*/
-                - /^feature\/.*-i18n/
-                - /^release.*/
-      - build_i18n:
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              only:
-                - master
-                - /^support.*/
-                - /^feature\/.*-i18n/
-                - /^release.*/
+      - build
       - unit_test:
-          filters:
-            branches:
-              ignore:
-                - master
-                - /^support.*/
-                - /^feature\/.*-i18n/
-                - /^release.*/
           requires:
             - build
-      - unit_test:
-          name: unit_test_i18n
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              only:
-                - master
-                - /^support.*/
-                - /^feature\/.*-i18n/
-                - /^release.*/
-          requires:
-            - build_i18n
       - deploy_canary:
           filters:
             branches:
@@ -191,6 +154,19 @@ workflows:
                 - /^release.*/
           requires:
             - unit_test
+  build_and_deploy_i18n:
+    jobs:
+      - build_i18n:
+          filters:
+            tags:
+              only: /^v.*/
+      - unit_test:
+          name: unit_test_i18n
+          filters:
+            tags:
+              only: /^v.*/
+          requires:
+            - build_i18n
       - deploy_branch:
           name: deploy_branch_i18n
           filters:
@@ -225,4 +201,4 @@ workflows:
               ignore: /.*/
           requires:
             - hold
-      
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,9 +138,9 @@ workflows:
             branches:
               ignore:
                 - master
-                - /^support.*/
+                - /^support\/.*/
                 - /^feature\/.*-i18n/
-                - /^release.*/
+                - /^release\/.*/
       - unit_test:
           requires:
             - build
@@ -154,14 +154,25 @@ workflows:
           filters:
             branches:
               ignore:
-                - master
                 - develop
-                - /^support.*/
-                - /^feature\/.*-i18n/
-                - /^release.*/
           requires:
             - unit_test
   build_and_deploy_i18n:
+    jobs:
+      - build_i18n:
+          filters:
+            branches:
+              only:
+                - /^support\/.*/
+                - /^feature\/.*-i18n/
+                - /^release\/.*/
+      - unit_test:
+          requires:
+            - build_i18n
+      - deploy_branch:
+          requires:
+            - unit_test
+  build_and_deploy_hold:
     jobs:
       - build_i18n:
           filters:
@@ -170,36 +181,19 @@ workflows:
             branches:
               only:
                 - master
-                - /^support.*/
-                - /^feature\/.*-i18n/
-                - /^release.*/
       - unit_test:
-          name: unit_test_i18n
           filters:
             tags:
               only: /^v.*/
           requires:
             - build_i18n
-      - deploy_branch:
-          name: deploy_branch_i18n
-          filters:
-            branches:
-              only:
-                - /^support.*/
-                - /^feature\/.*-i18n/
-                - /^release.*/
-          requires:
-            - unit_test_i18n
       - hold:
           type: approval
           filters:
             tags:
               only: /^v.*/
-            branches:
-              only: 
-                - master
           requires:
-            - unit_test_i18n
+            - unit_test
       - deploy_latest:
           filters:
             branches:
@@ -214,4 +208,3 @@ workflows:
               ignore: /.*/
           requires:
             - hold
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
             - dist
             - .circleci
   # generate bundles for all languages and locales
-  build_all_locales:
+  build_i18n:
     docker:
       - image: circleci/node:14.5
     working_directory: ~/answers
@@ -91,28 +91,6 @@ jobs:
       - deploy-to-aws
   # deploys assets to an uncached folder in the S3 bucket named by branch
   deploy_branch:
-    docker:
-      - image: circleci/python:2.7
-    working_directory: ~/answers
-    steps:
-      - run:
-          name: "Setup branch formatting, replace / with -"
-          command: echo 'export FORMATTED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH} | sed "s/\//-/g")' >> $BASH_ENV
-      - deploy-to-aws:
-          subdirectory: '/dev/${FORMATTED_CIRCLE_BRANCH}'
-  # deploys support branch assets to an uncached folder in the S3 bucket named by branch
-  deploy_support:
-    docker:
-      - image: circleci/python:2.7
-    working_directory: ~/answers
-    steps:
-      - run:
-          name: "Setup branch formatting, replace / with -"
-          command: echo 'export FORMATTED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH} | sed "s/\//-/g")' >> $BASH_ENV
-      - deploy-to-aws:
-          subdirectory: '/dev/${FORMATTED_CIRCLE_BRANCH}'
-  # deploys assets from feature branches ending in i18n to an uncached folder in the S3 bucket named by branch
-  deploy_feature_i18n:
     docker:
       - image: circleci/python:2.7
     working_directory: ~/answers
@@ -157,9 +135,13 @@ workflows:
     jobs:
       - build:
           filters:
-            tags:
-              only: /^v.*/
-      - build_all_locales:
+            branches:
+              ignore:
+                - master
+                - /^support*/
+                - /^feature\/*-i18n/
+                - /^release*/
+      - build_i18n:
           filters:
             tags:
               only: /^v.*/
@@ -168,12 +150,57 @@ workflows:
                 - master
                 - /^support*/
                 - /^feature\/*-i18n/
+                - /^release*/
       - unit_test:
+          filters:
+            branches:
+              ignore:
+                - master
+                - /^support*/
+                - /^feature\/*-i18n/
+                - /^release*/
+          requires:
+            - build
+      - unit_test:
+          name: unit_test_i18n
           filters:
             tags:
               only: /^v.*/
+            branches:
+              only:
+                - master
+                - /^support*/
+                - /^feature\/*-i18n/
+                - /^release*/
           requires:
-            - build
+            - build_i18n
+      - deploy_canary:
+          filters:
+            branches:
+              only: develop
+          requires:
+            - unit_test
+      - deploy_branch:
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
+                - /^support*/
+                - /^feature\/*-i18n/
+                - /^release*/
+          requires:
+            - unit_test
+      - deploy_branch:
+          name: deploy_branch_i18n
+          filters:
+            branches:
+              only:
+                - /^support*/
+                - /^feature\/*-i18n/
+                - /^release*/
+          requires:
+            - unit_test_i18n
       - hold:
           type: approval
           filters:
@@ -183,40 +210,13 @@ workflows:
               only: 
                 - master
           requires:
-            - unit_test
-            - build_all_locales
+            - unit_test_i18n
       - deploy_latest:
           filters:
             branches:
               only: master
           requires:
             - hold
-      - deploy_branch:
-          filters:
-            branches:
-              ignore:
-                - master
-                - develop
-                - /^support*/
-                - /^feature\/*-i18n/
-          requires:
-            - unit_test
-      - deploy_feature_i18n:
-          filters:
-            branches:
-              only:
-                - /^feature\/*-i18n/
-          requires:
-            - unit_test
-            - build_all_locales
-      - deploy_support:
-          filters:
-            branches:
-              only:
-                - /^support*/
-          requires:
-            - unit_test
-            - build_all_locales
       - deploy_version:
           filters:
             tags:
@@ -225,9 +225,4 @@ workflows:
               ignore: /.*/
           requires:
             - hold
-      - deploy_canary:
-          filters:
-            branches:
-              only: develop
-          requires:
-            - unit_test
+      

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,14 @@ workflows:
   version: 2
   build_and_deploy:
     jobs:
-      - build
+      - build:
+        filters:
+            branches:
+              ignore:
+                - master
+                - /^support.*/
+                - /^feature\/.*-i18n/
+                - /^release.*/
       - unit_test:
           requires:
             - build
@@ -160,6 +167,12 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+            branches:
+              only:
+                - master
+                - /^support.*/
+                - /^feature\/.*-i18n/
+                - /^release.*/
       - unit_test:
           name: unit_test_i18n
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,7 @@ workflows:
             tags:
               only: /^v.*/
       - build_all_locales:
-          filter:
+          filters:
             tags:
               only: /^v.*/
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,19 @@ jobs:
           paths:
             - dist
             - .circleci
+  # generate bundles for all languages and locales
+  build_all_locales:
+    docker:
+      - image: circleci/node:14.5
+    working_directory: ~/answers
+    steps:
+      - setup-workspace
+      - run: npm run build-locales
+      - persist_to_workspace:
+          root: .
+          paths:
+            - dist
+            - .circleci
   # run the jest unit tests
   unit_test:
     docker:
@@ -78,6 +91,28 @@ jobs:
       - deploy-to-aws
   # deploys assets to an uncached folder in the S3 bucket named by branch
   deploy_branch:
+    docker:
+      - image: circleci/python:2.7
+    working_directory: ~/answers
+    steps:
+      - run:
+          name: "Setup branch formatting, replace / with -"
+          command: echo 'export FORMATTED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH} | sed "s/\//-/g")' >> $BASH_ENV
+      - deploy-to-aws:
+          subdirectory: '/dev/${FORMATTED_CIRCLE_BRANCH}'
+  # deploys support branch assets to an uncached folder in the S3 bucket named by branch
+  deploy_support:
+    docker:
+      - image: circleci/python:2.7
+    working_directory: ~/answers
+    steps:
+      - run:
+          name: "Setup branch formatting, replace / with -"
+          command: echo 'export FORMATTED_CIRCLE_BRANCH=$(echo ${CIRCLE_BRANCH} | sed "s/\//-/g")' >> $BASH_ENV
+      - deploy-to-aws:
+          subdirectory: '/dev/${FORMATTED_CIRCLE_BRANCH}'
+  # deploys assets from feature branches ending in i18n to an uncached folder in the S3 bucket named by branch
+  deploy_feature_i18n:
     docker:
       - image: circleci/python:2.7
     working_directory: ~/answers
@@ -124,6 +159,15 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+      - build_all_locales:
+          filter:
+            tags:
+              only: /^v.*/
+            branches:
+              only:
+                - master
+                - /^support*/
+                - /^feature\/*-i18n/
       - unit_test:
           filters:
             tags:
@@ -140,6 +184,7 @@ workflows:
                 - master
           requires:
             - unit_test
+            - build_all_locales
       - deploy_latest:
           filters:
             branches:
@@ -152,8 +197,26 @@ workflows:
               ignore:
                 - master
                 - develop
+                - /^support*/
+                - /^feature\/*-i18n/
           requires:
             - unit_test
+      - deploy_feature_i18n:
+          filters:
+            branches:
+              only:
+                - /^feature\/*-i18n/
+          requires:
+            - unit_test
+            - build_all_locales
+      - deploy_support:
+          filters:
+            branches:
+              only:
+                - /^support*/
+          requires:
+            - unit_test
+            - build_all_locales
       - deploy_version:
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,9 +138,9 @@ workflows:
             branches:
               ignore:
                 - master
-                - /^support*/
-                - /^feature\/*-i18n/
-                - /^release*/
+                - /^support.*/
+                - /^feature\/.*-i18n/
+                - /^release.*/
       - build_i18n:
           filters:
             tags:
@@ -148,17 +148,17 @@ workflows:
             branches:
               only:
                 - master
-                - /^support*/
-                - /^feature\/*-i18n/
-                - /^release*/
+                - /^support.*/
+                - /^feature\/.*-i18n/
+                - /^release.*/
       - unit_test:
           filters:
             branches:
               ignore:
                 - master
-                - /^support*/
-                - /^feature\/*-i18n/
-                - /^release*/
+                - /^support.*/
+                - /^feature\/.*-i18n/
+                - /^release.*/
           requires:
             - build
       - unit_test:
@@ -169,9 +169,9 @@ workflows:
             branches:
               only:
                 - master
-                - /^support*/
-                - /^feature\/*-i18n/
-                - /^release*/
+                - /^support.*/
+                - /^feature\/.*-i18n/
+                - /^release.*/
           requires:
             - build_i18n
       - deploy_canary:
@@ -186,9 +186,9 @@ workflows:
               ignore:
                 - master
                 - develop
-                - /^support*/
-                - /^feature\/*-i18n/
-                - /^release*/
+                - /^support.*/
+                - /^feature\/.*-i18n/
+                - /^release.*/
           requires:
             - unit_test
       - deploy_branch:
@@ -196,9 +196,9 @@ workflows:
           filters:
             branches:
               only:
-                - /^support*/
-                - /^feature\/*-i18n/
-                - /^release*/
+                - /^support.*/
+                - /^feature\/.*-i18n/
+                - /^release.*/
           requires:
             - unit_test_i18n
       - hold:


### PR DESCRIPTION
Update .circleci/config.yml for i18n builds

We only want to build all locales for the master branch, releases branches matching `/^release\/*/`, tagged releases, support branches matching `/^support\/*/` and feature branches matching `/^feature\/*-i18n/`. For canary (develop) and all other branches, just run the regular npm build which will only build and test the SDK assets for English. This is much quicker (2mins vs 11min), and it saves us a lot of space on AWS S3.

J=none
TEST=manual

Create a test support branch and a feature/-TEST-TEST-i18n branch to trigger i18n builds. Observe circle and confirm that builds in S3 are created for all locales. Confirm that this branch triggers a regular build in CircleCI. Run a localized jambo build and point it to the i18n assets in S3. Load the locale fr_CA for the answers site and observe it using the fr_CA build files.