### PR TITLE
Add shouldHideOnEmptySearch config option to SearchBar

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,12 @@ ANSWERS.addComponent('SearchBar', {
     enabled: false,
     // Optional, the message in the alert. Defaults to the below
     message: "We are unable to determine your location"
+  },
+  // Optional, options to pass to the autocomplete component
+  autocomplete: {
+    // Optional, boolean used to hide the autocomplete when the search input is empty (even if the
+    // input is focused). Defaults to false.
+    shouldHideOnEmptySearch: false,
   }
 })
 ```

--- a/src/ui/components/search/autocompletecomponent.js
+++ b/src/ui/components/search/autocompletecomponent.js
@@ -112,6 +112,12 @@ export default class AutoCompleteComponent extends Component {
      * @type {string}
      */
     this.listLabelIdName = opts.listLabelIdName || 'yxt-SearchBar-listLabel--SearchBar';
+
+    /**
+     * Whether to hide the autocomplete when the search input is empty
+     * @type {boolean}
+     */
+    this._shouldHideOnEmptySearch = opts.shouldHideOnEmptySearch || false;
   }
 
   /**
@@ -136,7 +142,9 @@ export default class AutoCompleteComponent extends Component {
    * those are client-interaction specific values and aren't returned from the server.
    */
   setState (data) {
-    if (!this.isQueryInputFocused()) {
+    const queryInputEl = DOM.query(this._parentContainer, this._inputEl);
+    const shouldHideAutocomplete = this._shouldHideOnEmptySearch && !queryInputEl.value;
+    if (!this.isQueryInputFocused() || shouldHideAutocomplete) {
       this._sectionIndex = 0;
       this._resultIndex = -1;
       data = {};

--- a/src/ui/components/search/autocompletecomponent.js
+++ b/src/ui/components/search/autocompletecomponent.js
@@ -119,7 +119,7 @@ export default class AutoCompleteComponent extends Component {
      */
     this._shouldHideOnEmptySearch = opts.shouldHideOnEmptySearch || false;
 
-    /*
+    /**
      * Callback invoked when the autocomplete component changes from closed to open.
      * @type {function}
      */

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -279,7 +279,7 @@ export default class SearchComponent extends Component {
      * @type {Object}
      */
     this._autocompleteConfig = {
-      shouldHideOnEmptySearch: config.autocomplete && config.autocomplete.shouldHideOnEmptySearch,
+      shouldHideOnEmptySearch: config.autocomplete && config.autocomplete.shouldHideOnEmptySearch
     };
   }
 

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -273,6 +273,14 @@ export default class SearchComponent extends Component {
      * @type {string}
      */
     this.inputIdName = `yxt-SearchBar-input--${this.name}`;
+
+    /**
+     * Options to pass to the autocomplete component
+     * @type {Object}
+     */
+    this._autocompleteConfig = {
+      shouldHideOnEmptySearch: config.autocomplete && config.autocomplete.shouldHideOnEmptySearch,
+    };
   }
 
   static get type () {
@@ -548,6 +556,7 @@ export default class SearchComponent extends Component {
       originalQuery: this.query,
       inputEl: inputSelector,
       listLabelIdName: this.inputLabelIdName,
+      ...this._autocompleteConfig,
       onSubmit: () => {
         if (this._useForm) {
           DOM.trigger(DOM.query(this._container, this._formEl), 'submit');


### PR DESCRIPTION
TEST=manual

Provide this option, then on test site click into empty search bar, note autocomplete does not appear. Begin typing, on first keystroke see autocomplete appear. Hit backspace, when search input is empty, see autocomplete disappear again.