### PR TITLE
SearchBar: Update to show clear button on external query

### DIFF
--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -184,6 +184,8 @@ export default class SearchComponent extends Component {
         }
         return;
       }
+      const clearButton = DOM.query(this._container, '.js-yxt-SearchBar-clear');
+      this._updateClearButton(clearButton, q);
 
       const queryTrigger = this.core.globalStorage.getState(StorageKeys.QUERY_TRIGGER);
       const resetPagination = this._verticalKey &&
@@ -432,13 +434,7 @@ export default class SearchComponent extends Component {
     DOM.on(this.queryEl, 'input', e => {
       const input = e.target.value;
       this.query = input;
-      if (!this._showClearButton && input.length > 0) {
-        this._showClearButton = true;
-        button.classList.remove('yxt-SearchBar--hidden');
-      } else if (this._showClearButton && input.length === 0) {
-        this._showClearButton = false;
-        button.classList.add('yxt-SearchBar--hidden');
-      }
+      this._updateClearButton(button, input);
     });
   }
 
@@ -758,5 +754,25 @@ export default class SearchComponent extends Component {
 
   focusInputElement () {
     DOM.query(this._container, this._inputEl).focus();
+  }
+
+  /**
+   * Updates the Search inputs clear button based on the current input value
+   *
+   * @param {Element} button
+   * @param {string} input
+   */
+  _updateClearButton (button, input) {
+    if (!button) {
+      return;
+    }
+
+    if (!this._showClearButton && input.length > 0) {
+      this._showClearButton = true;
+      button.classList.remove('yxt-SearchBar--hidden');
+    } else if (this._showClearButton && input.length === 0) {
+      this._showClearButton = false;
+      button.classList.add('yxt-SearchBar--hidden');
+    }
   }
 }

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -184,8 +184,7 @@ export default class SearchComponent extends Component {
         }
         return;
       }
-      const clearButton = DOM.query(this._container, '.js-yxt-SearchBar-clear');
-      this._updateClearButton(clearButton, q);
+      this._updateClearButtonVisibility(q);
 
       const queryTrigger = this.core.globalStorage.getState(StorageKeys.QUERY_TRIGGER);
       const resetPagination = this._verticalKey &&
@@ -407,7 +406,7 @@ export default class SearchComponent extends Component {
   }
 
   initClearButton () {
-    const button = DOM.query(this._container, '.js-yxt-SearchBar-clear');
+    const button = this._getClearButton();
     this._showClearButton = this._showClearButton || this.query;
     button.classList.toggle('yxt-SearchBar--hidden', !this._showClearButton);
 
@@ -434,7 +433,7 @@ export default class SearchComponent extends Component {
     DOM.on(this.queryEl, 'input', e => {
       const input = e.target.value;
       this.query = input;
-      this._updateClearButton(button, input);
+      this._updateClearButtonVisibility(input);
     });
   }
 
@@ -757,22 +756,28 @@ export default class SearchComponent extends Component {
   }
 
   /**
+   * Returns the clear button element, if exists
+   *
+   * @returns {Element}
+   */
+  _getClearButton () {
+    return DOM.query(this._container, '.js-yxt-SearchBar-clear');
+  }
+
+  /**
    * Updates the Search inputs clear button based on the current input value
    *
-   * @param {Element} button
    * @param {string} input
    */
-  _updateClearButton (button, input) {
-    if (!button) {
-      return;
-    }
+  _updateClearButtonVisibility (input) {
+    const clearButton = this._getClearButton();
 
     if (!this._showClearButton && input.length > 0) {
       this._showClearButton = true;
-      button.classList.remove('yxt-SearchBar--hidden');
+      clearButton.classList.remove('yxt-SearchBar--hidden');
     } else if (this._showClearButton && input.length === 0) {
       this._showClearButton = false;
-      button.classList.add('yxt-SearchBar--hidden');
+      clearButton.classList.add('yxt-SearchBar--hidden');
     }
   }
 }


### PR DESCRIPTION
Since this PR (https://github.com/yext/answers/pull/1130), searches can be triggered from outside of the SearchBar component using a function `ANSWERS.search`. However, the SearchBar component was previously not adding the "clear button" icon when this happened. Updated the SearchBar component to show the clear button for external queries as well as internal ones.

TEST=manual,unit

Test with the Overlay prototype which uses the ANSWERS.search function. Also tested manually typing in the search input and see clear button appear.