### PR TITLE
AppliedFilters: listen to new VERTICAL_SEARCH_LOADED key

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -233,6 +233,7 @@ export default class Core {
         if (typeof analyticsEvent === 'object') {
           this._analyticsReporter.report(AnalyticsEvent.fromData(analyticsEvent));
         }
+        this.globalStorage.set(StorageKeys.VERTICAL_SEARCH_LOADED, true);
         window.performance.mark('yext.answers.verticalQueryResponseRendered');
       });
   }

--- a/src/core/storage/storagekeys.js
+++ b/src/core/storage/storagekeys.js
@@ -36,5 +36,6 @@ export default {
   RESULTS_HEADER: 'results-header',
   API_CONTEXT: 'context',
   REFERRER_PAGE_URL: 'referrerPageUrl',
-  QUERY_TRIGGER: 'queryTrigger'
+  QUERY_TRIGGER: 'queryTrigger',
+  VERTICAL_SEARCH_LOADED: 'vertical-search-loaded'
 };

--- a/src/ui/components/results/appliedfilterscomponent.js
+++ b/src/ui/components/results/appliedfilterscomponent.js
@@ -27,7 +27,7 @@ export default class AppliedFiltersComponent extends Component {
     this._verticalKey = this._config.verticalKey ||
       this.core.globalStorage.getState(StorageKeys.SEARCH_CONFIG).verticalKey;
 
-    this.moduleId = StorageKeys.DYNAMIC_FILTERS;
+    this.moduleId = StorageKeys.VERTICAL_SEARCH_LOADED;
   }
 
   static areDuplicateNamesAllowed () {


### PR DESCRIPTION
The AppliedFilters components must load after the Facets
component. This is because the Facets component, in addition
to rendering the facets, is also responsible for registering
each new vertical search's new set of facets.

For some context, each vertical search response is capable of
returning a set of facet filters, which we want displayed both
in the AppliedFilters component, as well as the Facets component.
The Facets component is ALSO responsible for loading these
facets into the SDK's FilterRegistry (it should not be).

Created SLAP-721 for correctly dealing with this. It would
be a pretty large code change, so for now we're adding this
short-term fix.

J=SLAP-712
TEST=manual

test that I can search "Consulting", which will return a
search response with the "Consulting" facet selected,
and the AppliedFilters component will show a removable
"Consulting" filter, and that this does not occur
without this change