### PR TITLE
AppliedFilters/VerticalResultsCount: remove extra margin

### DIFF
--- a/src/ui/sass/modules/_AppliedFilters.scss
+++ b/src/ui/sass/modules/_AppliedFilters.scss
@@ -2,7 +2,6 @@
 
 .yxt-AppliedFilters
 {
-  margin-right: var(--yxt-base-spacing);
   border-top: 0;
   display: flex;
   flex-wrap: wrap;
@@ -10,7 +9,6 @@
 
   &-filterLabel, &-filterValue, &-filterSeparator {
     margin-right: calc(var(--yxt-base-spacing) / 4);
-    margin-bottom: calc(var(--yxt-base-spacing) / 4);
     display: flex;
   }
 

--- a/src/ui/sass/modules/_VerticalResultsCount.scss
+++ b/src/ui/sass/modules/_VerticalResultsCount.scss
@@ -2,8 +2,6 @@
 
 .yxt-VerticalResultsCount
 {
-  margin-right: calc(var(--yxt-base-spacing) / 4);
-  margin-bottom: 4px;
   white-space: nowrap;
   @include Text(
     $size: var(--yxt-font-size-md),


### PR DESCRIPTION
When these components were factored out of the ResultsHeader
component, they retained margin styling that was originally
there to space them correctly on top of VerticalResults.
This has been removed, since they are no longer tied down
to vertical results.

TEST=manual

Test that AppliedFilters, removable: true and false, and
showFieldNames: true and false, does not have extra margin

test that VerticalResultsCount also does not have extra margin