### PR TITLE
package.json: Changes for public npm release

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,2 @@
 node_modules/
-app/
 **/.DS_Store

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+node_modules/
+app/
+**/.DS_Store

--- a/package.json
+++ b/package.json
@@ -1,8 +1,16 @@
 {
   "name": "answers",
-  "version": "1.0.0",
+  "version": "1.6.2",
   "description": "Javascript Answers Programming Interface",
-  "main": "gulpfile.js",
+  "main": "dist/answers-umd.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/yext/answers.git"
+  },
+  "bugs": {
+    "url": "https://github.com/yext/answers/issues"
+  },
+  "homepage": "https://github.com/yext/answers#readme",
   "dependencies": {
     "@mapbox/mapbox-gl-language": "^0.10.1",
     "@yext/rtf-converter": "^1.2.0",
@@ -127,5 +135,5 @@
     }
   },
   "author": "Billy",
-  "license": "ISC"
+  "license": "BSD-3-Clause"
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,14 @@
     "url": "https://github.com/yext/answers/issues"
   },
   "homepage": "https://github.com/yext/answers#readme",
+  "keywords": [
+    "yext",
+    "search",
+    "search-engine",
+    "autocomplete",
+    "javascript",
+    "vanilla"
+  ],
   "dependencies": {
     "@mapbox/mapbox-gl-language": "^0.10.1",
     "@yext/rtf-converter": "^1.2.0",
@@ -134,6 +142,6 @@
       }
     }
   },
-  "author": "Billy",
+  "author": "Yext",
   "license": "BSD-3-Clause"
 }

--- a/package.json
+++ b/package.json
@@ -143,5 +143,8 @@
     }
   },
   "author": "Yext",
-  "license": "BSD-3-Clause"
+  "license": "BSD-3-Clause",
+  "engines": {
+    "node": ">=12"
+  }
 }


### PR DESCRIPTION
Change the license to match the LICENSE file.
Change the main file to the dist umd file, as that is the file most
likely to be imported when including this package.

Add the repository, bugs, and homepage fields to point to the current
GitHub repository.

Add a .npmignore for the registry that is exactly like the .gitignore
except it allows the dist folder. We allow the dist on publish so that
we do not need to build on postinstall. The dist files are available as
soon as installation is done.

J=SLAP-812
TEST=manual

Tested on a test NPM package
Saw all changes reflected on the test package in the registry after
pushing.