### PR TITLE
Verify all translations are present in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,21 @@ jobs:
       - attach_workspace:
           at: ~/answers
       - run: ./.circleci/run_acceptance.sh
-        
+  # verify all translations are present
+  translation_test:
+    docker:
+      - image: circleci/node.14.5
+    working_directory: ~/answers
+    steps:
+      - setup-workspace
+      - attach_workspace:
+          at: ~/answers
+      - run: 
+        name: Verify translation files
+        command: |
+          npm run extract-translations
+          cd conf/i18n/translations
+          find . -type f -name "*.po" | xargs -n1 -I {{po_file}} msgcmp {{po_file}} messages.pot
   # deploy to S3 in the root folder, overwriting the existing latest version
   deploy_latest:
     docker:
@@ -158,6 +172,9 @@ workflows:
       - acceptance_test:
           requires:
             - build
+      - translation_test:
+          requires:
+            - build
       - deploy_canary:
           filters:
             branches:
@@ -165,6 +182,7 @@ workflows:
           requires:
             - unit_test
             - acceptance_test
+            - translation_test
       - deploy_branch:
           filters:
             branches:
@@ -188,10 +206,14 @@ workflows:
       - acceptance_test:
           requires:
             - build_i18n
+      - translation_test:
+          requires:
+            - build_i18n
       - deploy_branch:
           requires:
             - unit_test
             - acceptance_test
+            - translation_test
   build_and_deploy_hold:
     jobs:
       - build_i18n:
@@ -213,6 +235,12 @@ workflows:
               only: /^v.*/
           requires:
             - build_i18n
+      - translation_test:
+          filters:
+            tags:
+              only: /^v.*/
+          requires:
+            - build_i18n
       - hold:
           type: approval
           filters:
@@ -221,6 +249,7 @@ workflows:
           requires:
             - unit_test
             - acceptance_test
+            - translation_test
       - deploy_latest:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,11 +102,11 @@ jobs:
       - attach_workspace:
           at: ~/answers
       - run: 
-        name: Verify translation files
-        command: |
-          npm run extract-translations
-          cd conf/i18n/translations
-          find . -type f -name "*.po" | xargs -n1 -I {{po_file}} msgcmp {{po_file}} messages.pot
+          name: Verify translation files
+          command: |
+            npm run extract-translations
+            cd conf/i18n/translations
+            find . -type f -name "*.po" | xargs -n1 -I {{po_file}} msgcmp {{po_file}} messages.pot
   # deploy to S3 in the root folder, overwriting the existing latest version
   deploy_latest:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
           name: Verify translation files
           command: |
             npm run extract-translations
-            apt-get install gettext
+            sudo apt-get install gettext
             cd conf/i18n/translations
             find . -type f -name "*.po" | xargs -n1 -I {{po_file}} msgcmp {{po_file}} messages.pot
   # deploy to S3 in the root folder, overwriting the existing latest version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,6 +191,7 @@ workflows:
           requires:
             - unit_test
             - acceptance_test
+            - translation_test
   build_and_deploy_i18n:
     jobs:
       - build_i18n:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
           name: Verify translation files
           command: |
             npm run extract-translations
-            sudo apt-get install -qq -d gettext
+            sudo apt-get install -qq gettext
             cd conf/i18n/translations
             for po_file in *.po
               do msgcmp $po_file messages.pot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ jobs:
   # verify all translations are present
   translation_test:
     docker:
-      - image: circleci/node.14.5
+      - image: circleci/node:14.5
     working_directory: ~/answers
     steps:
       - setup-workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,7 @@ jobs:
           name: Verify translation files
           command: |
             npm run extract-translations
+            apt-get install gettext
             cd conf/i18n/translations
             find . -type f -name "*.po" | xargs -n1 -I {{po_file}} msgcmp {{po_file}} messages.pot
   # deploy to S3 in the root folder, overwriting the existing latest version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,9 +105,11 @@ jobs:
           name: Verify translation files
           command: |
             npm run extract-translations
-            sudo apt-get install gettext
+            sudo apt-get install -qq -d gettext
             cd conf/i18n/translations
-            find . -type f -name "*.po" | xargs -n1 -I {{po_file}} msgcmp {{po_file}} messages.pot
+            for po_file in *.po
+              do msgcmp $po_file messages.pot
+            done
   # deploy to S3 in the root folder, overwriting the existing latest version
   deploy_latest:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,12 +104,8 @@ jobs:
       - run: 
           name: Verify translation files
           command: |
-            npm run extract-translations
             sudo apt-get install -qq gettext
-            cd conf/i18n/translations
-            for po_file in *.po
-              do msgcmp $po_file messages.pot
-            done
+            ./.circleci/run_translation_verification.sh
   # deploy to S3 in the root folder, overwriting the existing latest version
   deploy_latest:
     docker:

--- a/.circleci/run_translation_verification.sh
+++ b/.circleci/run_translation_verification.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+npm run extract-translations
+
+cd conf/i18n/translations
+
+for po_file in *.po
+  do msgcmp $po_file messages.pot
+done

--- a/conf/i18n/translations/de.po
+++ b/conf/i18n/translations/de.po
@@ -444,4 +444,4 @@ msgstr "Eine Fragen stellen"
 #: src/ui/components/search/searchcomponent.js:81
 msgctxt "Verb, clears search"
 msgid "Clear"
-
+msgstr "entfernen"

--- a/conf/i18n/translations/de.po
+++ b/conf/i18n/translations/de.po
@@ -444,4 +444,4 @@ msgstr "Eine Fragen stellen"
 #: src/ui/components/search/searchcomponent.js:81
 msgctxt "Verb, clears search"
 msgid "Clear"
-msgstr "entfernen"
+


### PR DESCRIPTION
Add a translation_test job to Circle which tests that all the PO files contain all the translations defined in the POT file.

Use the utility "msgcmp" to compare the files.

The original PR for this is #1124 , but I accidentally merged that without squashing, so I am re-doing it.

J=SLAP-724
TEST=manual

Observe CircleCI pass when all translations are present. Push a test commit where a translation is missing and observe it fail.