### PR TITLE
Use lodash escapeRegExp on plural translation keys

### DIFF
--- a/conf/i18n/translator.js
+++ b/conf/i18n/translator.js
@@ -1,4 +1,5 @@
 const i18next = require('i18next');
+const escapeRegExp = require('lodash.escaperegexp');
 
 /**
  * This class wraps an instance of the i18next library and provides methods supporting
@@ -55,7 +56,7 @@ class Translator {
    *   https://www.gnu.org/software/gettext/manual/html_node/Plural-forms.html
    */
   translatePlural (phrase, pluralForm) {
-    const escapedPhrase = this._escapeInterpolationBrackets(phrase);
+    const escapedPhrase = escapeRegExp(phrase);
     const pluralKeyRegex = new RegExp(`${escapedPhrase}_([0-9]+|plural)`);
     const i18nextOptions = this._i18next.options;
 
@@ -86,9 +87,9 @@ class Translator {
    *   https://www.gnu.org/software/gettext/manual/html_node/Plural-forms.html
    */
   translatePluralWithContext (phrase, pluralForm, context) {
-    const escapedPhrase = this._escapeInterpolationBrackets(phrase);
+    const escapedPhraseAndContext = escapeRegExp(`${phrase}_${context}`);
     const pluralWithContextKeyRegex = new RegExp(
-      `${escapedPhrase}_${context}_([0-9]+|plural)`);
+      `${escapedPhraseAndContext}_([0-9]+|plural)`);
     const i18nextOptions = this._i18next.options;
 
     // We first look for the translations in the given locale. If none can be
@@ -147,18 +148,6 @@ class Translator {
           return pluralForms;
         },
         { 0: localeTranslations[translationKey] });
-  }
-
-  /**
-   * Escapes the interpolation brackets in a phrase
-   *
-   * @param {string} phrase
-   * @returns {string}
-   */
-  _escapeInterpolationBrackets (phrase) {
-    return phrase
-      .replace(/\[\[/g, '\\[\\[')
-      .replace(/\]\]/g, '\\]\\]');
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -11621,6 +11621,11 @@
       "integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg=",
       "dev": true
     },
+    "lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
+    },
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "js-levenshtein": "^1.1.6",
     "kind-of": "^6.0.3",
     "lodash.clonedeep": "^4.5.0",
+    "lodash.escaperegexp": "^4.1.2",
     "markdown-it-for-inline": "^0.1.1",
     "plural-forms": "^0.5.1",
     "stylelint-scss": "^3.18.0",


### PR DESCRIPTION
Use escapeRegExp rather than escapeInterpolationBrackets for plural translation key.

There was a bug where the following translation was not being translated properly:
msgid "([[resultsCount]] result)" msgid_plural "([[resultsCount]] results)" msgstr[0] "[[resultsCount]] resultado" msgstr[1] "[[resultsCount]] resultados"

The translation was failing due to the open and closing parentheses being interpreted as a regex capture group during the key lookup. This was because we manually check translation keys inside i18next with a regex test for plural translations. Use lodash.escapeRegExp to solve this issue and escape all other possible RegExp characters.

J=none
TEST=manual

Run an internationalized jambo build and observe the proper translation inside of fr-answerstemplates.compiled.min.js. View the working translation on the local test page.