### PR TITLE
v1.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -890,7 +890,12 @@ The results count component displays the current results count on a vertical pag
 
 ```js
 ANSWERS.addComponent('VerticalResultsCount', {
-  container: '.results-count-container'
+  container: '.results-count-container',
+  noResults: {
+    // Optional, whether the results count should be visible when displaying no results.
+    // Defaults to false.
+    visible: false
+  }
 });
 ```
 

--- a/conf/i18n/translations/de.po
+++ b/conf/i18n/translations/de.po
@@ -128,10 +128,10 @@ msgid "Thank you for your question!"
 msgstr "Danke für Ihre Frage!"
 
 #: src/ui/templates/results/alternativeverticals.hbs:11
-msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">[[query]]</span>:"
-msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">[[query]]</span>:"
-msgstr[0] "Die folgenden Kategorie liefert Suchergebnisse für <span class=\"yxt-AlternativeVerticals-details--query\">[[query]]</span>:"
-msgstr[1] "Die folgenden Kategorien liefern Suchergebnisse für <span class=\"yxt-AlternativeVerticals-details--query\">[[query]]</span>:"
+msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[0] "Die folgenden Kategorie liefert Suchergebnisse für <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[1] "Die folgenden Kategorien liefern Suchergebnisse für <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
 
 #: src/ui/components/results/directanswercomponent.js:21
 msgid "This answered my question"

--- a/conf/i18n/translations/es.po
+++ b/conf/i18n/translations/es.po
@@ -191,10 +191,10 @@ msgid "Thank you for your question!"
 msgstr "Gracias por su pregunta."
 
 #: src/ui/templates/results/alternativeverticals.hbs:11
-msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">[[query]]</span>:"
-msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">[[query]]</span>:"
-msgstr[0] "La siguiente búsqueda ha generado categoría resultados para <span class=\"yxt-AlternativeVerticals-details--query\">[[query]]</span>:"
-msgstr[1] "La siguiente búsqueda ha generado categorias resultados para <span class=\"yxt-AlternativeVerticals-details--query\">[[query]]</span>:"
+msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[0] "La siguiente búsqueda ha generado categoría resultados para <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[1] "La siguiente búsqueda ha generado categorias resultados para <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
 
 #: src/ui/components/results/directanswercomponent.js:21
 msgid "This answered my question"

--- a/conf/i18n/translations/fr.po
+++ b/conf/i18n/translations/fr.po
@@ -185,10 +185,10 @@ msgid "Thank you for your question!"
 msgstr "Merci pour votre question !"
 
 #: src/ui/templates/results/alternativeverticals.hbs:11
-msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">[[query]]</span>:"
-msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">[[query]]</span>:"
-msgstr[0] "La catégorie de recherche suivante a produit des résultats pour <span class=\"yxt-AlternativeVerticals-details--query\"> [[query]]</span>:"
-msgstr[1] "Les catégories de recherche suivantes ont produit des résultats pour <span class=\"yxt-AlternativeVerticals-details--query\">[[query]]</span>:"
+msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[0] "La catégorie de recherche suivante a produit des résultats pour <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[1] "Les catégories de recherche suivantes ont produit des résultats pour <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
 
 #: src/ui/components/results/directanswercomponent.js:21
 msgid "This answered my question"

--- a/conf/i18n/translations/it.po
+++ b/conf/i18n/translations/it.po
@@ -191,10 +191,10 @@ msgid "Thank you for your question!"
 msgstr "Grazie per la sua domanda."
 
 #: src/ui/templates/results/alternativeverticals.hbs:11
-msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">[[query]]</span>:"
-msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">[[query]]</span>:"
-msgstr[0] "La categoria di ricerca ha generato risultati per <span class=\"yxt-AlternativeVerticals-details--query\">[[query]]</span>:"
-msgstr[1] "La categorie di ricerca ha generato risultati per <span class=\"yxt-AlternativeVerticals-details--query\">[[query]]</span>:"
+msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[0] "La categoria di ricerca ha generato risultati per <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[1] "La categorie di ricerca ha generato risultati per <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
 
 #: src/ui/components/results/directanswercomponent.js:21
 msgid "This answered my question"

--- a/conf/i18n/translations/ja.po
+++ b/conf/i18n/translations/ja.po
@@ -150,9 +150,9 @@ msgid "Suggestions:"
 msgstr "提案："
 
 #: src/ui/templates/results/alternativeverticals.hbs:11
-msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">[[query]]</span>:"
-msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">[[query]]</span>:"
-msgstr[0] "以下の検索カテゴリーで<span class=\"yxt-AlternativeVerticals-details--query\">[[query]]</span>の検索結果が見つかりました。"
+msgid "The following search category yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgid_plural "The following search categories yielded results for <span class=\"yxt-AlternativeVerticals-details--query\">\"[[query]]\"</span>:"
+msgstr[0] "以下の検索カテゴリーで<span class=\"yxt-AlternativeVerticals-details--query\">「[[query]]」</span>の検索結果が見つかりました。"
 
 #: src/ui/templates/results/noresults.hbs:34
 msgid "Try fewer words."

--- a/src/core/i18n/translationprocessor.js
+++ b/src/core/i18n/translationprocessor.js
@@ -1,4 +1,4 @@
-import { getNPlurals, getPluralFunc, hasLang } from 'plural-forms/dist/minimal';
+import { getNPlurals, getPluralFunc, hasLang } from 'plural-forms/dist/minimal-safe';
 
 export default class TranslationProcessor {
   /**

--- a/src/core/models/highlightedvalue.js
+++ b/src/core/models/highlightedvalue.js
@@ -19,6 +19,16 @@ export default class HighlightedValue {
   }
 
   /**
+   * get highlighted value string
+   * @param {Function} transformFunction takes a string and returns the transformed string
+   * @returns {string} The value interpolated with highlighting markup and transformed in between
+   */
+  getWithTransformFunction (transformFunction) {
+    this._sortMatchedSubstrings();
+    return this.buildHighlightedValue(this.value, this.matchedSubstrings, transformFunction);
+  }
+
+  /**
    * get inverted highlighted value string
    * @returns {string}
    */
@@ -26,6 +36,17 @@ export default class HighlightedValue {
     this._sortMatchedSubstrings();
     const invertedSubstrings = this._getInvertedSubstrings(this.matchedSubstrings, this.value.length);
     return this.buildHighlightedValue(this.value, invertedSubstrings);
+  }
+
+  /**
+   * get inverted highlighted value string
+   * @param {Function} transformFunction takes a string and returns the transformed string
+   * @returns {string} The value interpolated with highlighting markup and transformed in between
+   */
+  getInvertedWithTransformFunction (transformFunction) {
+    this._sortMatchedSubstrings();
+    const invertedSubstrings = this._getInvertedSubstrings(this.matchedSubstrings, this.value.length);
+    return this.buildHighlightedValue(this.value, invertedSubstrings, transformFunction);
   }
 
   /**
@@ -63,6 +84,13 @@ export default class HighlightedValue {
    *    }
    *  }
    *
+   * @param {Function} transformFunction function to apply to strings in between highlighting markup
+   *
+   *  example function :
+   *  function (string) {
+   *    return handlebars.escapeExpression(string);
+   *  }
+   *
    * @returns {string} copy of input value with highlighting applied
    *
    *  example object :
@@ -74,22 +102,31 @@ export default class HighlightedValue {
    *  }
    *
    */
-  buildHighlightedValue (val, highlightedSubstrings) {
+  buildHighlightedValue (
+    val,
+    highlightedSubstrings,
+    transformFunction = function (x) { return x; }
+  ) {
     let highlightedValue = '';
     let nextStart = 0;
 
     if (highlightedSubstrings.length === 0) {
-      return val;
+      return transformFunction(val);
     }
 
     for (let j = 0; j < highlightedSubstrings.length; j++) {
       let start = Number(highlightedSubstrings[j].offset);
       let end = start + highlightedSubstrings[j].length;
 
-      highlightedValue += [val.slice(nextStart, start), '<strong>', val.slice(start, end), '</strong>'].join('');
+      highlightedValue += [
+        transformFunction(val.slice(nextStart, start)),
+        '<strong>',
+        transformFunction(val.slice(start, end)),
+        '</strong>'
+      ].join('');
 
       if (j === highlightedSubstrings.length - 1 && end < val.length) {
-        highlightedValue += val.slice(end);
+        highlightedValue += transformFunction(val.slice(end));
       }
 
       nextStart = end;

--- a/src/ui/components/filters/filterboxcomponent.js
+++ b/src/ui/components/filters/filterboxcomponent.js
@@ -236,7 +236,7 @@ export default class FilterBoxComponent extends Component {
       this._filterComponents.push(component);
       this._filterNodes[i] = component.getFilterNode();
     }
-    this._saveFilterNodesToStorage();
+    this._saveFilterNodesToStorage(this.config.isDynamic);
 
     // Initialize apply button
     if (!this.config.searchOnChange) {
@@ -244,7 +244,7 @@ export default class FilterBoxComponent extends Component {
 
       if (button) {
         DOM.on(button, 'click', () => {
-          this._saveFilterNodesToStorage();
+          this._saveFilterNodesToStorage(false);
           this._search();
         });
       }
@@ -276,7 +276,7 @@ export default class FilterBoxComponent extends Component {
   onFilterNodeChange (index, filterNode, saveFilterNodes, searchOnChange) {
     this._filterNodes[index] = filterNode;
     if (saveFilterNodes || searchOnChange) {
-      this._saveFilterNodesToStorage();
+      this._saveFilterNodesToStorage(false);
     }
     if (searchOnChange) {
       this._search();
@@ -294,14 +294,16 @@ export default class FilterBoxComponent extends Component {
   /**
    * Save current filters to storage to be used in the next search
    * @private
+   * @param {boolean} replaceHistory Whether we replace or push a new history
+   *                                 state for the associated changes
    */
-  _saveFilterNodesToStorage () {
+  _saveFilterNodesToStorage (replaceHistory) {
     if (this.config.isDynamic) {
       const availableFieldIds = this.config.filterConfigs.map(config => config.fieldId);
       this.core.setFacetFilterNodes(availableFieldIds, this._getValidFilterNodes());
-      this._filterComponents.forEach(fc => fc.saveSelectedToPersistentStorage());
+      this._filterComponents.forEach(fc => fc.saveSelectedToPersistentStorage(replaceHistory));
     } else {
-      this._filterComponents.forEach(fc => fc.apply());
+      this._filterComponents.forEach(fc => fc.apply(replaceHistory));
     }
   }
 

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -288,7 +288,7 @@ export default class FilterOptionsComponent extends Component {
     this.showMoreState = this.config.showMore;
 
     if (this.config.storeOnChange) {
-      this.apply();
+      this.apply(this.config.isDynamic);
     }
   }
 
@@ -571,7 +571,7 @@ export default class FilterOptionsComponent extends Component {
   updateListeners (alwaysSaveFilterNodes, blockSearchOnChange) {
     const filterNode = this.getFilterNode();
     if (this.config.storeOnChange) {
-      this.apply();
+      this.apply(false);
     }
 
     this.config.onChange(filterNode, alwaysSaveFilterNodes, blockSearchOnChange);
@@ -590,7 +590,12 @@ export default class FilterOptionsComponent extends Component {
     this.updateListeners();
   }
 
-  apply () {
+  /**
+   * Apply filter changes
+   * @param {boolean} replaceHistory Whether we replace or push a new history
+   *                                 state for the associated changes
+   */
+  apply (replaceHistory) {
     switch (this.config.optionType) {
       case OptionTypes.RADIUS_FILTER:
         this.core.setLocationRadiusFilterNode(this.getLocationRadiusFilterNode());
@@ -602,7 +607,7 @@ export default class FilterOptionsComponent extends Component {
         throw new AnswersComponentError(`Unknown optionType ${this.config.optionType}`, 'FilterOptions');
     }
 
-    this.saveSelectedToPersistentStorage();
+    this.saveSelectedToPersistentStorage(replaceHistory);
   }
 
   floatSelected () {
@@ -662,9 +667,15 @@ export default class FilterOptionsComponent extends Component {
 
   /**
    * Saves selected options to persistent storage
+   * @param {boolean} replaceHistory Whether we replace or push a new history
+   *                                 state for the associated changes
    */
-  saveSelectedToPersistentStorage () {
-    this.core.persistentStorage.set(this.name, this.config.options.filter(o => o.selected).map(o => o.label));
+  saveSelectedToPersistentStorage (replaceHistory) {
+    this.core.persistentStorage.set(
+      this.name,
+      this.config.options.filter(o => o.selected).map(o => o.label),
+      replaceHistory || (this.core.persistentStorage.get(this.name) === null)
+    );
   }
 
   /**

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -45,7 +45,14 @@ class FilterOptionsConfig {
     this.optionType = config.optionType || OptionTypes.STATIC_FILTER;
 
     /**
-     * The list of filter options to display with checked status
+     * The list of filter options to display with checked status as
+     * initially specified in the user configuration
+     * @type {object[]}
+     */
+    this.initialOptions = config.options.map(o => ({ ...o }));
+
+    /**
+     * The list of filter options to display.
      * @type {object[]}
      */
     this.options = config.options.map(o => ({ ...o }));
@@ -178,32 +185,34 @@ class FilterOptionsConfig {
     }
     // previousOptions will be null if there were no previousOptions in persistentStorage
     const previousOptions = config.previousOptions;
-    this.options = this.setSelectedOptions(this.options, previousOptions);
+    this.options = this.getSelectedOptions(this.options, previousOptions);
   }
 
   /**
-   * Sets selected options on load based on options stored in persistent storage and options with selected: true.
-   * If no previous options were stored in persistentStorage, default to options marked
-   * as selected. If multiple options are marked as selected for 'singleoption', only the
-   * first should be selected.
-   * @param {Array<Object>} options
-   * @param {Array<string>} previousOptions
-   * @returns {Array<Object>}
+   * Returns a list of options with `selected` determined by initialOptions and
+   * optionsOverrides. optionsOverrides take precedence over initialOptions. If the
+   * control is singleoption and `selected` appears more than once in either
+   * initialOptions or optionsOverrides then the first instance is used.
+   * @param {Array<Object>} initialOptions Options from the component configuration
+   * @param {Array<string>} optionsOverrides Options as they are formatted for persistentStorage
+   * @returns {Array<Object>} The options in the same format as initialOptions with updated
+   *                          selected values
    */
-  setSelectedOptions (options, previousOptions) {
-    if (previousOptions && this.control === 'singleoption') {
+  getSelectedOptions (initialOptions, optionsOverrides) {
+    const options = initialOptions.map(o => ({ ...o }));
+    if (optionsOverrides && this.control === 'singleoption') {
       let hasSeenSelectedOption = false;
       return options.map(o => {
-        if (previousOptions.includes(o.label) && !hasSeenSelectedOption) {
+        if (optionsOverrides.includes(o.label) && !hasSeenSelectedOption) {
           hasSeenSelectedOption = true;
           return { ...o, selected: true };
         }
         return { ...o, selected: false };
       });
-    } else if (previousOptions && this.control === 'multioption') {
+    } else if (optionsOverrides && this.control === 'multioption') {
       return options.map(o => ({
         ...o,
-        selected: previousOptions.includes(o.label)
+        selected: optionsOverrides.includes(o.label)
       }));
     } else if (this.control === 'singleoption') {
       let hasSeenSelectedOption = false;
@@ -289,6 +298,25 @@ export default class FilterOptionsComponent extends Component {
 
     if (this.config.storeOnChange) {
       this.apply(this.config.isDynamic);
+    }
+
+    if (!this.config.isDynamic) {
+      // Update listener for when navigating backwards in history. When we back nav, the
+      // globalStorage is updated with the previous URL filter values. We should not update
+      // this.name otherwise, instead opt for this.core.setStaticFilterNodes()
+      this.core.globalStorage.on('update', this.name, (data) => {
+        try {
+          const newOptions = JSON.parse(data);
+          this.config.options = this.config.getSelectedOptions(
+            this.config.initialOptions,
+            newOptions
+          );
+          this.updateListeners();
+          this.setState();
+        } catch (e) {
+          console.warn(`Filter option ${data} could not be parsed`);
+        }
+      });
     }
   }
 

--- a/src/ui/components/results/verticalresultscountcomponent.js
+++ b/src/ui/components/results/verticalresultscountcomponent.js
@@ -1,6 +1,7 @@
 import Component from '../component';
 import StorageKeys from '../../../core/storage/storagekeys';
 import SearchStates from '../../../core/storage/searchstates';
+import ResultsContext from '../../../core/storage/resultscontext';
 
 export default class VerticalResultsCountComponent extends Component {
   constructor (config = {}, systemConfig = {}) {
@@ -10,6 +11,13 @@ export default class VerticalResultsCountComponent extends Component {
         this.setState(verticalResults);
       }
     });
+
+    /**
+     * When the page is in a No Results state, whether to display the
+     * vertical results count.
+     * @type {boolean}
+     */
+    this._visibleForNoResults = !!(config.noResults || {}).visible;
   }
 
   static areDuplicateNamesAllowed () {
@@ -32,11 +40,15 @@ export default class VerticalResultsCountComponent extends Component {
     const resultsLength = (verticalResults.results || []).length;
 
     const offset = this.core.globalStorage.getState(StorageKeys.SEARCH_OFFSET) || 0;
+    const isNoResults = verticalResults.resultsContext === ResultsContext.NO_RESULTS;
+    const hasZeroResults = resultsCount === 0;
+    const isHidden = (!this._visibleForNoResults && isNoResults) || hasZeroResults;
     return super.setState({
       ...data,
       total: resultsCount,
       pageStart: offset + 1,
-      pageEnd: offset + resultsLength
+      pageEnd: offset + resultsLength,
+      isHidden: isHidden
     });
   }
 

--- a/src/ui/rendering/handlebarsrenderer.js
+++ b/src/ui/rendering/handlebarsrenderer.js
@@ -236,15 +236,17 @@ export default class HandlebarsRenderer extends Renderer {
     });
 
     self.registerHelper('highlightValue', function (value, getInverted) {
-      const escapedInput = self.escapeExpression(value.value || value.shortValue);
+      const input = value.value || value.shortValue;
 
       const highlightedVal = new HighlightedValue({
-        value: escapedInput,
+        value: input,
         matchedSubstrings: value.matchedSubstrings
       });
+      const escapeFunction = (val) => self.escapeExpression(val);
 
-      return getInverted ? self.SafeString(highlightedVal.getInverted())
-        : self.SafeString(highlightedVal.get());
+      return getInverted
+        ? self.SafeString(highlightedVal.getInvertedWithTransformFunction(escapeFunction))
+        : self.SafeString(highlightedVal.getWithTransformFunction(escapeFunction));
     });
   }
 }

--- a/src/ui/templates/results/alternativeverticals.hbs
+++ b/src/ui/templates/results/alternativeverticals.hbs
@@ -8,7 +8,7 @@
   {{#if verticalSuggestions}}
     <div class="yxt-AlternativeVerticals-suggestionsWrapper">
       <div class="yxt-AlternativeVerticals-details">
-        {{translate phrase='The following search category yielded results for <span class="yxt-AlternativeVerticals-details--query">[[query]]</span>:' pluralForm='The following search categories yielded results for <span class="yxt-AlternativeVerticals-details--query">[[query]]</span>:' count=verticalSuggestions.length query=query }}
+        {{translate phrase='The following search category yielded results for <span class="yxt-AlternativeVerticals-details--query">"[[query]]"</span>:' pluralForm='The following search categories yielded results for <span class="yxt-AlternativeVerticals-details--query">"[[query]]"</span>:' count=verticalSuggestions.length query=query }}
       </div>
       <ul class="yxt-AlternativeVerticals-suggestionsList">
         {{#each verticalSuggestions}}

--- a/src/ui/templates/results/verticalresultscount.hbs
+++ b/src/ui/templates/results/verticalresultscount.hbs
@@ -1,4 +1,4 @@
-{{#unless (eq total 0)}}
+{{#unless isHidden}}
   <div class="yxt-VerticalResultsCount"
     aria-label="{{translate phrase='[[start]] through [[end]] of [[resultsCount]]' start=pageStart end=pageEnd resultsCount=total }}">
     <div aria-hidden="true">

--- a/tests/core/models/highlightedvalue.js
+++ b/tests/core/models/highlightedvalue.js
@@ -68,4 +68,25 @@ describe('createing highlighted values', () => {
     expect(result).toEqual(expectedResult);
     expect(invertedResult).toEqual(expectedInvertedResult);
   });
+
+  it('properly handles a transformFunction', () => {
+    const data = {
+      key: 'jesse',
+      value: 'Jes\'se Sharps',
+      matchedSubstrings: [ { offset: 8, length: 4 }, { offset: 1, length: 4 } ]
+    };
+
+    const expectedResult = 'J<strong>es%27s</strong>e S<strong>harp</strong>s';
+    const expectedInvertedResult = '<strong>J</strong>es%27s<strong>e S</strong>harp<strong>s</strong>';
+
+    let highlightedValue = new HighlightedValue(data);
+    const transformFn = (string) => {
+      return string.replace(/'/gi, '%27');
+    };
+    const result = highlightedValue.getWithTransformFunction(transformFn);
+    const invertedResult = highlightedValue.getInvertedWithTransformFunction(transformFn);
+
+    expect(result).toEqual(expectedResult);
+    expect(invertedResult).toEqual(expectedInvertedResult);
+  });
 });

--- a/tests/ui/components/filters/filteroptionscomponent.js
+++ b/tests/ui/components/filters/filteroptionscomponent.js
@@ -79,7 +79,8 @@ describe('filter options component', () => {
           }
           return null;
         },
-        delete: () => { }
+        delete: () => { },
+        on: () => {}
       },
       persistentStorage: new PersistentStorage()
     };
@@ -405,7 +406,8 @@ describe('filter options component', () => {
               return ['label1', 'label2'];
             }
           },
-          delete: () => { }
+          delete: () => { },
+          on: () => {}
         },
         setStaticFilterNodes: () => { }
       });
@@ -543,7 +545,8 @@ describe('filter options component', () => {
       COMPONENT_MANAGER = mockManager({
         globalStorage: {
           getState: () => { },
-          delete: () => { }
+          delete: () => { },
+          on: () => {}
         },
         persistentStorage: {
           set: () => { },


### PR DESCRIPTION
## Version 1.6.2
### Bug Fixes
- The new `VerticalResultsCount` component has a new `noResults.visible` configuration option.
The option defaults to false. This means that by default, the count does not appear when there are no results. (#1142)
- Updated the SDK to use the `minimal-safe` distribution of the `plural-forms` library. This distribution does 
not make use of `unsafe-eval`s. (#1149)
- Fixed a bug that prevented text in escaped query suggestions from being properly highlighted. (#1144)
- Made a couple of small translation corrections. (#1123)
- Corrected the back navigation behavior for `FilterOptions`. (#1080)
- Corrected a back navigation issue for `Facets` resulting from history getting pushed instead of replaced. (#1064)
