### PR TITLE
DefaultTemplatesLoader: Fix async template loading race condition

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -5,7 +5,7 @@ module.exports = [
   },
   {
     path: 'dist/answers-modern.min.js',
-    limit: '105kb'
+    limit: '110kb'
   },
   {
     path: 'dist/answerstemplates.compiled.min.js',

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -294,19 +294,6 @@ class Answers {
     return Promise.all([loadTemplates, ponyfillCssVariables, masterSwitch]);
   }
 
-  _checkMasterSwitch () {
-    window.performance.mark('yext.answers.statusStart');
-    const handleFulfilledMasterSwitch = (isDisabled) => {
-      this._disabledByMasterSwitch = isDisabled;
-    };
-    const handleRejectedMasterSwitch = () => {
-      this._disabledByMasterSwitch = false;
-    };
-    return this._masterSwitchApi.isDisabled()
-      .then(handleFulfilledMasterSwitch, handleRejectedMasterSwitch)
-      .finally(() => window.performance.mark('yext.answers.statusEnd'));
-  }
-
   _loadTemplates ({ useTemplates, templateBundle }) {
     if (useTemplates === false || templateBundle) {
       if (templateBundle) {
@@ -321,6 +308,19 @@ class Answers {
       });
       return this.templates.fetchTemplates();
     }
+  }
+
+  _checkMasterSwitch () {
+    window.performance.mark('yext.answers.statusStart');
+    const handleFulfilledMasterSwitch = (isDisabled) => {
+      this._disabledByMasterSwitch = isDisabled;
+    };
+    const handleRejectedMasterSwitch = () => {
+      this._disabledByMasterSwitch = false;
+    };
+    return this._masterSwitchApi.isDisabled()
+      .then(handleFulfilledMasterSwitch, handleRejectedMasterSwitch)
+      .finally(() => window.performance.mark('yext.answers.statusEnd'));
   }
 
   domReady (cb) {

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -130,6 +130,12 @@ class Answers {
      * @private
      */
     this._analyticsReporterService = null;
+
+    /**
+     * @type {boolean}
+     * @private
+     */
+    this._disabledByMasterSwitch = false;
   }
 
   static setInstance (instance) {
@@ -272,9 +278,40 @@ class Answers {
 
     this._onReady = parsedConfig.onReady || function () {};
 
-    if (parsedConfig.useTemplates === false || parsedConfig.templateBundle) {
-      if (parsedConfig.templateBundle) {
-        this.renderer.init(parsedConfig.templateBundle, this._getInitLocale());
+    const asyncDeps = this._loadAsyncDependencies(parsedConfig);
+    return asyncDeps.finally(() => {
+      if (this._disabledByMasterSwitch) {
+        throw new Error('MasterSwitchApi determined the front-end should be disabled');
+      }
+      this._onReady();
+    });
+  }
+
+  _loadAsyncDependencies (parsedConfig) {
+    const loadTemplates = this._loadTemplates(parsedConfig);
+    const ponyfillCssVariables = this._handlePonyfillCssVariables(parsedConfig.disableCssVariablesPonyfill);
+    const masterSwitch = this._checkMasterSwitch();
+    return Promise.all([loadTemplates, ponyfillCssVariables, masterSwitch]);
+  }
+
+  _checkMasterSwitch () {
+    window.performance.mark('yext.answers.statusStart');
+    const handleFulfilledMasterSwitch = (isDisabled) => {
+      this._disabledByMasterSwitch = isDisabled;
+    };
+    const handleRejectedMasterSwitch = () => {
+      this._disabledByMasterSwitch = false;
+    };
+    return this._masterSwitchApi.isDisabled()
+      .then(handleFulfilledMasterSwitch, handleRejectedMasterSwitch)
+      .finally(() => window.performance.mark('yext.answers.statusEnd'));
+  }
+
+  _loadTemplates ({ useTemplates, templateBundle }) {
+    if (useTemplates === false || templateBundle) {
+      if (templateBundle) {
+        this.renderer.init(templateBundle, this._getInitLocale());
+        return Promise.resolve();
       }
     } else {
       // Templates are currently downloaded separately from the CORE and UI bundle.
@@ -282,27 +319,8 @@ class Answers {
       this.templates = new DefaultTemplatesLoader(templates => {
         this.renderer.init(templates, this._getInitLocale());
       });
+      return this.templates.fetchTemplates();
     }
-
-    const handleFulfilledMasterSwitch = (isDisabled) => {
-      window.performance.mark('yext.answers.statusEnd');
-      if (!isDisabled) {
-        this._onReady();
-      } else {
-        throw new Error('MasterSwitchApi determined the front-end should be disabled');
-      }
-    };
-    const handleRejectedMasterSwitch = () => {
-      window.performance.mark('yext.answers.statusEnd');
-      this._onReady();
-    };
-
-    return this._handlePonyfillCssVariables(parsedConfig.disableCssVariablesPonyfill)
-      .then(() => {
-        window.performance.mark('yext.answers.statusStart');
-        return this._masterSwitchApi.isDisabled();
-      })
-      .then(handleFulfilledMasterSwitch, handleRejectedMasterSwitch);
   }
 
   domReady (cb) {

--- a/src/ui/rendering/defaulttemplatesloader.js
+++ b/src/ui/rendering/defaulttemplatesloader.js
@@ -33,7 +33,7 @@ export default class DefaultTemplatesLoader {
     // If template have already been loaded, do nothing
     let node = DOM.query('#yext-answers-templates');
     if (node) {
-      return;
+      return Promise.resolve();
     }
 
     // Inject a script to fetch the compiled templates,

--- a/src/ui/rendering/defaulttemplatesloader.js
+++ b/src/ui/rendering/defaulttemplatesloader.js
@@ -15,7 +15,6 @@ export default class DefaultTemplatesLoader {
     }
     this._templates = {};
     this._onLoaded = onLoaded || function () {};
-    this._fetchTemplates();
   }
 
   static setInstance (instance) {
@@ -30,7 +29,7 @@ export default class DefaultTemplatesLoader {
     return this.instance;
   }
 
-  _fetchTemplates () {
+  fetchTemplates () {
     // If template have already been loaded, do nothing
     let node = DOM.query('#yext-answers-templates');
     if (node) {
@@ -55,7 +54,7 @@ export default class DefaultTemplatesLoader {
    * register the templates internally so that they can be later consumed
    * (e.g. by components and renderers) with convienience.
    *
-   * `fetchTemplates` will automatically call this, providing the compiled templates from the server.
+   * This is called from inside handlebarswrapper.txt.
    */
   register (templates) {
     this._templates = templates;


### PR DESCRIPTION
If somebody was using the built-in template loader, instead of
manually specifying a script tag with the templates, we had a race condition
between the master switch api call and the default templates loader.
There was a chance components would be addComponent-ed before any
templates were registered.

This commit uses Promise.all() so we don't delay the masterswitch api +
ponyfill while waiting for the templates to load.
Without this update, waiting for the template loader, and after it's finished only
then running the ponyfill and checking the master switch api, caused an additional ~75-100ms
slowdown. Updating the code to use Promise.all() got us back the old performance, 
barring a few occasional spikes (which I'm assuming would have errored out without 
this change) his was measured by adding a performance mark at the start of the onReady().
Theoretically the page would also be slightly faster on ie11, since the master switch api no longer
blocks the ponyfill, but I haven't confirm this.

There was some consideration to use Promise.race() with the master switch api,
so that if the master switch was disabled then the site would fail immediately
instead of waiting for the other async deps, but it felt weird to optimize for
this and it made the code more complicated.

T=https://yextops.zendesk.com/agent/tickets/356651
TEST=manual

for these changes, I had to change the COMPILED_TEMPLATES_URL
to point to my localhost

test that if I force the template loader to wait an extra 2 seconds
before creating the templates script tag, the rest of the page will
wait for the templates to load (and check that without this code
change we would see the page fail to load without waiting)

test that if that master switch is disabled, the experience will
still not load

test that if the master switch takes longer than the timeout,
the page will load (tested by changing the timeout to 0ms)

test that I can chain more .then()s after the ANSWERS.init()
promise (was worried that using finally() would prevent this)

test speed as noted above

test that ponyfill still works on ie11 with --yxt-filter-options-options-max-height