### PR TITLE
Add autocomplete onOpen and onClose hooks

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -5,7 +5,7 @@ module.exports = [
   },
   {
     path: 'dist/answers-modern.min.js',
-    limit: '105kb'
+    limit: '110kb'
   },
   {
     path: 'dist/answerstemplates.compiled.min.js',

--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ ANSWERS.addComponent('SearchBar', {
     // Optional, the message in the alert. Defaults to the below
     message: "We are unable to determine your location"
   },
-  // Optional, options the autocomplete component
+  // Optional, options to pass to the autocomplete component
   autocomplete: {
     // Optional, callback invoked when the autocomplete component changes from open to closed.
     onClose: function() {},

--- a/README.md
+++ b/README.md
@@ -456,6 +456,13 @@ ANSWERS.addComponent('SearchBar', {
     enabled: false,
     // Optional, the message in the alert. Defaults to the below
     message: "We are unable to determine your location"
+  },
+  // Optional, options the autocomplete component
+  autocomplete: {
+    // Optional, callback invoked when the autocomplete component changes from open to closed.
+    onClose: function() {},
+    // Optional, callback invoked when the autocomplete component changes from closed to open.
+    onOpen: function() {},
   }
 })
 ```

--- a/src/ui/components/search/autocompletecomponent.js
+++ b/src/ui/components/search/autocompletecomponent.js
@@ -112,6 +112,24 @@ export default class AutoCompleteComponent extends Component {
      * @type {string}
      */
     this.listLabelIdName = opts.listLabelIdName || 'yxt-SearchBar-listLabel--SearchBar';
+
+    /**
+     * Callback invoked when the autocomplete component changes from closed to open.
+     * @type {function}
+     */
+    this._onOpen = opts.onOpen || function () {};
+
+    /**
+     * Callback invoked when the autocomplete component changes from open to closed.
+     * @type {function}
+     */
+    this._onClose = opts.onClose || function () {};
+
+    /**
+     * Indicates the initial open/closed status of this component
+     * @type {boolean}
+     */
+    this._isOpen = false;
   }
 
   /**
@@ -136,11 +154,22 @@ export default class AutoCompleteComponent extends Component {
    * those are client-interaction specific values and aren't returned from the server.
    */
   setState (data) {
+    const wasOpen = this._isOpen;
     if (!this.isQueryInputFocused()) {
+      this._isOpen = false;
       this._sectionIndex = 0;
       this._resultIndex = -1;
       data = {};
+    } else {
+      this._isOpen = true;
     }
+
+    if (wasOpen && !this._isOpen) {
+      this._onClose();
+    } else if (!wasOpen && this._isOpen) {
+      this.onOpen();
+    }
+
     super.setState(Object.assign({}, data, {
       hasResults: this.hasResults(data),
       sectionIndex: this._sectionIndex,

--- a/src/ui/components/search/autocompletecomponent.js
+++ b/src/ui/components/search/autocompletecomponent.js
@@ -167,7 +167,7 @@ export default class AutoCompleteComponent extends Component {
     if (wasOpen && !this._isOpen) {
       this._onClose();
     } else if (!wasOpen && this._isOpen) {
-      this.onOpen();
+      this._onOpen();
     }
 
     super.setState(Object.assign({}, data, {

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -273,6 +273,12 @@ export default class SearchComponent extends Component {
      * @type {string}
      */
     this.inputIdName = `yxt-SearchBar-input--${this.name}`;
+
+    /**
+     * Options to pass to the autocomplete component
+     * @type {Object}
+     */
+    this._autocompleteConfig = config.autocomplete || {};
   }
 
   static get type () {
@@ -548,6 +554,7 @@ export default class SearchComponent extends Component {
       originalQuery: this.query,
       inputEl: inputSelector,
       listLabelIdName: this.inputLabelIdName,
+      ...this._autocompleteConfig,
       onSubmit: () => {
         if (this._useForm) {
           DOM.trigger(DOM.query(this._container, this._formEl), 'submit');

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -278,7 +278,10 @@ export default class SearchComponent extends Component {
      * Options to pass to the autocomplete component
      * @type {Object}
      */
-    this._autocompleteConfig = config.autocomplete || {};
+    this._autocompleteConfig = {
+      onOpen: config.autocomplete && config.autocomplete.onOpen,
+      onClose: config.autocomplete && config.autocomplete.onClose
+    };
   }
 
   static get type () {


### PR DESCRIPTION
TEST=manual

Test with the theme, specifying both onOpen and onClose with simple `console.log` statements. See the "open" print statement print once when the autocomplete opens, and "close" print once when autocomplete closes.