### PR TITLE
persist facets through the url

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -246,7 +246,7 @@ export default class Core {
       this.globalStorage.getState(StorageKeys.FACET_FILTER_NODE),
       (key, value) => key === 'metadata' ? undefined : value
     ));
-    this.persistentStorage.set(StorageKeys.FACET_FILTER_NODE, facetNodesWithoutMetadata);
+    this.persistentStorage.set(StorageKeys.PERSISTED_FACETS, facetNodesWithoutMetadata);
   }
 
   clearResults () {

--- a/src/core/storage/globalstorage.js
+++ b/src/core/storage/globalstorage.js
@@ -34,14 +34,14 @@ export default class GlobalStorage {
    */
   setAll (data) {
     for (const [key, val] of Object.entries(data)) {
-      if (key === StorageKeys.QUERY || key === StorageKeys.FACET_FILTER_NODE) {
+      if (key === StorageKeys.QUERY || key === StorageKeys.PERSISTED_FACETS) {
         continue;
       }
       this.set(key, val);
     }
 
-    if (data[StorageKeys.FACET_FILTER_NODE]) {
-      this._applyPersistedFacets(data[StorageKeys.FACET_FILTER_NODE]);
+    if (data[StorageKeys.PERSISTED_FACETS]) {
+      this._applyPersistedFacets(data[StorageKeys.PERSISTED_FACETS]);
       this.set(StorageKeys.FORCE_USE_FACETS_ONCE, true);
     }
 

--- a/src/core/storage/storagekeys.js
+++ b/src/core/storage/storagekeys.js
@@ -37,8 +37,6 @@ export default {
   API_CONTEXT: 'context',
   REFERRER_PAGE_URL: 'referrerPageUrl',
   QUERY_TRIGGER: 'queryTrigger',
-  FACETS_LOADED: 'facets-loaded',
-  QUERY_SOURCE: 'query-source',
   PERSISTED_FACETS: 'persisted-facets',
   FORCE_USE_FACETS_ONCE: 'force-use-facets-once'
 };

--- a/src/core/storage/storagekeys.js
+++ b/src/core/storage/storagekeys.js
@@ -39,5 +39,6 @@ export default {
   QUERY_TRIGGER: 'queryTrigger',
   FACETS_LOADED: 'facets-loaded',
   QUERY_SOURCE: 'query-source',
+  PERSISTED_FACETS: 'persisted-facets',
   FORCE_USE_FACETS_ONCE: 'force-use-facets-once'
 };

--- a/src/core/storage/storagekeys.js
+++ b/src/core/storage/storagekeys.js
@@ -36,5 +36,8 @@ export default {
   RESULTS_HEADER: 'results-header',
   API_CONTEXT: 'context',
   REFERRER_PAGE_URL: 'referrerPageUrl',
-  QUERY_TRIGGER: 'queryTrigger'
+  QUERY_TRIGGER: 'queryTrigger',
+  FACETS_LOADED: 'facets-loaded',
+  QUERY_SOURCE: 'query-source',
+  FORCE_USE_FACETS_ONCE: 'force-use-facets-once'
 };

--- a/src/ui/components/filters/filterboxcomponent.js
+++ b/src/ui/components/filters/filterboxcomponent.js
@@ -282,7 +282,6 @@ export default class FilterBoxComponent extends Component {
     if (this.config.isDynamic) {
       const availableFieldIds = this.config.filterConfigs.map(config => config.fieldId);
       this.core.setFacetFilterNodes(availableFieldIds, this._getValidFilterNodes());
-      this._filterComponents.forEach(fc => fc.saveSelectedToPersistentStorage(replaceHistory));
     } else {
       this._filterComponents.forEach(fc => fc.apply(replaceHistory));
     }


### PR DESCRIPTION
This commit correctly persists facets through the url. Previously,
facets would appear to be persisted, but would only be applied visually,
and not actually have any impact on the api request.

J=SLAP-843
TEST=manual

tested reloading the page, and navigating to another page and back,
and seeing my facets still there and applied to the query