### PR TITLE
gitignore: Remove app from the gitignore to match npmignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules/
-app/
 dist/
 **/.DS_Store


### PR DESCRIPTION
We noticed the app directory is in the gitignore when it doesn't exist
in the repository. Removing it to be consistent with the npmignore

TEST=auto