### PR TITLE
Update the acceptance tests to use the new Slapshot account.

### DIFF
--- a/tests/acceptance/fixtures/html/facets.html
+++ b/tests/acceptance/fixtures/html/facets.html
@@ -21,9 +21,9 @@
 
   <script>
     ANSWERS.init({
-      apiKey: 'df4b24f4075800e5e9705090c54c6c13',
-      experienceKey: 'sdkacceptancetests',
-      businessId: '2287528',
+      apiKey: '2d8c550071a64ea23e263118a2b0680b',
+      experienceKey: 'slanswers',
+      businessId: '3350634',
       experienceVersion: 'PRODUCTION',
       templateBundle: TemplateBundle.default,
       search: {

--- a/tests/acceptance/fixtures/html/universal.html
+++ b/tests/acceptance/fixtures/html/universal.html
@@ -15,9 +15,9 @@
     
         <script>
             ANSWERS.init({
-                apiKey: 'df4b24f4075800e5e9705090c54c6c13',
-                experienceKey: 'sdkacceptancetests',
-                businessId: '2287528',
+                apiKey: '2d8c550071a64ea23e263118a2b0680b',
+                experienceKey: 'slanswers',
+                businessId: '3350634',
                 experienceVersion: 'PRODUCTION',
                 templateBundle: TemplateBundle.default,
                 onReady: function() {
@@ -33,12 +33,12 @@
                         {
                           label: 'Home',
                           url: './universal',
-                          isFirst: true
+                          isFirst: true,
+                          isActive: true
                         },
                         {
                           label: 'Facets',
                           url: './links',
-                          isActive: true
                         },
                         {
                           label: 'Vertical',

--- a/tests/acceptance/fixtures/html/vertical.html
+++ b/tests/acceptance/fixtures/html/vertical.html
@@ -16,9 +16,10 @@
     
         <script>
             ANSWERS.init({
-                apiKey: 'df4b24f4075800e5e9705090c54c6c13',
-                experienceKey: 'sdkacceptancetests',
-                businessId: '2287528',
+                apiKey: '2d8c550071a64ea23e263118a2b0680b',
+                experienceKey: 'slanswers',
+                businessId: '3350634',
+                experienceVersion: 'PRODUCTION',
                 templateBundle: TemplateBundle.default,
                 experienceVersion: 'PRODUCTION',
                 search: {
@@ -44,11 +45,11 @@
                         {
                           label: 'Facets',
                           url: './links',
-                          isActive: true
                         },
                         {
                           label: 'Vertical',
                           url: './vertical',
+                          isActive: true
                         }
                       ],
                     });


### PR DESCRIPTION
Previously, all of our acceptance tests were using Rose's test
account. This isn't ideal since Rose frequently makes changes
to her account. These changes have the potential to break our tests.
To mitigate this, we have created the Slapshot Test account. We
control all aspects of the account, so data won't be changed out
from under us unexpectedly, breaking our tests. This PR points the
tests to the new account.

J=SLAP-348
TEST=manual

Made sure all the acceptance tests passed.