### PR TITLE
Add onSubmit function to SearchBar component

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -5,7 +5,7 @@ module.exports = [
   },
   {
     path: 'dist/answers-modern.min.js',
-    limit: '105kb'
+    limit: '110kb'
   },
   {
     path: 'dist/answerstemplates.compiled.min.js',

--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ ANSWERS.addComponent('SearchBar', {
     // Optional, a function invoked when a search is submitted via this component. The users search
     // is passed in as a string
     onSubmit: function(searchTerms) {}
-  }
+  },
   // Optional, options to pass to the autocomplete component
   autocomplete: {
     // Optional, boolean used to hide the autocomplete when the search input is empty (even if the

--- a/README.md
+++ b/README.md
@@ -460,8 +460,11 @@ ANSWERS.addComponent('SearchBar', {
   // Optional, functions invoked when certain events occur
   customHooks: {
     // Optional, a callback invoked when the clear search button is clicked
-    onClearSearch: function() {}
-  },
+    onClearSearch: function() {},
+    // Optional, a function invoked when a search is submitted via this component. The users search
+    // is passed in as a string
+    onSubmit: function(searchTerms) {}
+  }
   // Optional, options to pass to the autocomplete component
   autocomplete: {
     // Optional, boolean used to hide the autocomplete when the search input is empty (even if the
@@ -471,12 +474,6 @@ ANSWERS.addComponent('SearchBar', {
     onClose: function() {},
     // Optional, callback invoked when the autocomplete component changes from closed to open.
     onOpen: function() {},
-  },
-  // Optional, functions invoked when certain events occur
-  customHooks: {
-    // Optional, a function invoked when a search is submitted via this component. The users search
-    // is passed in as a string
-    onSubmit: function(searchTerms) {}
   }
 })
 ```

--- a/README.md
+++ b/README.md
@@ -456,7 +456,10 @@ ANSWERS.addComponent('SearchBar', {
     enabled: false,
     // Optional, the message in the alert. Defaults to the below
     message: "We are unable to determine your location"
-  }
+  },
+  // Optional, a callback invoked when a search is submitted via this component. The users search
+  //           is passed in as a string
+  onSubmit: function(searchTerms) {}
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -457,9 +457,12 @@ ANSWERS.addComponent('SearchBar', {
     // Optional, the message in the alert. Defaults to the below
     message: "We are unable to determine your location"
   },
-  // Optional, a callback invoked when a search is submitted via this component. The users search
-  //           is passed in as a string
-  onSubmit: function(searchTerms) {}
+  // Optional, functions invoked when certain events occur
+  customHooks: {
+    // Optional, a function invoked when a search is submitted via this component. The users search
+    // is passed in as a string
+    onSubmit: function(searchTerms) {}
+  }
 })
 ```
 

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -278,11 +278,11 @@ export default class SearchComponent extends Component {
       /**
        * Callback invoked when the clear search button is clicked
        */
-      onClearSearch: config.onClearSearch || function () {},
+      onClearSearch: (config.customHooks && config.customHooks.onClearSearch) || function () {},
       /**
        * Callback invoked when a search is submitted via this component
        */
-      onSubmit: config.onSubmit || function () {}
+      onSubmit: (config.customHooks && config.customHooks.onSubmit) || function () {}
     };
 
     /**

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -274,10 +274,12 @@ export default class SearchComponent extends Component {
      */
     this.inputIdName = `yxt-SearchBar-input--${this.name}`;
 
-    /**
-     * Callback invoked when a search is submitted via this component
-     */
-    this.onSubmit = config.onSubmit || function () {};
+    this.customHooks = {
+      /**
+       * Callback invoked when a search is submitted via this component
+       */
+      onSubmit: config.onSubmit || function () {}
+    };
   }
 
   static get type () {
@@ -492,6 +494,8 @@ export default class SearchComponent extends Component {
     const params = new SearchParams(window.location.search.substring(1));
     params.set('query', query);
 
+    this.customHooks.onSubmit(query);
+
     const context = this.core.globalStorage.getState(StorageKeys.API_CONTEXT);
     if (context) {
       params.set(StorageKeys.API_CONTEXT, context);
@@ -631,7 +635,6 @@ export default class SearchComponent extends Component {
    * @returns {Promise} A promise that will perform the query and update globalStorage accordingly.
    */
   search (query, searchOptions) {
-    this.onSubmit(query);
     if (this._verticalKey) {
       this.core.verticalSearch(this._config.verticalKey, searchOptions, { input: query });
     } else {

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -273,6 +273,11 @@ export default class SearchComponent extends Component {
      * @type {string}
      */
     this.inputIdName = `yxt-SearchBar-input--${this.name}`;
+
+    /**
+     * Callback invoked when a search is submitted via this component
+     */
+    this.onSubmit = config.onSubmit || function () {};
   }
 
   static get type () {
@@ -626,6 +631,7 @@ export default class SearchComponent extends Component {
    * @returns {Promise} A promise that will perform the query and update globalStorage accordingly.
    */
   search (query, searchOptions) {
+    this.onSubmit(query);
     if (this._verticalKey) {
       this.core.verticalSearch(this._config.verticalKey, searchOptions, { input: query });
     } else {

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -278,7 +278,11 @@ export default class SearchComponent extends Component {
       /**
        * Callback invoked when the clear search button is clicked
        */
-      onClearSearch: config.onClearSearch || function () {}
+      onClearSearch: config.onClearSearch || function () {},
+      /**
+       * Callback invoked when a search is submitted via this component
+       */
+      onSubmit: config.onSubmit || function () {}
     };
 
     /**
@@ -289,13 +293,6 @@ export default class SearchComponent extends Component {
       shouldHideOnEmptySearch: config.autocomplete && config.autocomplete.shouldHideOnEmptySearch,
       onOpen: config.autocomplete && config.autocomplete.onOpen,
       onClose: config.autocomplete && config.autocomplete.onClose
-    };
-
-    this.customHooks = {
-      /**
-       * Callback invoked when a search is submitted via this component
-       */
-      onSubmit: config.onSubmit || function () {}
     };
   }
 


### PR DESCRIPTION
Add an onSubmit hook to the SearchBar component. This `onSubmit` function is necessary for the Overlay and should happen as (or before) the search network call is conducted.

This is different than the onUniversalSearch and onVerticalSearch because those functions are meant to be used for analytics. Those functions happen after the search is conducted and provide result information to a user; they also are expected to return an analytics event. 

TEST=manual

Add a simple onSubmit function with a console.log statement. See output printed to console when search is conducted.