### PR TITLE
Search: update search hook placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,9 +461,8 @@ ANSWERS.addComponent('SearchBar', {
   customHooks: {
     // Optional, a callback invoked when the clear search button is clicked
     onClearSearch: function() {},
-    // Optional, a function invoked when a search is submitted via this component. The users search
-    // is passed in as a string
-    onSubmit: function(searchTerms) {}
+    // Optional, a function invoked when a search is conducted. The search terms are passed in as a string
+    onConductSearch: function(searchTerms) {}
   },
   // Optional, options to pass to the autocomplete component
   autocomplete: {

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -566,7 +566,7 @@ export default class SearchComponent extends Component {
       inputEl: inputSelector,
       listLabelIdName: this.inputLabelIdName,
       ...this._autocompleteConfig,
-      onConductSearch: () => {
+      onSubmit: () => {
         if (this._useForm) {
           DOM.trigger(DOM.query(this._container, this._formEl), 'submit');
         } else {

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -281,9 +281,9 @@ export default class SearchComponent extends Component {
        */
       onClearSearch: (config.customHooks && config.customHooks.onClearSearch) || function () {},
       /**
-       * Callback invoked when a search is submitted via this component
+       * Callback invoked when a search is conducted
        */
-      onSubmit: (config.customHooks && config.customHooks.onSubmit) || function () {}
+      onConductSearch: (config.customHooks && config.customHooks.onConductSearch) || function () {}
     };
 
     /**
@@ -504,8 +504,6 @@ export default class SearchComponent extends Component {
     const params = new SearchParams(window.location.search.substring(1));
     params.set('query', query);
 
-    this.customHooks.onSubmit(query);
-
     const context = this.core.globalStorage.getState(StorageKeys.API_CONTEXT);
     if (context) {
       params.set(StorageKeys.API_CONTEXT, context);
@@ -568,7 +566,7 @@ export default class SearchComponent extends Component {
       inputEl: inputSelector,
       listLabelIdName: this.inputLabelIdName,
       ...this._autocompleteConfig,
-      onSubmit: () => {
+      onConductSearch: () => {
         if (this._useForm) {
           DOM.trigger(DOM.query(this._container, this._formEl), 'submit');
         } else {
@@ -602,6 +600,7 @@ export default class SearchComponent extends Component {
     this._throttled = true;
     setTimeout(() => { this._throttled = false; }, this._searchCooldown);
 
+    this.customHooks.onConductSearch(query);
     // If _promptForLocation is enabled, we will compute the query's intent and, from there,
     // determine if it's necessary to prompt the user for their location information. It will
     // be unnecessary if the query does not have near me intent or we already have their location

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -600,7 +600,6 @@ export default class SearchComponent extends Component {
     this._throttled = true;
     setTimeout(() => { this._throttled = false; }, this._searchCooldown);
 
-    this.customHooks.onConductSearch(query);
     // If _promptForLocation is enabled, we will compute the query's intent and, from there,
     // determine if it's necessary to prompt the user for their location information. It will
     // be unnecessary if the query does not have near me intent or we already have their location
@@ -645,6 +644,8 @@ export default class SearchComponent extends Component {
    * @returns {Promise} A promise that will perform the query and update globalStorage accordingly.
    */
   search (query, searchOptions) {
+    this.customHooks.onConductSearch(query);
+
     if (this._verticalKey) {
       this.core.verticalSearch(this._config.verticalKey, searchOptions, { input: query });
     } else {


### PR DESCRIPTION
Move custom hook from `onQuerySubmit` to `search`. This means that the hook is invoked whenever a search is conducted. Since the hook has not been in any releases, we're free to change its name without any backwards compatibility issues. Changed from `onSubmit` to `onConductSearch`.

TEST=manual,unit

Test with Overlay locally. Confirm that this hook is invoked when searches are conducted via typing in the search bar as well as with the ANSWERS.search function.