### PR TITLE
Update Core's verticalSearch method to always pass a query to onVerticalSearch

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -156,6 +156,9 @@ export default class Core {
     const context = this.globalStorage.getState(StorageKeys.API_CONTEXT);
     const referrerPageUrl = this.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL);
 
+    const defaultQueryInput = this.globalStorage.getState(StorageKeys.QUERY) || '';
+    const parsedQuery = Object.assign({}, { input: defaultQueryInput }, query);
+
     if (setQueryParams) {
       if (context) {
         this.persistentStorage.set(StorageKeys.API_CONTEXT, context, true);
@@ -181,8 +184,7 @@ export default class Core {
       .verticalSearch(verticalKey, {
         limit: this.globalStorage.getState(StorageKeys.SEARCH_CONFIG).limit,
         geolocation: this.globalStorage.getState(StorageKeys.GEOLOCATION),
-        input: this.globalStorage.getState(StorageKeys.QUERY) || '',
-        ...query,
+        ...parsedQuery,
         filter: this.filterRegistry.getStaticFilterPayload(),
         facetFilter: this.filterRegistry.getFacetFilterPayload(),
         offset: this.globalStorage.getState(StorageKeys.SEARCH_OFFSET) || 0,
@@ -226,7 +228,7 @@ export default class Core {
 
         const exposedParams = {
           verticalKey: verticalKey,
-          queryString: query.input,
+          queryString: parsedQuery.input,
           resultsCount: this.globalStorage.getState(StorageKeys.VERTICAL_RESULTS).resultsCount,
           resultsContext: data[StorageKeys.VERTICAL_RESULTS].resultsContext
         };


### PR DESCRIPTION
The `verticalSearch` method was previously passing `query.input` to the
`onVerticalSearch` hook. However, this value is undefined when pagination is
used to conduct the search. When `query.input` is undefined, the query in
`globalStorage` should be passed instead.

J=SLAP-828
TEST=manual

Console logged the input to `onVerticalSearch` saw that that `input` was
correct when using the search bar or pagination.