### PR TITLE
Add redirectUrlTarget config option to SearchBar component

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ ANSWERS.addComponent('SearchBar', {
   clearButton: true,
   // Optional, redirect search query to url
   redirectUrl: 'path/to/url',
-  // Optional, target frame for the redirect url, defaults to current frame
+  // Optional, target frame for the redirect url, defaults to current frame. Expects a valid target: "_blank", "_self", "_parent", "_top" or the name of a frame
   redirectUrlTarget: '_self',
   // Optional, defaults to native form node within container
   formSelector: 'form',

--- a/README.md
+++ b/README.md
@@ -431,6 +431,8 @@ ANSWERS.addComponent('SearchBar', {
   clearButton: true,
   // Optional, redirect search query to url
   redirectUrl: 'path/to/url',
+  // Optional, target frame for the redirect url, defaults to current frame
+  redirectUrlTarget: '_self',
   // Optional, defaults to native form node within container
   formSelector: 'form',
   // Optional, defaults to true. When true, a form is used as the query submission context.

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -137,8 +137,6 @@ export default class SearchComponent extends Component {
      * redirectUrl is also supplied.
      * Optional, defaults to current frame.
      *
-     * If no redirectUrlTarget provided, we keep the page as a single page app.
-     *
      * @type {string}
      */
     this.redirectUrlTarget = config.redirectUrlTarget || '_self';

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -133,7 +133,7 @@ export default class SearchComponent extends Component {
     this.redirectUrl = config.redirectUrl || null;
 
     /**
-     * redirectUrlTarget will force the search query submission to open in the frame specified, if
+     * redirectUrlTarget will force the search query submission to open in the frame specified if
      * redirectUrl is also supplied.
      * Optional, defaults to current frame.
      *

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -500,7 +500,7 @@ export default class SearchComponent extends Component {
       if (this._allowEmptySearch || query) {
         const newUrl = this.redirectUrl + '?' + params.toString();
         if (this.redirectUrlTarget) {
-          window[this.redirectUrlTarget].location.href = newUrl;
+          window.open(newUrl, this.redirectUrlTarget) || (window.location.href = newUrl);
         } else {
           window.location.href = newUrl;
         }

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -133,6 +133,17 @@ export default class SearchComponent extends Component {
     this.redirectUrl = config.redirectUrl || null;
 
     /**
+     * redirectUrlTarget will force the search query submission to open in a new tab if
+     * redirectUrl is also supplied.
+     * Optional, defaults to current page.
+     *
+     * If no redirectUrlTarget provided, we keep the page as a single page app.
+     *
+     * @type {boolean}
+     */
+    this.redirectUrlTarget = config.redirectUrlTarget || null;
+
+    /**
      * true if there is another search bar present on the page.
      * Twins only update the query, and do not search
      */
@@ -487,7 +498,12 @@ export default class SearchComponent extends Component {
     // serialized and submitted.
     if (typeof this.redirectUrl === 'string') {
       if (this._allowEmptySearch || query) {
-        window.location.href = this.redirectUrl + '?' + params.toString();
+        const newUrl = this.redirectUrl + '?' + params.toString();
+        if (this.redirectUrlTarget) {
+          window[this.redirectUrlTarget].location.href = newUrl;
+        } else {
+          window.location.href = newUrl;
+        }
         return false;
       }
     }

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -141,7 +141,7 @@ export default class SearchComponent extends Component {
      *
      * @type {boolean}
      */
-    this.redirectUrlTarget = config.redirectUrlTarget || null;
+    this.redirectUrlTarget = config.redirectUrlTarget || '_self';
 
     /**
      * true if there is another search bar present on the page.
@@ -499,11 +499,7 @@ export default class SearchComponent extends Component {
     if (typeof this.redirectUrl === 'string') {
       if (this._allowEmptySearch || query) {
         const newUrl = this.redirectUrl + '?' + params.toString();
-        if (this.redirectUrlTarget) {
-          window.open(newUrl, this.redirectUrlTarget) || (window.location.href = newUrl);
-        } else {
-          window.location.href = newUrl;
-        }
+        window.open(newUrl, this.redirectUrlTarget) || (window.location.href = newUrl);
         return false;
       }
     }

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -128,7 +128,7 @@ export default class SearchComponent extends Component {
      *
      * If no redirectUrl provided, we keep the page as a single page app.
      *
-     * @type {boolean}
+     * @type {string}
      */
     this.redirectUrl = config.redirectUrl || null;
 
@@ -139,7 +139,7 @@ export default class SearchComponent extends Component {
      *
      * If no redirectUrlTarget provided, we keep the page as a single page app.
      *
-     * @type {boolean}
+     * @type {string}
      */
     this.redirectUrlTarget = config.redirectUrlTarget || '_self';
 

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -133,9 +133,9 @@ export default class SearchComponent extends Component {
     this.redirectUrl = config.redirectUrl || null;
 
     /**
-     * redirectUrlTarget will force the search query submission to open in a new tab if
+     * redirectUrlTarget will force the search query submission to open in the frame specified, if
      * redirectUrl is also supplied.
-     * Optional, defaults to current page.
+     * Optional, defaults to current frame.
      *
      * If no redirectUrlTarget provided, we keep the page as a single page app.
      *


### PR DESCRIPTION
Add a config option that allows a user to specify the target of the redirect url, if provided.

TEST=manual

Specify "redirectUrlTarget: "_blank"" with a redirectUrl, see it open in new tab. Also tested "_self", "_parent" and "_top". 