### PR TITLE
Add quotes surrounding no results query

### DIFF
--- a/conf/i18n/translations/de.po
+++ b/conf/i18n/translations/de.po
@@ -128,10 +128,10 @@ msgid "Thank you for your question!"
 msgstr "Danke für Ihre Frage!"
 
 #: src/ui/templates/results/alternativeverticals.hbs:11
-msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">[[query]]</span>:"
-msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">[[query]]</span>:"
-msgstr[0] "Die folgenden Kategorie liefert Suchergebnisse für <span class=\"yxt-AlternativeVerticals-details--query\">[[query]]</span>:"
-msgstr[1] "Die folgenden Kategorien liefern Suchergebnisse für <span class=\"yxt-AlternativeVerticals-details--query\">[[query]]</span>:"
+msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[0] "Die folgenden Kategorie liefert Suchergebnisse für <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[1] "Die folgenden Kategorien liefern Suchergebnisse für <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
 
 #: src/ui/components/results/directanswercomponent.js:21
 msgid "This answered my question"

--- a/conf/i18n/translations/es.po
+++ b/conf/i18n/translations/es.po
@@ -191,10 +191,10 @@ msgid "Thank you for your question!"
 msgstr "Gracias por su pregunta."
 
 #: src/ui/templates/results/alternativeverticals.hbs:11
-msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">[[query]]</span>:"
-msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">[[query]]</span>:"
-msgstr[0] "La siguiente búsqueda ha generado categoría resultados para <span class=\"yxt-AlternativeVerticals-details--query\">[[query]]</span>:"
-msgstr[1] "La siguiente búsqueda ha generado categorias resultados para <span class=\"yxt-AlternativeVerticals-details--query\">[[query]]</span>:"
+msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[0] "La siguiente búsqueda ha generado categoría resultados para <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[1] "La siguiente búsqueda ha generado categorias resultados para <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
 
 #: src/ui/components/results/directanswercomponent.js:21
 msgid "This answered my question"

--- a/conf/i18n/translations/fr.po
+++ b/conf/i18n/translations/fr.po
@@ -185,10 +185,10 @@ msgid "Thank you for your question!"
 msgstr "Merci pour votre question !"
 
 #: src/ui/templates/results/alternativeverticals.hbs:11
-msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">[[query]]</span>:"
-msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">[[query]]</span>:"
-msgstr[0] "La catégorie de recherche suivante a produit des résultats pour <span class=\"yxt-AlternativeVerticals-details--query\"> [[query]]</span>:"
-msgstr[1] "Les catégories de recherche suivantes ont produit des résultats pour <span class=\"yxt-AlternativeVerticals-details--query\">[[query]]</span>:"
+msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[0] "La catégorie de recherche suivante a produit des résultats pour <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[1] "Les catégories de recherche suivantes ont produit des résultats pour <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
 
 #: src/ui/components/results/directanswercomponent.js:21
 msgid "This answered my question"

--- a/conf/i18n/translations/it.po
+++ b/conf/i18n/translations/it.po
@@ -191,10 +191,10 @@ msgid "Thank you for your question!"
 msgstr "Grazie per la sua domanda."
 
 #: src/ui/templates/results/alternativeverticals.hbs:11
-msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">[[query]]</span>:"
-msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">[[query]]</span>:"
-msgstr[0] "La categoria di ricerca ha generato risultati per <span class=\"yxt-AlternativeVerticals-details--query\">[[query]]</span>:"
-msgstr[1] "La categorie di ricerca ha generato risultati per <span class=\"yxt-AlternativeVerticals-details--query\">[[query]]</span>:"
+msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[0] "La categoria di ricerca ha generato risultati per <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[1] "La categorie di ricerca ha generato risultati per <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
 
 #: src/ui/components/results/directanswercomponent.js:21
 msgid "This answered my question"

--- a/conf/i18n/translations/ja.po
+++ b/conf/i18n/translations/ja.po
@@ -152,7 +152,7 @@ msgstr "提案："
 #: src/ui/templates/results/alternativeverticals.hbs:11
 msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
 msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
-msgstr[0] "以下の検索カテゴリーで<span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>の検索結果が見つかりました。"
+msgstr[0] "以下の検索カテゴリーで<span class=\"yxt-AlternativeVerticals-details--query\">「[[query]]」</span>の検索結果が見つかりました。"
 
 #: src/ui/templates/results/noresults.hbs:34
 msgid "Try fewer words."

--- a/conf/i18n/translations/ja.po
+++ b/conf/i18n/translations/ja.po
@@ -150,9 +150,9 @@ msgid "Suggestions:"
 msgstr "提案："
 
 #: src/ui/templates/results/alternativeverticals.hbs:11
-msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">[[query]]</span>:"
-msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">[[query]]</span>:"
-msgstr[0] "以下の検索カテゴリーで<span class=\"yxt-AlternativeVerticals-details--query\">[[query]]</span>の検索結果が見つかりました。"
+msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[0] "以下の検索カテゴリーで<span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>の検索結果が見つかりました。"
 
 #: src/ui/templates/results/noresults.hbs:34
 msgid "Try fewer words."

--- a/src/ui/templates/results/alternativeverticals.hbs
+++ b/src/ui/templates/results/alternativeverticals.hbs
@@ -8,7 +8,7 @@
   {{#if verticalSuggestions}}
     <div class="yxt-AlternativeVerticals-suggestionsWrapper">
       <div class="yxt-AlternativeVerticals-details">
-        {{translate phrase='The following search category yielded results for <span class="yxt-AlternativeVerticals-details--query">[[query]]</span>:' pluralForm='The following search categories yielded results for <span class="yxt-AlternativeVerticals-details--query">[[query]]</span>:' count=verticalSuggestions.length query=query }}
+        {{translate phrase='The following search category yielded results for <span class="yxt-AlternativeVerticals-details--query">"[[query]]"</span>:' pluralForm='The following search categories yielded results for <span class="yxt-AlternativeVerticals-details--query">"[[query]]"</span>:' count=verticalSuggestions.length query=query }}
       </div>
       <ul class="yxt-AlternativeVerticals-suggestionsList">
         {{#each verticalSuggestions}}


### PR DESCRIPTION
Add quotes around the no results query which was missing in our translation files

J=none
TEST=manual

Run a build and view the quotes surrounding the query. Also test a Japanese and Spanish site.