### PR TITLE
Create the new CoreAdapter wrapper.

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -5,7 +5,7 @@ module.exports = [
   },
   {
     path: 'dist/answers-modern.min.js',
-    limit: '110kb'
+    limit: '115kb'
   },
   {
     path: 'dist/answerstemplates.compiled.min.js',

--- a/conf/gulp-tasks/bundle/bundle.js
+++ b/conf/gulp-tasks/bundle/bundle.js
@@ -31,11 +31,11 @@ exports.modernBundle = function (callback, outputConfig, bundleName, locale, lib
     plugins: [
       resolve(),
       commonjs({
-        include: [/^(\.\/)?node_modules\/.*$/, /answers-core/]
+        include: [/node_modules/, /answers-core/]
       }),
       babel({
         babelrc: false,
-        exclude: [/^(\.\/)?node_modules\/.*$/, /answers-core/],
+        exclude: [/node_modules/, /answers-core/],
         presets: ['@babel/env']
       })
     ]
@@ -63,7 +63,7 @@ exports.legacyBundle = function (callback, outputConfig, bundleName, locale, lib
     plugins: [
       resolve(),
       commonjs({
-        include: [/^(\.\/)?node_modules\/.*$/, /answers-core/]
+        include: [/node_modules/, /answers-core/]
       }),
       babel({
         runtimeHelpers: true,

--- a/conf/gulp-tasks/bundle/bundle.js
+++ b/conf/gulp-tasks/bundle/bundle.js
@@ -31,11 +31,11 @@ exports.modernBundle = function (callback, outputConfig, bundleName, locale, lib
     plugins: [
       resolve(),
       commonjs({
-        include: './node_modules/**'
+        include: [/^(\.\/)?node_modules\/.*$/, /answers-core/]
       }),
       babel({
         babelrc: false,
-        exclude: 'node_modules/**',
+        exclude: [/^(\.\/)?node_modules\/.*$/, /answers-core/],
         presets: ['@babel/env']
       })
     ]
@@ -63,12 +63,12 @@ exports.legacyBundle = function (callback, outputConfig, bundleName, locale, lib
     plugins: [
       resolve(),
       commonjs({
-        include: './node_modules/**'
+        include: [/^(\.\/)?node_modules\/.*$/, /answers-core/]
       }),
       babel({
         runtimeHelpers: true,
         babelrc: false,
-        exclude: /node_modules\/(?!whatwg-fetch).*/,
+        exclude: [/node_modules\/(?!whatwg-fetch).*/, /answers-core/],
         presets: [
           [
             '@babel/preset-env',

--- a/src/core/core-adapter.js
+++ b/src/core/core-adapter.js
@@ -130,18 +130,18 @@ export default class CoreAdapter {
   /**
    * Initializes the {@link CoreAdapter} by providing it with an instance of the Core library.
    */
-  init() {
+  init () {
     const params = { apiKey: this._apiKey, experienceKey: this._experienceKey };
     return provideCore(params).then(coreLibrary => {
       this._coreLibrary = coreLibrary;
-    })
+    });
   }
 
   /**
    * @returns {boolean} A boolean indicating if the {@link CoreAdapter} has been
    *                    initailized.
    */
-  isInitialized() {
+  isInitialized () {
     return !!this._coreLibrary;
   }
 

--- a/src/core/core-adapter.js
+++ b/src/core/core-adapter.js
@@ -1,4 +1,5 @@
 /** @module Core */
+import provideCore from '@yext/answers-core';
 
 import SearchDataTransformer from './search/searchdatatransformer';
 
@@ -21,10 +22,11 @@ import FilterRegistry from './filters/filterregistry';
 /** @typedef {import('./services/questionanswerservice').default} QuestionAnswerService */
 
 /**
- * Core is the main application container for all of the network and storage
- * related behaviors of the application.
+ * CoreAdapter is the main application container for all of the network and storage
+ * related behaviors of the application. It uses an instance of the external Core
+ * library to perform the actual network calls.
  */
-export default class Core {
+export default class CoreAdapter {
   constructor (config = {}) {
     /**
      * A reference to the client API Key used for all requests
@@ -123,6 +125,24 @@ export default class Core {
      * @type {Function}
      */
     this.onVerticalSearch = config.onVerticalSearch || function () {};
+  }
+
+  /**
+   * Initializes the {@link CoreAdapter} by providing it with an instance of the Core library.
+   */
+  init() {
+    const params = { apiKey: this._apiKey, experienceKey: this._experienceKey };
+    return provideCore(params).then(coreLibrary => {
+      this._coreLibrary = coreLibrary;
+    })
+  }
+
+  /**
+   * @returns {boolean} A boolean indicating if the {@link CoreAdapter} has been
+   *                    initailized.
+   */
+  isInitialized() {
+    return !!this._coreLibrary;
   }
 
   /**


### PR DESCRIPTION
This PR creates the `CoreAdapater`, which will use the new Core library to
perform all network requests. The adapter is essentially the SDK's old
`Core` class, with the addition of an `init` method. This method calls the new
`provideCore` function to get an instance of the library. Note that the Core
library is not added to the SDK's package.json. This is because it has not yet
been published to npm and the Github repo does not contain a dist build.

You can point the SDK at your local version of answer-core by adding a line
like this to the package.json dependencies:

`"@yext/answers-core": "file:../answers-core"`

This will enable you to test your answers-core changes against the SDK. Once
answers-core has been published to npm, we will commit the dependency to the
package.json. We will also be able to get rid of the answers-core specific
things added to bundle.js

I initially considered having answers-umd invoke `provideCore` and then
instantiate `CoreAdapter` after `_loadAsyncDependencies`. This would not have
worked, however. It would mean that `ANSWERS` instance methods, such as
`setSessionsOptIn` could not be called until `onReady`. This would be a
breaking change.

J=SLAP-836
TEST=manual

Pointed the SDK to my local answers-core build. Created a bundle of the SDK
and made sure that `CoreAdapter` was initialized with a Core library instance.