### PR TITLE
VerticalResults: revert hideResultsHeader config

### DIFF
--- a/README.md
+++ b/README.md
@@ -834,8 +834,6 @@ ANSWERS.addComponent('VerticalResults', {
   // Optional, a modifier that will be appended to a class on the results list like this `yxt-Results--{modifier}`
   modifier: '',
   // Optional, whether to hide the default results header that VerticalResults provides. Defaults to false.
-  hideResultsHeader: false,
-  // Optional, the card used to display each individual result, see the Cards section for more details,
   card: {
     // Optional, The type of card, built-in types are: 'Standard', 'Accordion', and 'Legacy'. Defaults to 'Standard'
     cardType: 'Standard',

--- a/README.md
+++ b/README.md
@@ -833,7 +833,7 @@ ANSWERS.addComponent('VerticalResults', {
   resultsCountTemplate: '<div>{{resultsCountStart}} - {{resultsCountEnd}} of {{resultsCount}}</div>',
   // Optional, a modifier that will be appended to a class on the results list like this `yxt-Results--{modifier}`
   modifier: '',
-  // Optional, whether to hide the default results header that VerticalResults provides. Defaults to false.
+  // Optional, the card used to display each individual result, see the Cards section for more details,
   card: {
     // Optional, The type of card, built-in types are: 'Standard', 'Accordion', and 'Legacy'. Defaults to 'Standard'
     cardType: 'Standard',

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -72,13 +72,6 @@ class VerticalResultsConfig {
     this.resultsCountTemplate = config.resultsCountTemplate || '';
 
     /**
-     * Whether to display the results header (assuming there is something like the results count
-     * or applied filters to display).
-     * @type {boolean}
-     */
-    this.hideResultsHeader = config.hideResultsHeader;
-
-    /**
      * Config for the applied filters in the results header.
      * @type {Object}
      */

--- a/src/ui/templates/results/verticalresults.hbs
+++ b/src/ui/templates/results/verticalresults.hbs
@@ -41,9 +41,7 @@
 {{/inline}}
 
 {{#*inline 'resultsHeader'}}
-  {{#unless _config.hideResultsHeader}}
-    <div data-component="ResultsHeader"></div>
-  {{/unless}}
+  <div data-component="ResultsHeader"></div>
 {{/inline}}
 
 {{#*inline "results"}}


### PR DESCRIPTION
This can already be specified with
showAppliedFilters: false (which you can already
specify two different ways) and showResultCount: false.

TEST=manual

Test that this config does not do anything anymore