### PR TITLE
Pagination: remove extra DOM nodes

### DIFF
--- a/src/ui/templates/results/pagination.hbs
+++ b/src/ui/templates/results/pagination.hbs
@@ -59,16 +59,18 @@
         <span id="active-page" class="yxt-Pagination-page{{#if this.activeMobile}} yxt-Pagination--activeMobile{{/if}}{{#if this.activeDesktop}} yxt-Pagination--activeDesktop{{/if}}"
         aria-label="{{translate phrase='Currently on page [[pageNumber]]' pageNumber=../pageNumber }}">{{../pageLabel}} {{../pageNumber}}</span>
       {{else}}
-        <a
-          class="yxt-Pagination-link js-yxt-Pagination-link{{#if this.desktopHidden}} desktop-hidden{{/if}}{{#if this.mobileHidden}} mobile-hidden{{/if}}"
-          aria-label="{{translate phrase='Go to page [[pageNumber]] of results' pageNumber=this.number }}"
-          data-number="{{this.number}}"
-          data-eventtype="PAGINATE"
-          data-eventoptions='{"currentPage":{{../pageNumber}}, "newPage":{{this.number}}, "totalPageCount":{{../maxPage}} }'
-          tabindex="0"
-        >
-          {{this.number}}
-        </a>
+        {{#unless (and this.desktopHidden this.mobileHidden)}}
+          <a
+            class="yxt-Pagination-link js-yxt-Pagination-link{{#if this.desktopHidden}} desktop-hidden{{/if}}{{#if this.mobileHidden}} mobile-hidden{{/if}}"
+            aria-label="{{translate phrase='Go to page [[pageNumber]] of results' pageNumber=this.number }}"
+            data-number="{{this.number}}"
+            data-eventtype="PAGINATE"
+            data-eventoptions='{"currentPage":{{../pageNumber}}, "newPage":{{this.number}}, "totalPageCount":{{../maxPage}} }'
+            tabindex="0"
+          >
+            {{this.number}}
+          </a>
+        {{/unless}}
       {{/if}}
     {{/each}}
 

--- a/tests/ui/components/results/paginationcomponent.js
+++ b/tests/ui/components/results/paginationcomponent.js
@@ -137,7 +137,7 @@ describe('rendering the page numbers', () => {
       onPaginate: paginate
     });
     const wrapper = mount(component);
-    expect(wrapper.find('.js-yxt-Pagination-link')).toHaveLength(6);
+    expect(wrapper.find('.js-yxt-Pagination-link')).toHaveLength(4);
     const next = wrapper.find('.js-yxt-Pagination-next');
     expect(next).toHaveLength(1);
     next.first().simulate('click');


### PR DESCRIPTION
This commit removes the vast majority of extra DOM nodes
in the pagination component that are being display: none'd,
using bhaines impl at https://github.com/yext-pages/answers-mercy.pagescdn.com/pull/92
it works by not rendering pagination nodes that are being display: none'd
on both desktop and mobile

J=SLAP-698
TEST=manual

test that in the DOM explorer, we aren't rendering extra page numbers
test that I can still click through the page numbers, and run new searches,
  and the page numbers will still be there