### PR TITLE
v1.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "answers",
-  "version": "1.0.0",
+  "name": "@yext/answers",
+  "version": "1.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "answers",
-  "version": "1.6.2",
+  "name": "@yext/answers",
+  "version": "1.7.0",
   "description": "Javascript Answers Programming Interface",
   "main": "dist/answers-umd.js",
   "repository": {

--- a/src/ui/components/search/locationbiascomponent.js
+++ b/src/ui/components/search/locationbiascomponent.js
@@ -128,7 +128,7 @@ export default class LocationBiasComponent extends Component {
       accuracyText: this._getAccuracyHelpText(data.accuracy),
       isPreciseLocation: data.accuracy === 'DEVICE' && this._allowUpdate,
       isUnknownLocation: data.accuracy === 'UNKNOWN',
-      shouldShow: data.accuracy !== undefined,
+      shouldShow: data.accuracy !== undefined && data.accuracy !== null,
       allowUpdate: this._allowUpdate
     }, val));
   }


### PR DESCRIPTION
## Version 1.7.0
Version 1.7.0 of the SDK includes a number of changes needed to support the Overlay integration of Answers. It is also the first version of the SDK that will be published to the npm registry.
### Changes
- Two new hooks were added for the `AutoComplete` component: `onOpen` and `onClose`. These hooks allow custom behavior when the dropdown of query suggestions opens or closes. (#1131). 
- The `shouldHideOnEmptySearch` configuration option was added to the `SearchBar` component. This option allows the `AutoComplete`'s query suggestions to be hidden when the search input is empty. (#1136)
- An `onClearSearch` hook was added to the `SearchBar` component. This hook allows custom JS to be executed whenever a user clicks the button to clear the search.
- An `onConductSearch` hook was added to the `SearchBar` component. With this hook, custom JS can be run whenever the user submits a query via the component. (#1132)
- The SDK's analytics events were updated to include a `querySource`. The source, which defaults to `STANDARD`, describes the Answers integration type. It can be set in the config provided to `ANSWERS.init`. (#1163)
- A Percy integration was added to the SDK's repository. This integration allows us to run visual regression tests against all code checked into the repo. (#1148)
- Small changes were made to the SDK to get it ready for release via the npm registry. (#1187)
- Sourcemaps were added for the answers.min.js, answers-umd.min.js, and answers-modern.min.js assets. (#1178)
### Bug Fixes
- The `Pagination` component now renders only those page links that are visible. Previously, we were rendering every available page link, those that weren't supposed to be visible were `display: none`'d. This resulted in unnecessary nodes being added to the DOM. (#1143)
- To better support WCAG, a focus state was added to the `SortOptions` component's radio buttons. (#1165)
- The `onVerticalSearch` hook is now passed the query when fired as a result of pagination. (#1188)
- A bug with the `LocationBias` component was fixed that caused it to load improperly under certain
circumstances. (#1195)