### PR TITLE
VerticalResultsCount: add noResults.visible config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -890,7 +890,12 @@ The results count component displays the current results count on a vertical pag
 
 ```js
 ANSWERS.addComponent('VerticalResultsCount', {
-  container: '.results-count-container'
+  container: '.results-count-container',
+  noResults: {
+    // Optional, whether the results count should be visible when displaying no results.
+    // Defaults to false.
+    visible: false
+  }
 });
 ```
 

--- a/src/ui/components/results/verticalresultscountcomponent.js
+++ b/src/ui/components/results/verticalresultscountcomponent.js
@@ -1,6 +1,7 @@
 import Component from '../component';
 import StorageKeys from '../../../core/storage/storagekeys';
 import SearchStates from '../../../core/storage/searchstates';
+import ResultsContext from '../../../core/storage/resultscontext';
 
 export default class VerticalResultsCountComponent extends Component {
   constructor (config = {}, systemConfig = {}) {
@@ -10,6 +11,8 @@ export default class VerticalResultsCountComponent extends Component {
         this.setState(verticalResults);
       }
     });
+
+    this._visibleForNoResults = (config.noResults || {}).visible;
   }
 
   static areDuplicateNamesAllowed () {
@@ -36,7 +39,9 @@ export default class VerticalResultsCountComponent extends Component {
       ...data,
       total: resultsCount,
       pageStart: offset + 1,
-      pageEnd: offset + resultsLength
+      pageEnd: offset + resultsLength,
+      hiddenForNoResults: !this._visibleForNoResults,
+      isNoResults: verticalResults.resultsContext === ResultsContext.NO_RESULTS
     });
   }
 

--- a/src/ui/components/results/verticalresultscountcomponent.js
+++ b/src/ui/components/results/verticalresultscountcomponent.js
@@ -13,7 +13,7 @@ export default class VerticalResultsCountComponent extends Component {
     });
 
     /**
-     * When the page is in a No Results state, whether to display the 
+     * When the page is in a No Results state, whether to display the
      * vertical results count.
      * @type {boolean}
      */
@@ -42,7 +42,7 @@ export default class VerticalResultsCountComponent extends Component {
     const offset = this.core.globalStorage.getState(StorageKeys.SEARCH_OFFSET) || 0;
     const isNoResults = verticalResults.resultsContext === ResultsContext.NO_RESULTS;
     const hasZeroResults = resultsCount === 0;
-    const isHidden = hasZeroResults || !this._visibleForNoResults && isNoResults;
+    const isHidden = (!this._visibleForNoResults && isNoResults) || hasZeroResults;
     return super.setState({
       ...data,
       total: resultsCount,

--- a/src/ui/components/results/verticalresultscountcomponent.js
+++ b/src/ui/components/results/verticalresultscountcomponent.js
@@ -12,7 +12,12 @@ export default class VerticalResultsCountComponent extends Component {
       }
     });
 
-    this._visibleForNoResults = (config.noResults || {}).visible;
+    /**
+     * When the page is in a No Results state, whether to display the 
+     * vertical results count.
+     * @type {boolean}
+     */
+    this._visibleForNoResults = !!(config.noResults || {}).visible;
   }
 
   static areDuplicateNamesAllowed () {
@@ -35,13 +40,15 @@ export default class VerticalResultsCountComponent extends Component {
     const resultsLength = (verticalResults.results || []).length;
 
     const offset = this.core.globalStorage.getState(StorageKeys.SEARCH_OFFSET) || 0;
+    const isNoResults = verticalResults.resultsContext === ResultsContext.NO_RESULTS;
+    const hasZeroResults = resultsCount === 0;
+    const isHidden = hasZeroResults || !this._visibleForNoResults && isNoResults;
     return super.setState({
       ...data,
       total: resultsCount,
       pageStart: offset + 1,
       pageEnd: offset + resultsLength,
-      hiddenForNoResults: !this._visibleForNoResults,
-      isNoResults: verticalResults.resultsContext === ResultsContext.NO_RESULTS
+      isHidden: isHidden
     });
   }
 

--- a/src/ui/templates/results/verticalresultscount.hbs
+++ b/src/ui/templates/results/verticalresultscount.hbs
@@ -1,21 +1,19 @@
-{{#unless (eq total 0)}}
-  {{#unless (and isNoResults hiddenForNoResults)}}
-    <div class="yxt-VerticalResultsCount"
-      aria-label="{{translate phrase='[[start]] through [[end]] of [[resultsCount]]' start=pageStart end=pageEnd resultsCount=total }}">
-      <div aria-hidden="true">
-        {{translate
-          phrase=
+{{#unless isHidden}}
+  <div class="yxt-VerticalResultsCount"
+    aria-label="{{translate phrase='[[start]] through [[end]] of [[resultsCount]]' start=pageStart end=pageEnd resultsCount=total }}">
+    <div aria-hidden="true">
+      {{translate
+        phrase=
 '<span class="yxt-VerticalResultsCount-start">[[start]]</span>
 <span class="yxt-VerticalResultsCount-dash">-</span>
 <span class="yxt-VerticalResultsCount-end">[[end]]</span>
 <span class="yxt-VerticalResultsCount-of">of</span>
 <span class="yxt-VerticalResultsCount-total">[[resultsCount]]</span>'
-          context='Example: 1-10 of 50'
-          start=pageStart
-          end=pageEnd
-          resultsCount=total
-        }}
-      </div>
+        context='Example: 1-10 of 50'
+        start=pageStart
+        end=pageEnd
+        resultsCount=total
+      }}
     </div>
-  {{/unless}}
+  </div>
 {{/unless}}

--- a/src/ui/templates/results/verticalresultscount.hbs
+++ b/src/ui/templates/results/verticalresultscount.hbs
@@ -1,19 +1,21 @@
 {{#unless (eq total 0)}}
-  <div class="yxt-VerticalResultsCount"
-    aria-label="{{translate phrase='[[start]] through [[end]] of [[resultsCount]]' start=pageStart end=pageEnd resultsCount=total }}">
-    <div aria-hidden="true">
-      {{translate
-        phrase=
+  {{#unless (and isNoResults hiddenForNoResults)}}
+    <div class="yxt-VerticalResultsCount"
+      aria-label="{{translate phrase='[[start]] through [[end]] of [[resultsCount]]' start=pageStart end=pageEnd resultsCount=total }}">
+      <div aria-hidden="true">
+        {{translate
+          phrase=
 '<span class="yxt-VerticalResultsCount-start">[[start]]</span>
 <span class="yxt-VerticalResultsCount-dash">-</span>
 <span class="yxt-VerticalResultsCount-end">[[end]]</span>
 <span class="yxt-VerticalResultsCount-of">of</span>
 <span class="yxt-VerticalResultsCount-total">[[resultsCount]]</span>'
-        context='Example: 1-10 of 50'
-        start=pageStart
-        end=pageEnd
-        resultsCount=total
-      }}
+          context='Example: 1-10 of 50'
+          start=pageStart
+          end=pageEnd
+          resultsCount=total
+        }}
+      </div>
     </div>
-  </div>
+  {{/unless}}
 {{/unless}}


### PR DESCRIPTION
By default, the VerticalResultsCount should be hidden during
NoResults.

J=SLAP-767
TEST=manual

Test that when unspecified, will hide the component during no results
when set to false, will hide the component during no results
when set to true, will display the component during no results