### PR TITLE
Add unit tests to the i18n build process

### DIFF
--- a/conf/i18n/constants.js
+++ b/conf/i18n/constants.js
@@ -2,7 +2,7 @@ exports.TRANSLATION_FLAGGER_REGEX = /TranslationFlagger.flag\((\s)*\{[^;]+?\}(\s
 
 exports.DEFAULT_LOCALE = 'en';
 
-exports.LANGUAGES_TO_LOCALES = {
+const LANGUAGES_TO_LOCALES = {
   'en': [
     'en_AE',
     'en_AI',
@@ -104,5 +104,6 @@ exports.LANGUAGES_TO_LOCALES = {
     'ja_JP'
   ]
 };
+exports.LANGUAGES_TO_LOCALES = LANGUAGES_TO_LOCALES;
 
-exports.ALL_LANGUAGES = ['en', 'es', 'fr', 'it', 'de', 'ja'];
+exports.ALL_LANGUAGES = Object.keys(LANGUAGES_TO_LOCALES);

--- a/conf/i18n/constants.js
+++ b/conf/i18n/constants.js
@@ -105,4 +105,4 @@ exports.LANGUAGES_TO_LOCALES = {
   ]
 };
 
-exports.ALL_LANGUAGES = Object.keys('en', 'es', 'fr', 'it', 'de', 'ja');
+exports.ALL_LANGUAGES = ['en', 'es', 'fr', 'it', 'de', 'ja'];

--- a/conf/i18n/constants.js
+++ b/conf/i18n/constants.js
@@ -105,4 +105,4 @@ exports.LANGUAGES_TO_LOCALES = {
   ]
 };
 
-exports.ALL_LANGUAGES = Object.keys(this.LANGUAGES_TO_LOCALES);
+exports.ALL_LANGUAGES = Object.keys('en', 'es', 'fr', 'it', 'de', 'ja');

--- a/conf/i18n/extract/translationextractor.js
+++ b/conf/i18n/extract/translationextractor.js
@@ -51,6 +51,15 @@ class TranslationExtractor {
   }
 
   /**
+   * Returns the extracted messages as a pot file string.
+   * //github.com/lukasgeiter/gettext-extractor/wiki/API-Reference#getpotstringheaders
+   * @returns {Array<Object>}
+   */
+  getPotString () {
+    return this._extractor.getPotString();
+  }
+
+  /**
    * Registers a given {@link TranslationPlaceholder}'s message.
    *
    * @param {TranslationPlaceholder} placeholder

--- a/conf/i18n/translationresolver.js
+++ b/conf/i18n/translationresolver.js
@@ -28,7 +28,7 @@ class TranslationResolver {
     const count = placeholder.getCount();
     const context = placeholder.getContext();
     if (count && context) {
-      throw new Error('Translate plural with context not currently supported');
+      return this._resolveWithPluralAndContext(placeholder);
     }
 
     if (count) {
@@ -82,6 +82,22 @@ class TranslationResolver {
   _resolveWithPlural (placeholder) {
     const translationResult = this._translator.translatePlural(
       placeholder.getPhrase(), placeholder.getPluralForm());
+    const interpValues = placeholder.getInterpolationValues();
+    return this._resolveInternal(
+      translationResult, interpValues, placeholder.getCount());
+  }
+
+  /**
+   * Converts the {@link TranslationPlaceholder} of a phrase with context needing both
+   * translation and pluralization into the appropriate run-time call.
+   *
+   * @param {TranslationPlaceholder} placeholder The {@link TranslationPlaceholder}.
+   * @returns {string} The correct call for getting the translated, pluralized
+   *                   string at run-time.
+   */
+  _resolveWithPluralAndContext (placeholder) {
+    const translationResult = this._translator.translatePluralWithContext(
+      placeholder.getPhrase(), placeholder.getPluralForm(), placeholder.getContext());
     const interpValues = placeholder.getInterpolationValues();
     return this._resolveInternal(
       translationResult, interpValues, placeholder.getCount());

--- a/package-lock.json
+++ b/package-lock.json
@@ -4727,6 +4727,14 @@
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+          "dev": true
+        }
       }
     },
     "babel-template": {
@@ -15811,9 +15819,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
       "dev": true
     },
     "regenerator-transform": {

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
   "semistandard": {
     "globals": [
       "beforeEach",
+      "beforeAll",
       "describe",
       "it",
       "expect",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "jsdoc": "^3.6.3",
     "node-sass": "^4.12.0",
     "postcss-pxtorem": "4.0.1",
+    "regenerator-runtime": "^0.13.7",
     "rollup": "^1.4.1",
     "rollup-plugin-babel": "^4.3.2",
     "rollup-plugin-commonjs": "^9.2.1",
@@ -95,7 +96,8 @@
     ],
     "testMatch": [
       "**/tests/core/**/*.js",
-      "**/tests/ui/**/*.js"
+      "**/tests/ui/**/*.js",
+      "**/tests/conf/**/*.js"
     ]
   },
   "semistandard": {

--- a/tests/conf/i18n/extract/translationextractor.js
+++ b/tests/conf/i18n/extract/translationextractor.js
@@ -2,7 +2,7 @@ const TranslationExtractor = require('../../../../conf/i18n/extract/translatione
 const path = require('path');
 const fs = require('fs');
 
-describe('TranslationExtractor', () => {
+describe('TranslationExtractor generates proper POT files', () => {
   function readFile (filename) {
     const fixturesDir = path.resolve(__dirname, '../../../fixtures');
     return fs.readFileSync(path.join(fixturesDir, filename)).toString();

--- a/tests/conf/i18n/extract/translationextractor.js
+++ b/tests/conf/i18n/extract/translationextractor.js
@@ -1,0 +1,35 @@
+const TranslationExtractor = require('../../../../conf/i18n/extract/translationextractor');
+const path = require('path');
+const fs = require('fs');
+
+describe('TranslationExtractor', () => {
+  function readFile (filename) {
+    const fixturesDir = path.resolve(__dirname, '../../../fixtures');
+    return fs.readFileSync(path.join(fixturesDir, filename)).toString();
+  }
+
+  let extractor;
+  beforeEach(() => {
+    extractor = new TranslationExtractor();
+  });
+
+  it('can extract from a javascript file', () => {
+    const rawJavascript = readFile('rawjavascript.js');
+    const expectedJavascriptPot = readFile('expectedjavascript.pot');
+
+    extractor.extract(rawJavascript, 'rawjavascript.js');
+    const potString = extractor.getPotString();
+
+    expect(potString).toEqual(expectedJavascriptPot);
+  });
+
+  it('can extract from a hbs file', () => {
+    const rawTemplate = readFile('rawtemplate.hbs');
+    const expectedTemplatePot = readFile('expectedtemplate.pot');
+
+    extractor.extract(rawTemplate, 'rawtemplate.hbs');
+    const potString = extractor.getPotString();
+
+    expect(potString).toEqual(expectedTemplatePot);
+  });
+});

--- a/tests/conf/i18n/runtimecallgeneratorutils.js
+++ b/tests/conf/i18n/runtimecallgeneratorutils.js
@@ -1,0 +1,29 @@
+const { generateProcessTranslationJsCall } = require('../../../conf/i18n/runtimecallgeneratorutils');
+
+describe('generateProcessTranslationJsCall usage', () => {
+  it('simple translation', () => {
+    const translation = 'Bonjour';
+    const interpolationValues = {};
+
+    const actualJsCall = generateProcessTranslationJsCall(translation, interpolationValues);
+    const expectedJsCall = `ANSWERS.processTranslation('Bonjour', {})`;
+
+    expect(actualJsCall).toEqual(expectedJsCall);
+  });
+
+  it('translation with plural form', () => {
+    const translations = {
+      '0': '[[count]] résultat pour [[verticalName]]',
+      '1': '[[count]] résultats pour [[verticalName]]'
+    };
+    const interpolationValues = {
+      count: 'myCount',
+      verticalName: 'verticalName'
+    };
+
+    const actualJsCall = generateProcessTranslationJsCall(translations, interpolationValues, 'myCount');
+    const expectedJsCall = `ANSWERS.processTranslation({0:'[[count]] résultat pour [[verticalName]]',1:'[[count]] résultats pour [[verticalName]]'}, {count:myCount,verticalName:verticalName}, myCount)`;
+
+    expect(actualJsCall).toEqual(expectedJsCall);
+  });
+});

--- a/tests/conf/i18n/runtimecallgeneratorutils.js
+++ b/tests/conf/i18n/runtimecallgeneratorutils.js
@@ -1,6 +1,6 @@
 const { generateProcessTranslationJsCall } = require('../../../conf/i18n/runtimecallgeneratorutils');
 
-describe('generateProcessTranslationJsCall usage', () => {
+describe('generateProcessTranslationJsCall works as expected', () => {
   it('simple translation', () => {
     const translation = 'Bonjour';
     const interpolationValues = {};

--- a/tests/conf/i18n/translatecallparser.js
+++ b/tests/conf/i18n/translatecallparser.js
@@ -1,6 +1,6 @@
 const TranslateCallParser = require('../../../conf/i18n/translatecallparser');
 
-describe('TranslateCallParser usage', () => {
+describe('TranslateCallParser creates a TranslationPlaceholder from a TranslationFlagger', () => {
   const translateCallParser = new TranslateCallParser();
   it('All params parse properly', () => {
     const translateCall = `TranslationFlagger.flag({

--- a/tests/conf/i18n/translatecallparser.js
+++ b/tests/conf/i18n/translatecallparser.js
@@ -1,0 +1,33 @@
+const TranslateCallParser = require('../../../conf/i18n/translatecallparser');
+
+describe('TranslateCallParser usage', () => {
+  const translateCallParser = new TranslateCallParser();
+  it('All params parse properly', () => {
+    const translateCall = `TranslationFlagger.flag({
+        phrase: 'Simple phrase',
+        pluralForm: 'Plural form',
+        context: 'Context',
+        count: 42,
+        interpolationValues: {
+          start: min,
+          end: max
+        }
+      })`;
+    const lineNumber = 1;
+    const filePath = 'src/file.js';
+    const expectedResult = {
+      _phrase: 'Simple phrase',
+      _pluralForm: 'Plural form',
+      _context: 'Context',
+      _count: '42',
+      _interpolationValues: {
+        start: 'min',
+        end: 'max'
+      },
+      _lineNumber: lineNumber,
+      _filepath: filePath
+    };
+    const actualResult = translateCallParser.parse(translateCall, lineNumber, filePath);
+    expect(actualResult).toMatchObject(expectedResult);
+  });
+});

--- a/tests/conf/i18n/translatehelpervisitor.js
+++ b/tests/conf/i18n/translatehelpervisitor.js
@@ -13,10 +13,14 @@ async function createTranslator () {
 }
 
 describe('TranslateHelperVisitor translates visited nodes', () => {
-  it('static translation', async () => {
+  let translator;
+  beforeEach(async () => {
+    translator = await createTranslator();
+  });
+
+  it('static translation', () => {
     const template = `{{ translate phrase='Hello' }}`;
     const ast = Handlebars.parse(template);
-    const translator = await createTranslator();
 
     new TranslateHelperVisitor(translator).accept(ast);
     const indexOfFirstStatement = 0;
@@ -25,10 +29,9 @@ describe('TranslateHelperVisitor translates visited nodes', () => {
     expect(translatedValue).toEqual('Bonjour');
   });
 
-  it('plural translation', async () => {
+  it('plural translation', () => {
     const template = `{{ translate phrase='result' pluralForm='results' count=resultCount }}`;
     const ast = Handlebars.parse(template);
-    const translator = await createTranslator();
 
     new TranslateHelperVisitor(translator).accept(ast);
     const indexOfFirstStatement = 0;
@@ -50,11 +53,10 @@ describe('TranslateHelperVisitor translates visited nodes', () => {
     expect(hashPairs).toMatchObject([expectedCount, expectedPluralForm0, expectedPluralForm1]);
   });
 
-  it('a non-translate helper should not be modified', async () => {
+  it('a non-translate helper should not be modified', () => {
     const template = `{{ yext phrase='Hello' }}`;
     const ast = Handlebars.parse(template);
     const originalAst = _.cloneDeep(ast);
-    const translator = await createTranslator();
 
     new TranslateHelperVisitor(translator).accept(ast);
 

--- a/tests/conf/i18n/translatehelpervisitor.js
+++ b/tests/conf/i18n/translatehelpervisitor.js
@@ -26,7 +26,7 @@ describe('TranslateHelperVisitor usage', () => {
   });
 
   it('plural translation', async () => {
-    const template = `{{ translate phrase='result' pluralForm='results' count='resultCount' }}`;
+    const template = `{{ translate phrase='result' pluralForm='results' count=resultCount }}`;
     const ast = Handlebars.parse(template);
     const translator = await createTranslator();
 
@@ -34,22 +34,28 @@ describe('TranslateHelperVisitor usage', () => {
     const indexOfFirstStatement = 0;
     const hashPairs = ast.body[indexOfFirstStatement].hash.pairs;
 
-    const expectedHashPairs = {
-      count: 'resultCount',
-      pluralForm0: 'résultat',
-      pluralForm1: 'résultats'
+    const expectedPluralForm0 = {
+      key: 'pluralForm0',
+      value: { type: 'StringLiteral', value: 'résultat' }
     };
 
-    // For each expected hash pair, confirm that a hash pair with the same key and value
-    // exists in the visited AST
-    Object.entries(expectedHashPairs)
-      .map(([expectedHashKey, expectedHashValue]) => {
-        expect(hashPairs.some(hashPair => {
-          const keysMatch = hashPair.key === expectedHashKey;
-          const valuesMatch = hashPair.value.value === expectedHashValue;
-          return keysMatch && valuesMatch;
-        })).toBeTruthy();
-      });
+    const expectedPluralForm1 = {
+      key: 'pluralForm1',
+      value: { type: 'StringLiteral', value: 'résultats' }
+    };
+
+    const expectedCount = {
+      key: 'count',
+      value: { type: 'PathExpression', parts: ['resultCount'] }
+    };
+
+    const actualPluralForm0 = hashPairs.find(hashPair => hashPair.key === 'pluralForm0');
+    const actualPluralForm1 = hashPairs.find(hashPair => hashPair.key === 'pluralForm1');
+    const actualCount = hashPairs.find(hashPair => hashPair.key === 'count');
+
+    expect(actualPluralForm0).toMatchObject(expectedPluralForm0);
+    expect(actualPluralForm1).toMatchObject(expectedPluralForm1);
+    expect(actualCount).toMatchObject(expectedCount);
   });
 
   it('a non-translate helper should not be modified', async () => {

--- a/tests/conf/i18n/translatehelpervisitor.js
+++ b/tests/conf/i18n/translatehelpervisitor.js
@@ -34,13 +34,15 @@ describe('TranslateHelperVisitor usage', () => {
     const indexOfFirstStatement = 0;
     const hashPairs = ast.body[indexOfFirstStatement].hash.pairs;
 
-    const expectedHashValues = {
+    const expectedHashPairs = {
       count: 'resultCount',
       pluralForm0: 'résultat',
       pluralForm1: 'résultats'
     };
 
-    Object.entries(expectedHashValues)
+    // For each expected hash pair, confirm that a hash pair with the same key and value
+    // exists in the visited AST
+    Object.entries(expectedHashPairs)
       .map(([expectedHashKey, expectedHashValue]) => {
         expect(hashPairs.some(hashPair => {
           const keysMatch = hashPair.key === expectedHashKey;
@@ -53,11 +55,11 @@ describe('TranslateHelperVisitor usage', () => {
   it('a non-translate helper should not be modified', async () => {
     const template = `{{ yext phrase='Hello' }}`;
     const ast = Handlebars.parse(template);
-    const nonVisitedAst = _.cloneDeep(ast);
+    const originalAst = _.cloneDeep(ast);
     const translator = await createTranslator();
 
     new TranslateHelperVisitor(translator).accept(ast);
 
-    expect(nonVisitedAst).toMatchObject(ast);
+    expect(originalAst).toMatchObject(ast);
   });
 });

--- a/tests/conf/i18n/translatehelpervisitor.js
+++ b/tests/conf/i18n/translatehelpervisitor.js
@@ -1,0 +1,48 @@
+const TranslateHelperVisitor = require('../../../conf/i18n/translatehelpervisitor');
+const Translator = require('../../../conf/i18n/translator');
+const Handlebars = require('handlebars');
+const _ = require('lodash');
+
+async function createTranslator () {
+  const locale = 'fr';
+  return Translator.create(locale, [], { [locale]: { translation: {
+    'Hello': 'Bonjour'
+  } } });
+}
+
+describe('TranslateHelperVisitor usage', () => {
+  it('static translation', async () => {
+    const template = `{{ translate phrase='Hello' }}`;
+    const ast = Handlebars.parse(template);
+    const translator = await createTranslator();
+
+    new TranslateHelperVisitor(translator).accept(ast);
+    const indexOfFirstStatement = 0;
+    const translatedValue = ast.body[indexOfFirstStatement].value;
+
+    expect(translatedValue).toEqual('Bonjour');
+  });
+
+  it('non-translate helper', async () => {
+    const template = `{{ yext phrase='Hello' }}`;
+    const ast = Handlebars.parse(template);
+    const nonVisitedAst = _.cloneDeep(ast);
+    const translator = await createTranslator();
+
+    new TranslateHelperVisitor(translator).accept(ast);
+
+    expect(nonVisitedAst).toMatchObject(ast);
+  });
+
+  /* it('plural translation', async () => {
+    const template = `{{ translate phrase='result' pluralForm='results'}}`;
+    const ast = Handlebars.parse(template);
+    const translator = await createTranslator();
+
+    new TranslateHelperVisitor(translator).accept(ast);
+    const indexOfFirstStatement = 0;
+    const translatedValue = ast.body[indexOfFirstStatement].value;
+
+    expect(translatedValue).toEqual('Bonjour');
+  }); */
+});

--- a/tests/conf/i18n/translatehelpervisitor.js
+++ b/tests/conf/i18n/translatehelpervisitor.js
@@ -34,28 +34,20 @@ describe('TranslateHelperVisitor translates visited nodes', () => {
     const indexOfFirstStatement = 0;
     const hashPairs = ast.body[indexOfFirstStatement].hash.pairs;
 
+    const expectedCount = {
+      key: 'count',
+      value: { type: 'PathExpression', parts: ['resultCount'] }
+    };
     const expectedPluralForm0 = {
       key: 'pluralForm0',
       value: { type: 'StringLiteral', value: 'résultat' }
     };
-
     const expectedPluralForm1 = {
       key: 'pluralForm1',
       value: { type: 'StringLiteral', value: 'résultats' }
     };
 
-    const expectedCount = {
-      key: 'count',
-      value: { type: 'PathExpression', parts: ['resultCount'] }
-    };
-
-    const actualPluralForm0 = hashPairs.find(hashPair => hashPair.key === 'pluralForm0');
-    const actualPluralForm1 = hashPairs.find(hashPair => hashPair.key === 'pluralForm1');
-    const actualCount = hashPairs.find(hashPair => hashPair.key === 'count');
-
-    expect(actualPluralForm0).toMatchObject(expectedPluralForm0);
-    expect(actualPluralForm1).toMatchObject(expectedPluralForm1);
-    expect(actualCount).toMatchObject(expectedCount);
+    expect(hashPairs).toMatchObject([expectedCount, expectedPluralForm0, expectedPluralForm1]);
   });
 
   it('a non-translate helper should not be modified', async () => {

--- a/tests/conf/i18n/translatehelpervisitor.js
+++ b/tests/conf/i18n/translatehelpervisitor.js
@@ -12,7 +12,7 @@ async function createTranslator () {
   } } });
 }
 
-describe('TranslateHelperVisitor usage', () => {
+describe('TranslateHelperVisitor translates visited nodes', () => {
   it('static translation', async () => {
     const template = `{{ translate phrase='Hello' }}`;
     const ast = Handlebars.parse(template);

--- a/tests/conf/i18n/translatehelpervisitor.js
+++ b/tests/conf/i18n/translatehelpervisitor.js
@@ -14,7 +14,6 @@ async function createTranslator () {
 
 describe('TranslateHelperVisitor translates visited nodes', () => {
   let translator;
-  /* global beforeAll */
   beforeAll(async () => {
     translator = await createTranslator();
   });

--- a/tests/conf/i18n/translatehelpervisitor.js
+++ b/tests/conf/i18n/translatehelpervisitor.js
@@ -14,7 +14,8 @@ async function createTranslator () {
 
 describe('TranslateHelperVisitor translates visited nodes', () => {
   let translator;
-  beforeEach(async () => {
+  /* global beforeAll */
+  beforeAll(async () => {
     translator = await createTranslator();
   });
 

--- a/tests/conf/i18n/translationplaceholderutils.js
+++ b/tests/conf/i18n/translationplaceholderutils.js
@@ -1,8 +1,8 @@
 const Handlebars = require('handlebars');
 const { fromMustacheStatementNode } = require('../../../conf/i18n/translationplaceholderutils');
 const TranslationPlaceholder = require('../../../conf/i18n/models/translationplaceholder');
-describe('fromMustacheStatementNode usage', () => {
-  it('standard usage', () => {
+describe('Creating a translation placeholder from a HBS template', () => {
+  it('fromMustacheStatementNode usage', () => {
     const template = `{{ 
       translate 
       phrase='result' 

--- a/tests/conf/i18n/translationplaceholderutils.js
+++ b/tests/conf/i18n/translationplaceholderutils.js
@@ -1,0 +1,32 @@
+const Handlebars = require('handlebars');
+const { fromMustacheStatementNode } = require('../../../conf/i18n/translationplaceholderutils');
+const TranslationPlaceholder = require('../../../conf/i18n/models/translationplaceholder');
+describe('fromMustacheStatementNode usage', () => {
+  it('standard usage', () => {
+    const template = `{{ 
+      translate 
+      phrase='result' 
+      pluralForm='results' 
+      count='resultCount' 
+      param1='param1'
+      param2='param2'
+      context='testing' 
+    }}`;
+
+    const indexOfFirstMustacheStatement = 0;
+    const mustacheStatement = Handlebars.parse(template).body[indexOfFirstMustacheStatement];
+    const filePath = '/path/to/file';
+    const actualTranslationPlaceholder = fromMustacheStatementNode(mustacheStatement, filePath);
+
+    const expectedTranslationPlaceholder = new TranslationPlaceholder({
+      phrase: 'result',
+      pluralForm: 'results',
+      context: 'testing',
+      count: 'resultCount',
+      interpolationValues: { count: 'resultCount', param1: 'param1', param2: 'param2' },
+      lineNumber: 1,
+      filepath: filePath
+    });
+    expect(actualTranslationPlaceholder).toMatchObject(expectedTranslationPlaceholder);
+  });
+});

--- a/tests/conf/i18n/translationresolver.js
+++ b/tests/conf/i18n/translationresolver.js
@@ -1,0 +1,77 @@
+const TranslationResolver = require('../../../conf/i18n/translationresolver');
+const Translator = require('../../../conf/i18n/translator');
+const TranslationPlaceholder = require('../../../conf/i18n/models/translationplaceholder');
+
+async function createTranslationResolver () {
+  const translator = await createTranslator();
+  const passThroughRuntimeGenerator = translationResult => translationResult;
+  return new TranslationResolver(translator, passThroughRuntimeGenerator);
+}
+
+async function createTranslator () {
+  const locale = 'fr';
+  return Translator.create(locale, [], { [locale]: { translation: {
+    'Hello': 'Bonjour',
+    'result': 'résultat',
+    'result_plural': 'résultats',
+    'result_a number': 'résultat',
+    'result_a number_plural': 'résultats',
+    'mail_noun': 'courrier'
+  } } });
+}
+
+describe('TranslationResolver usage', () => {
+  it('resolves a simple phrase', async () => {
+    const translationResolver = await createTranslationResolver();
+    const placeholder = new TranslationPlaceholder({
+      phrase: 'Hello',
+      interpolationValues: {}
+    });
+    const resolverResult = translationResolver.resolve(placeholder);
+    expect(resolverResult).toEqual('Bonjour');
+  });
+
+  it('resolves with context', async () => {
+    const translationResolver = await createTranslationResolver();
+    const placeholder = new TranslationPlaceholder({
+      phrase: 'mail',
+      context: 'noun',
+      interpolationValues: {}
+    });
+    const resolverResult = translationResolver.resolve(placeholder);
+    expect(resolverResult).toEqual('courrier');
+  });
+
+  it('resolves plural forms', async () => {
+    const translationResolver = await createTranslationResolver();
+    const placeholder = new TranslationPlaceholder({
+      phrase: 'result',
+      pluralForm: 'results',
+      count: 'myCount',
+      interpolationValues: {}
+    });
+    const expectedResult = {
+      '0': 'résultat',
+      '1': 'résultats'
+    };
+    const resolverResult = translationResolver.resolve(placeholder);
+    expect(resolverResult).toMatchObject(expectedResult);
+  });
+
+  it('resolves plural forms with context', async () => {
+    const translationResolver = await createTranslationResolver();
+    const placeholder = new TranslationPlaceholder({
+      phrase: 'result',
+      pluralForm: 'results',
+      count: 'myCount',
+      context: 'a number',
+      interpolationValues: {}
+    });
+    const expectedResult = {
+      '0': 'résultat',
+      '1': 'résultats'
+    };
+    const resolverResult = translationResolver.resolve(placeholder);
+    expect(resolverResult).toMatchObject(expectedResult);
+  });
+});

--- a/tests/conf/i18n/translationresolver.js
+++ b/tests/conf/i18n/translationresolver.js
@@ -14,8 +14,8 @@ async function createTranslator () {
     'Hello': 'Bonjour',
     'result': 'résultat',
     'result_plural': 'résultats',
-    'result_a number': 'résultat',
-    'result_a number_plural': 'résultats',
+    'object_noun': 'objet',
+    'object_noun_plural': 'objets',
     'mail_noun': 'courrier'
   } } });
 }
@@ -61,15 +61,15 @@ describe('TranslationResolver usage', () => {
   it('resolves plural forms with context', async () => {
     const translationResolver = await createTranslationResolver();
     const placeholder = new TranslationPlaceholder({
-      phrase: 'result',
-      pluralForm: 'results',
+      phrase: 'object',
+      pluralForm: 'objects',
       count: 'myCount',
-      context: 'a number',
+      context: 'noun',
       interpolationValues: {}
     });
     const expectedResult = {
-      '0': 'résultat',
-      '1': 'résultats'
+      '0': 'objet',
+      '1': 'objets'
     };
     const resolverResult = translationResolver.resolve(placeholder);
     expect(resolverResult).toMatchObject(expectedResult);

--- a/tests/conf/i18n/translationresolver.js
+++ b/tests/conf/i18n/translationresolver.js
@@ -20,7 +20,7 @@ async function createTranslator () {
   } } });
 }
 
-describe('TranslationResolver usage', () => {
+describe('TranslationResolver can resolve various TranslationPlaceholders', () => {
   it('resolves a simple phrase', async () => {
     const translationResolver = await createTranslationResolver();
     const placeholder = new TranslationPlaceholder({

--- a/tests/conf/i18n/translator.js
+++ b/tests/conf/i18n/translator.js
@@ -1,0 +1,259 @@
+const path = require('path');
+
+const LocalFileParser = require('../../../conf/i18n/localfileparser');
+const Translator = require('../../../conf/i18n/translator');
+
+/* global beforeAll */
+
+describe('translations with one plural form (French)', () => {
+  let translator;
+  beforeAll(async () => {
+    const translationsPath = path.join(__dirname, '../../fixtures/translations');
+    const localFileParser = new LocalFileParser(translationsPath);
+
+    const frFRTranslations = await localFileParser.fetch('fr-FR');
+    const frTranslations = await localFileParser.fetch('fr');
+    const translations = {
+      fr: { translation: frTranslations },
+      'fr-FR': { translation: frFRTranslations }
+    };
+
+    translator = await Translator.create('fr-FR', ['fr'], translations);
+  });
+
+  describe('Translations without pluralization or context', () => {
+    it('simple translation works as expected', () => {
+      const translation = translator.translate('Item');
+      expect(translation).toEqual('Article');
+    });
+
+    it('simple translation with interpolation works as expected', () => {
+      const translation =
+        translator.translate('Hello [[name]]');
+      expect(translation).toEqual('Bonjour [[name]]');
+    });
+
+    it('translation fallback works as expected', () => {
+      const translation = translator.translate('Breakfast');
+      expect(translation).toEqual('Petit Déjeuner');
+    });
+
+    it('translation with a period . work as expected', () => {
+      const translation = translator.translate('The dog.');
+      expect(translation).toEqual('Le chien.');
+    });
+
+    it('translation with a colon : work as expected', () => {
+      const translation = translator.translate('The: dog');
+      expect(translation).toEqual('Le: chien');
+    });
+  });
+
+  describe('Translations with pluralization and no context', () => {
+    it('simple pluralization works as expected', () => {
+      const translation = translator.translatePlural('Item', 'Items');
+      const expectedResult = {
+        0: 'Article',
+        1: 'Articles'
+      };
+
+      expect(translation).toEqual(expectedResult);
+    });
+
+    it('pluralization with interpolation works as expected', () => {
+      const translation = translator.translatePlural(
+        'There is [[count]] item [[name]]', 'There are [[count]] items [[name]]');
+      const expectedResult = {
+        0: 'Il y a [[count]] article [[name]]',
+        1: 'Il y a [[count]] articles [[name]]'
+      };
+
+      expect(translation).toEqual(expectedResult);
+    });
+
+    it('falls back correctly when no translations present', () => {
+      const translation = translator.translatePlural(
+        'Missing [[count]] translation [[name]]',
+        'Missing [[count]] translations [[name]]');
+      const expectedResult = {
+        0: 'Missing [[count]] translation [[name]]',
+        1: 'Missing [[count]] translations [[name]]'
+      };
+
+      expect(translation).toEqual(expectedResult);
+    });
+  });
+
+  describe('Translations with context and no pluralization', () => {
+    it('context works as expected', () => {
+      const translationWithMaleContext = translator
+        .translateWithContext('Child', 'male');
+      const translationWithFemaleContext = translator
+        .translateWithContext('Child', 'female');
+      expect(translationWithMaleContext).toEqual('fils');
+      expect(translationWithFemaleContext).toEqual('fille');
+    });
+
+    it('context and interpolation works as expected', () => {
+      const translationWithMaleContext = translator.translateWithContext(
+        'I am looking for my child named [[name]]', 'male');
+      const translationWithFemaleContext = translator.translateWithContext(
+        'I am looking for my child named [[name]]', 'female');
+      expect(translationWithMaleContext).toEqual('Je cherche mon fils nommé [[name]]');
+      expect(translationWithFemaleContext).toEqual('Je cherche mon fille nommé [[name]]');
+    });
+  });
+
+  describe('Translations with pluralization and context', () => {
+    it('Pluralization and context works as expected', () => {
+      const translationWithMaleContext = translator.translatePluralWithContext(
+        'The person',
+        'The people',
+        'male');
+      const translationWithFemaleContext = translator.translatePluralWithContext(
+        'The person',
+        'The people',
+        'female');
+      const expectedResultWithMaleContext = {
+        0: 'L\'homme',
+        1: 'Les hommes'
+      };
+      const expectedResultWithFemaleContext = {
+        0: 'La femme',
+        1: 'Les femmes'
+      };
+      expect(translationWithMaleContext).toEqual(expectedResultWithMaleContext);
+      expect(translationWithFemaleContext).toEqual(expectedResultWithFemaleContext);
+    });
+
+    it('Pluralization and interpolation works as expected', () => {
+      const translationWithMaleContext = translator.translatePluralWithContext(
+        'The [[count]] person went on a walk',
+        'The [[count]] people went on a walk',
+        'male');
+      const translationWithFemaleContext = translator.translatePluralWithContext(
+        'The [[count]] person went on a walk',
+        'The [[count]] people went on a walk',
+        'female');
+      const expectedResultWithMaleContext = {
+        0: 'Le [[count]] homme est parti en promenade',
+        1: 'Les [[count]] Hommes fait une promenade'
+      };
+      const expectedResultWithFemaleContext = {
+        0: 'La [[count]] femme a fait une promenade',
+        1: 'Les [[count]] femmes fait une promenade'
+      };
+      expect(translationWithMaleContext).toEqual(expectedResultWithMaleContext);
+      expect(translationWithFemaleContext).toEqual(expectedResultWithFemaleContext);
+    });
+
+    it('Pluralization and interpolation with context works when translation is not found',
+      () => {
+        const translation = translator.translatePluralWithContext(
+          'The [[count]] elephant went on a drive',
+          'The [[count]] elephants went on a drive',
+          'male');
+        const expectedResult = {
+          0: 'The [[count]] elephant went on a drive',
+          1: 'The [[count]] elephants went on a drive'
+        };
+        expect(translation).toEqual(expectedResult);
+      }
+    );
+  });
+
+  describe('supports text intermixed with HTML', () => {
+    it('apostrophe inside text and html class with double quotes', () => {
+      const translation = translator.translate(
+        '<span class="yext">The dog\'s bone</span>');
+      expect(translation).toEqual('<span class="yext">L\'os du chien</span>');
+    });
+
+    it('test with apostrophe and double quotes', () => {
+      const translation = translator.translate(
+        '<span class="yext">The dog\'s bone</span>');
+      expect(translation).toEqual('<span class="yext">L\'os du chien</span>');
+    });
+
+    it('with interpolation', () => {
+      const translation = translator.translate(
+        '<a href="https://www.yext.com">View our website [[name]]</a>');
+      expect(translation).toEqual(
+        '<a href="https://www.yext.com">Voir notre site web [[name]]</a>');
+    });
+
+    it('with pluralization', () => {
+      const translation = translator.translatePlural(
+        '<a href="https://www.yext.com">View our website [[name]]</a>',
+        '<a href="https://www.yext.com">View our websites [[name]]</a>');
+      const expectedResult = {
+        0: '<a href="https://www.yext.com">Voir notre site web [[name]]</a>',
+        1: '<a href="https://www.yext.com">Voir nos sites web [[name]]</a>' };
+      expect(translation).toEqual(expectedResult);
+    });
+
+    it('with pluralization and context', () => {
+      const translation = translator.translatePluralWithContext(
+        '<a href="https://www.yext.com">View our website [[name]]</a>',
+        '<a href="https://www.yext.com">View our websites [[name]]</a>',
+        'internet web, not spider web');
+      const expectedResult = {
+        0: '<a href="https://www.yext.com">Voir notre site web [[name]]</a>',
+        1: '<a href="https://www.yext.com">Voir nos sites web [[name]]</a>' };
+      expect(translation).toEqual(expectedResult);
+    });
+  });
+
+  describe('Handles plural translation keys by escaping regex charaters', () => {
+    it('does not confuse parenthesis for a capturing group', () => {
+      const translation = translator.translatePlural(
+        '([[resultsCount]] result)',
+        '([[resultsCount]] results)');
+      const expectedResult = {
+        0: '([[resultsCount]] résultat)',
+        1: '([[resultsCount]] résultats)' };
+      expect(translation).toEqual(expectedResult);
+    });
+  });
+});
+
+describe('translations with multiple plural forms (Lithuanian)', () => {
+  let translator;
+  beforeAll(async () => {
+    const translationsPath = path.join(__dirname, '../../fixtures/translations');
+    const localFileParser = new LocalFileParser(translationsPath);
+
+    const ltLtTranslations = await localFileParser.fetch('lt-LT');
+    const translations = {
+      'lt-LT': { translation: ltLtTranslations }
+    };
+
+    translator = await Translator.create('lt-LT', [], translations);
+  });
+
+  it('simple pluralization works as expected', () => {
+    const translation = translator.translatePlural(
+      'Unable to email review', 'Unable to email reviews');
+    const expectedResult = {
+      0: 'Nepavyksta nusiųsti apžvalgos el. paštu',
+      1: 'Nepavyksta nusiųsti apžvalgų el. paštu',
+      2: 'Nepavyksta nusiųsti apžvalgų el. paštu'
+    };
+
+    expect(translation).toEqual(expectedResult);
+  });
+
+  it('pluralization with interpolation works as expected', () => {
+    const translation = translator.translatePlural(
+      '1 location selected',
+      '[[count]] locations selected]'
+    );
+    const expectedResult = {
+      0: 'Pasirinkta [[count]] tinklalapis',
+      1: 'Pasirinkta [[count]] tinklalapiai',
+      2: 'Pasirinkta [[count]] tinklalapių'
+    };
+
+    expect(translation).toEqual(expectedResult);
+  });
+});

--- a/tests/conf/i18n/translator.js
+++ b/tests/conf/i18n/translator.js
@@ -244,7 +244,7 @@ describe('translations with multiple plural forms (Lithuanian)', () => {
   it('pluralization with interpolation works as expected', () => {
     const translation = translator.translatePlural(
       '1 location selected',
-      '[[count]] locations selected]'
+      '[[count]] locations selected'
     );
     const expectedResult = {
       0: 'Pasirinkta [[count]] tinklalapis',

--- a/tests/conf/i18n/translator.js
+++ b/tests/conf/i18n/translator.js
@@ -3,11 +3,9 @@ const path = require('path');
 const LocalFileParser = require('../../../conf/i18n/localfileparser');
 const Translator = require('../../../conf/i18n/translator');
 
-/* global beforeAll */
-
 describe('translations with one plural form (French)', () => {
   let translator;
-  beforeAll(async () => {
+  beforeEach(async () => {
     const translationsPath = path.join(__dirname, '../../fixtures/translations');
     const localFileParser = new LocalFileParser(translationsPath);
 
@@ -219,7 +217,7 @@ describe('translations with one plural form (French)', () => {
 
 describe('translations with multiple plural forms (Lithuanian)', () => {
   let translator;
-  beforeAll(async () => {
+  beforeEach(async () => {
     const translationsPath = path.join(__dirname, '../../fixtures/translations');
     const localFileParser = new LocalFileParser(translationsPath);
 

--- a/tests/fixtures/expectedjavascript.pot
+++ b/tests/fixtures/expectedjavascript.pot
@@ -1,0 +1,29 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+
+#: rawjavascript.js:18
+msgid "([[resultsCount]] result)"
+msgid_plural "([[resultsCount]] results)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: rawjavascript.js:11
+msgid "Go to page [[maxPage]] of results"
+msgstr ""
+
+#: rawjavascript.js:7
+msgid "We are unable to determine your location"
+msgstr ""
+
+#: rawjavascript.js:32
+msgctxt "Alt-text"
+msgid "[[resultsCount]] autocomplete option found"
+msgid_plural "[[resultsCount]] autocomplete options found"
+msgstr[0] ""
+msgstr[1] ""
+
+#: rawjavascript.js:27
+msgctxt "Labels an input field"
+msgid "What are you interested in?"
+msgstr ""

--- a/tests/fixtures/expectedtemplate.pot
+++ b/tests/fixtures/expectedtemplate.pot
@@ -1,0 +1,29 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+
+#: rawtemplate.hbs:3
+msgid "([[resultsCount]] result)"
+msgid_plural "([[resultsCount]] results)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: rawtemplate.hbs:2
+msgid "Go to page [[maxPage]] of results"
+msgstr ""
+
+#: rawtemplate.hbs:1
+msgid "Go to the next page of results"
+msgstr ""
+
+#: rawtemplate.hbs:5
+msgctxt "Alt-text"
+msgid "[[resultsCount]] autocomplete option found"
+msgid_plural "[[resultsCount]] autocomplete options found"
+msgstr[0] ""
+msgstr[1] ""
+
+#: rawtemplate.hbs:4
+msgctxt "Change is a verb. Example: change filtering logic"
+msgid "change"
+msgstr ""

--- a/tests/fixtures/rawjavascript.js
+++ b/tests/fixtures/rawjavascript.js
@@ -1,0 +1,38 @@
+const TranslationFlagger = require('../../src/ui/i18n/translationflagger');
+
+// Interpolation values
+const maxPage = 3;
+const resultsCount = 3;
+
+TranslationFlagger.flag({
+  phrase: 'We are unable to determine your location'
+});
+
+TranslationFlagger.flag({
+  phrase: 'Go to page [[maxPage]] of results',
+  interpolationValues: {
+    maxPage: maxPage
+  }
+});
+
+TranslationFlagger.flag({
+  phrase: '([[resultsCount]] result)',
+  pluralForm: '([[resultsCount]] results)',
+  count: resultsCount,
+  interpolationValues: {
+    resultsCount: resultsCount
+  }
+});
+
+TranslationFlagger.flag({
+  phrase: 'What are you interested in?',
+  context: 'Labels an input field'
+});
+
+TranslationFlagger.flag({
+  phrase: '[[resultsCount]] autocomplete option found',
+  pluralForm: '[[resultsCount]] autocomplete options found',
+  count: resultsCount,
+  resultsCount: resultsCount,
+  context: 'Alt-text'
+});

--- a/tests/fixtures/rawtemplate.hbs
+++ b/tests/fixtures/rawtemplate.hbs
@@ -1,0 +1,11 @@
+{{translate phrase='Go to the next page of results' }}
+{{translate phrase='Go to page [[maxPage]] of results' maxPage=maxPage }}
+{{translate phrase='([[resultsCount]] result)' pluralForm='([[resultsCount]] results)' count=resultsCount resultsCount=resultsCount }}
+{{translate phrase='change' context='Change is a verb. Example: change filtering logic' }}
+{{translate
+  phrase='[[resultsCount]] autocomplete option found'
+  pluralForm='[[resultsCount]] autocomplete options found'
+  resultsCount=resultsCount
+  count=resultsCount
+  context='Alt-text'
+}}

--- a/tests/fixtures/translations/fr-FR.po
+++ b/tests/fixtures/translations/fr-FR.po
@@ -1,0 +1,88 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: i18next-conv\n"
+"mime-version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1)\n"
+"POT-Creation-Date: 2020-08-04T20:43:15.907Z\n"
+"PO-Revision-Date: 2020-08-04T20:43:15.907Z\n"
+"Language: fr\n"
+
+msgid "Item"
+msgid_plural "Item"
+msgstr[0] "Article"
+msgstr[1] "Articles"
+
+msgid "Hello [[name]]"
+msgstr "Bonjour [[name]]"
+
+msgid "There is [[count]] item [[name]]"
+msgid_plural "There are [[count]] items [[name]]"
+msgstr[0] "Il y a [[count]] article [[name]]"
+msgstr[1] "Il y a [[count]] articles [[name]]"
+
+msgctxt "male"
+msgid "Child"
+msgstr "fils"
+
+msgctxt "female"
+msgid "Child"
+msgstr "fille"
+
+msgctxt "male"
+msgid "I am looking for my child named [[name]]"
+msgstr "Je cherche mon fils nommé [[name]]"
+
+msgctxt "female"
+msgid "I am looking for my child named [[name]]"
+msgstr "Je cherche mon fille nommé [[name]]"
+
+msgctxt "male"
+msgid "The person"
+msgid_plural "The people"
+msgstr[0] "L'homme"
+msgstr[1] "Les hommes"
+
+msgctxt "female"
+msgid "The person"
+msgid_plural "The people"
+msgstr[0] "La femme"
+msgstr[1] "Les femmes"
+
+msgctxt "male"
+msgid "The [[count]] person went on a walk"
+msgid_plural "The [[count]] people went on a walk"
+msgstr[0] "Le [[count]] homme est parti en promenade"
+msgstr[1] "Les [[count]] Hommes fait une promenade"
+
+msgctxt "female"
+msgid "The [[count]] person went on a walk"
+msgid_plural "The [[count]] people went on a walk"
+msgstr[0] "La [[count]] femme a fait une promenade"
+msgstr[1] "Les [[count]] femmes fait une promenade"
+
+msgid "The dog."
+msgstr "Le chien."
+
+msgid "The: dog"
+msgstr "Le: chien"
+
+msgid "<a href=\"https://www.yext.com\">View our website [[name]]</a>"
+msgstr "<a href=\"https://www.yext.com\">Voir notre site web [[name]]</a>"
+
+msgid "<a href=\"https://www.yext.com\">View our website [[name]]</a>"
+msgid_plural "<a href=\"https://www.yext.com\">View our websites [[name]]</a>"
+msgstr[0] "<a href=\"https://www.yext.com\">Voir notre site web [[name]]</a>"
+msgstr[1] "<a href=\"https://www.yext.com\">Voir nos sites web [[name]]</a>"
+
+msgctxt "internet web, not spider web"
+msgid "<a href=\"https://www.yext.com\">View our website [[name]]</a>"
+msgid_plural "<a href=\"https://www.yext.com\">View our websites [[name]]</a>"
+msgstr[0] "<a href=\"https://www.yext.com\">Voir notre site web [[name]]</a>"
+msgstr[1] "<a href=\"https://www.yext.com\">Voir nos sites web [[name]]</a>"
+
+msgid "([[resultsCount]] result)"
+msgid_plural "([[resultsCount]] results)"
+msgstr[0] "([[resultsCount]] résultat)"
+msgstr[1] "([[resultsCount]] résultats)"

--- a/tests/fixtures/translations/fr.po
+++ b/tests/fixtures/translations/fr.po
@@ -1,0 +1,19 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: i18next-conv\n"
+"mime-version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1)\n"
+"POT-Creation-Date: 2020-07-21T21:08:49.169Z\n"
+"PO-Revision-Date: 2020-07-21T21:08:49.169Z\n"
+"Language: fr\n"
+
+msgid "Breakfast"
+msgstr "Petit Déjeuner"
+
+msgid "Alternatively, you can<a class=\"yxt-AlternativeVerticals-universalLink\" href=universalUrl>view results across all search categories</a>"
+msgstr "Sinon vous pouvez<a class=\"yxt-AlternativeVerticals-universalLink\" href=universalUrl>afficher les résultats dans toutes les catégories de recherche</a>"
+
+msgid "<span class=\"yext\">The dog's bone</span>"
+msgstr "<span class=\"yext\">L'os du chien</span>"

--- a/tests/fixtures/translations/lt-LT.po
+++ b/tests/fixtures/translations/lt-LT.po
@@ -1,0 +1,13 @@
+#: js/yext/pages/common/sitefields.js:36
+msgid "1 location selected"
+msgid_plural "[[count]] locations selected"
+msgstr[0] "Pasirinkta [[count]] tinklalapis"
+msgstr[1] "Pasirinkta [[count]] tinklalapiai"
+msgstr[2] "Pasirinkta [[count]] tinklalapių"
+
+#: js/yext/reviewsstorm/reviews.js:672
+msgid "Unable to email review"
+msgid_plural "Unable to email reviews"
+msgstr[0] "Nepavyksta nusiųsti apžvalgos el. paštu"
+msgstr[1] "Nepavyksta nusiųsti apžvalgų el. paštu"
+msgstr[2] "Nepavyksta nusiųsti apžvalgų el. paštu"

--- a/tests/setup/setup.js
+++ b/tests/setup/setup.js
@@ -1,4 +1,5 @@
 import { configure } from 'enzyme';
 import AnswersAdapter from './enzymeadapter';
+import 'regenerator-runtime/runtime';
 
 configure({ adapter: new AnswersAdapter() });


### PR DESCRIPTION
Add tests to the code responsible for transpiling the javascript and hbs helpers into processTranslation calls.

Test coverage includes `TranslationResolver`, `TranslateCallParser`, `TranslateHelperVisitor`, `Translator`, `fromMustacheStatementNode()`, and `generateProcessTranslationJsCall()`.

This PR also adds tests for the translation extractor and adds pluralWithContext support to the translation resolver. The tests for the translator are from the Jambo translator test suite. I tweaked the `ALL_LANGUAGES` to make it work with the tests.

J=SLAP-700
TEST=auto

Run unit tests and confirm they pass