### PR TITLE
Readme: deprecate the ResultsHeader component built into VerticalResults

### DIFF
--- a/README.md
+++ b/README.md
@@ -827,10 +827,6 @@ ANSWERS.addComponent('VerticalResults', {
   itemTemplate: `<div> Custom template </div>`,
   // Optional, set a max number of columns to display at the widest breakpoint. Possible values are 1, 2, 3 or 4, defaults to 1
   maxNumberOfColumns: 1,
-  // Optional, whether to display the total number of results, default true
-  showResultCount: true,
-  // Optional, a custom template for the results count. You can specify the variables resultsCountStart, resultsCountEnd, and resultsCount.
-  resultsCountTemplate: '<div>{{resultsCountStart}} - {{resultsCountEnd}} of {{resultsCount}}</div>',
   // Optional, a modifier that will be appended to a class on the results list like this `yxt-Results--{modifier}`
   modifier: '',
   // Optional, whether to hide the default results header that VerticalResults provides. Defaults to false.
@@ -851,7 +847,14 @@ ANSWERS.addComponent('VerticalResults', {
     // Optional, whether to display all results in the vertical when no results are found. Defaults to false, in which case only the no results card will be shown.
     displayAllResults: false
   },
+  // Optional, whether to display the total number of results, default true
+  // DEPRECATED: we recommend setting hideResultsHeader to true, and using the VerticalResultsCount and AppliedFilters components instead.
+  showResultCount: true,
+  // Optional, a custom template for the results count. You can specify the variables resultsCountStart, resultsCountEnd, and resultsCount.
+  // DEPRECATED: we recommend setting hideResultsHeader to true, and using the VerticalResultsCount and AppliedFilters components instead.
+  resultsCountTemplate: '<div>{{resultsCountStart}} - {{resultsCountEnd}} of {{resultsCount}}</div>',
   // Configuration for the applied filters bar in the header.
+  // DEPRECATED: we recommend setting hideResultsHeader to true, and using the VerticalResultsCount and AppliedFilters components instead.
   appliedFilters: {
     // If true, show any applied filters that were applied to the vertical search. Defaults to true
     show: true,

--- a/README.md
+++ b/README.md
@@ -849,9 +849,9 @@ ANSWERS.addComponent('VerticalResults', {
   },
 
   /**
-   * DEPRECATED: The config below is DEPRECATED.
-   * It will still work as expected, and the defaults will still be applied,
-   * but future major versions of the SDK will remove this config.
+   * NOTE: The config options below are DEPRECATED.
+   * They will still work as expected, and the defaults will still be applied,
+   * but future major versions of the SDK will remove them.
    * We recommend setting hideResultsHeader to true, and using the VerticalResultsCount and AppliedFilters components instead.
    */
   // Optional, whether to display the total number of results, default true

--- a/README.md
+++ b/README.md
@@ -847,14 +847,18 @@ ANSWERS.addComponent('VerticalResults', {
     // Optional, whether to display all results in the vertical when no results are found. Defaults to false, in which case only the no results card will be shown.
     displayAllResults: false
   },
+
+  /**
+   * DEPRECATED: The config below is DEPRECATED.
+   * It will still work as expected, and the defaults will still be applied,
+   * but future major versions of the SDK will remove this config.
+   * We recommend setting hideResultsHeader to true, and using the VerticalResultsCount and AppliedFilters components instead.
+   */
   // Optional, whether to display the total number of results, default true
-  // DEPRECATED: we recommend setting hideResultsHeader to true, and using the VerticalResultsCount and AppliedFilters components instead.
   showResultCount: true,
   // Optional, a custom template for the results count. You can specify the variables resultsCountStart, resultsCountEnd, and resultsCount.
-  // DEPRECATED: we recommend setting hideResultsHeader to true, and using the VerticalResultsCount and AppliedFilters components instead.
   resultsCountTemplate: '<div>{{resultsCountStart}} - {{resultsCountEnd}} of {{resultsCount}}</div>',
   // Configuration for the applied filters bar in the header.
-  // DEPRECATED: we recommend setting hideResultsHeader to true, and using the VerticalResultsCount and AppliedFilters components instead.
   appliedFilters: {
     // If true, show any applied filters that were applied to the vertical search. Defaults to true
     show: true,


### PR DESCRIPTION
Update the readme to guide people to the new VerticalResultsCount
and AppliedFilters components instead of the ResultsHeader component
tacked on top of VerticalResults

TEST=n0ne