### PR TITLE
Run build_i18n step on hotfix branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,6 +139,7 @@ workflows:
               ignore:
                 - master
                 - /^support\/.*/
+                - /^hotfix\/.*/
                 - /^feature\/.*-i18n/
                 - /^release\/.*/
       - unit_test:
@@ -164,6 +165,7 @@ workflows:
             branches:
               only:
                 - /^support\/.*/
+                - /^hotfix\/.*/
                 - /^feature\/.*-i18n/
                 - /^release\/.*/
       - unit_test:


### PR DESCRIPTION
Run build_i18n step on hotfix branches

This is necessary so that PRs into master can verify the build_i18n step worked

J=none
TEST=none