### PR TITLE
Use the minimal-safe build of the plural-forms library.

### DIFF
--- a/src/core/i18n/translationprocessor.js
+++ b/src/core/i18n/translationprocessor.js
@@ -1,4 +1,4 @@
-import { getNPlurals, getPluralFunc, hasLang } from 'plural-forms/dist/minimal';
+import { getNPlurals, getPluralFunc, hasLang } from 'plural-forms/dist/minimal-safe';
 
 export default class TranslationProcessor {
   /**


### PR DESCRIPTION
This PR changes the TranslationProcessor to use a different build of the plural-forms library. This new build, minimal-safe, does not rely on evals or other dynamic code execution constructs. The build we used previously used 'new Function(..)', with string arguments. This is prohibited by any CSP that disallows an unsafe-eval. A full list of the constructs gated by unsafe-eval can be found here: https://www.w3.org/TR/CSP3/#directive-script-src.

J=SLAP-619
TEST=manual

Ran the following tests:

- Created a site with a SearchBar and a strict CSP that disallowed unsafe-eval. Ensured that the SearchBar loaded and the AutoComplete worked as expected.
- Verified that translation with pluralization worked as expected.
- Verified that translation with pluralization and interpolation worked as expected.
- Used the processTranslation helper with an unknown locale. Verified that the pluralization rules defaulted to English.