### PR TITLE
Location Bias Fix

### DIFF
--- a/src/ui/components/search/locationbiascomponent.js
+++ b/src/ui/components/search/locationbiascomponent.js
@@ -128,7 +128,7 @@ export default class LocationBiasComponent extends Component {
       accuracyText: this._getAccuracyHelpText(data.accuracy),
       isPreciseLocation: data.accuracy === 'DEVICE' && this._allowUpdate,
       isUnknownLocation: data.accuracy === 'UNKNOWN',
-      shouldShow: data.accuracy !== undefined,
+      shouldShow: data.accuracy !== undefined && data.accuracy !== null,
       allowUpdate: this._allowUpdate
     }, val));
   }


### PR DESCRIPTION
Fix a bug where the location bias component would load improperly

The bug occurred when navigating to a blank vertical, performing a search, and hitting the back button. The location bias component would then have the properties for its state set to null. This caused the component to load since the component was only checking that the accuracy was not undefined. This commit makes sure the state is not null before loading the component.

J=none
Test=manual

Verify that the bug described above no longer occurs. Test other searches like 'locations near me' and check that the location bias component still works as expected