### PR TITLE
globalstorage: 2.0 scaffold + tests

### DIFF
--- a/src/core/storage/storage.js
+++ b/src/core/storage/storage.js
@@ -2,6 +2,7 @@
  * GlobalStorage is a container around application state.  It
  * exposes an interface for CRUD operations as well as listening
  * for stateful changes.
+ *
  * @param {Function} callback for state (persistent store) updates
  * @param {Function} callback for state (persistent store) reset
  */

--- a/src/core/storage/storage.js
+++ b/src/core/storage/storage.js
@@ -19,6 +19,7 @@ export default class GlobalStorage {
    * Decodes the initial state from the query params. This could be a
    * direct mapping from query param to storage keys in the storage or
    * could fetch a sessionId from some backend
+   *
    * @param {string} url The starting URL
    */
   init (url) {}
@@ -26,6 +27,7 @@ export default class GlobalStorage {
   /**
    * Set the data in storage with the given key to the provided
    * data, completely overwriting any existing data.
+   *
    * @param {string} key The storage key to set
    * @param {*} data The data to set
    */
@@ -34,6 +36,7 @@ export default class GlobalStorage {
   /**
    * Updates the storage and adds the entry to a persistent storage
    * buffer. The entry is not yet added to the persistent storage.
+   *
    * @param {string} key The storage key to set
    * @param {*} data The data to set
    */
@@ -47,6 +50,7 @@ export default class GlobalStorage {
 
   /**
    * Get the current state for the provided key
+   *
    * @param {string} key The storage key to get
    * @return {*} The state for the provided key
    */
@@ -54,6 +58,7 @@ export default class GlobalStorage {
 
   /**
    * Get the current state for all key/value pairs in storage
+   *
    * @return {Object} mapping from key to value representing the
    *                  current state
    */
@@ -62,12 +67,14 @@ export default class GlobalStorage {
   /**
    * Remove the data in storage with the given key to the
    * provided data
+   *
    * @param {string} key The storage key to delete
    */
   delete (key) {}
 
   /**
    * Returns the query parameters to encode the current state
+   *
    * @return {string} The query parameters for a page link with the
    *                  current state encoded
    *                  e.g. ?query=all&context=%7Bkey:'hello'%7D
@@ -76,6 +83,7 @@ export default class GlobalStorage {
 
   /**
    * Adds a listener to the given module for a given event
+   *
    * @param {string} event The event to listen to, e.g. ‘update’
    * @param {string} module The module key to listen for e.g. Pagination
    * @param {Function} callback The callback when an event is called,

--- a/src/core/storage/storage.js
+++ b/src/core/storage/storage.js
@@ -1,0 +1,87 @@
+/**
+ * GlobalStorage is a container around application state.  It
+ * exposes an interface for CRUD operations as well as listening
+ * for stateful changes.
+ * @param {Function} callback for state (persistent store) updates
+ * @param {Function} callback for state (persistent store) reset
+ */
+export default class GlobalStorage {
+  constructor (stateUpdateListener, stateResetListener) {
+    /**
+     * The persistent storage implementation to store state
+     * across browser sessions and URLs
+     * @type {PersistentStorage}
+     */
+    this.persistentStorage = undefined;
+  }
+
+  /**
+   * Decodes the initial state from the query params. This could be a
+   * direct mapping from query param to storage keys in the storage or
+   * could fetch a sessionId from some backend
+   * @param {string} url The starting URL
+   */
+  init (url) {}
+
+  /**
+   * Set the data in storage with the given key to the provided
+   * data, completely overwriting any existing data.
+   * @param {string} key The storage key to set
+   * @param {*} data The data to set
+   */
+  set (key, data) {}
+
+  /**
+   * Updates the storage and adds the entry to a persistent storage
+   * buffer. The entry is not yet added to the persistent storage.
+   * @param {string} key The storage key to set
+   * @param {*} data The data to set
+   */
+  setWithPersist (key, data, replaceHistory) {}
+
+  /**
+   * Flushes the persistent storage buffer and adds all entries
+   * to the persistent storage.
+   */
+  flushPersist () {}
+
+  /**
+   * Get the current state for the provided key
+   * @param {string} key The storage key to get
+   * @return {*} The state for the provided key
+   */
+  get (key) {}
+
+  /**
+   * Get the current state for all key/value pairs in storage
+   * @return {Object} mapping from key to value representing the
+   *                  current state
+   */
+  getAll () {}
+
+  /**
+   * Remove the data in storage with the given key to the
+   * provided data
+   * @param {string} key The storage key to delete
+   */
+  delete (key) {}
+
+  /**
+   * Returns the query parameters to encode the current state
+   * @return {string} The query parameters for a page link with the
+   *                  current state encoded
+   *                  e.g. ?query=all&context=%7Bkey:'hello'%7D
+   */
+  getUrlForNewPageMaintainingState () {}
+
+  /**
+   * Adds a listener to the given module for a given event
+   * @param {string} event The event to listen to, e.g. ‘update’
+   * @param {string} module The module key to listen for e.g. Pagination
+   * @param {Function} callback The callback when an event is called,
+   *                   function is given the data if relevant
+   */
+  on (event, module, callback) {}
+
+  off (event, module, callback) {}
+}

--- a/src/core/storage/storage.js
+++ b/src/core/storage/storage.js
@@ -80,7 +80,7 @@ export default class GlobalStorage {
    *                  current state encoded
    *                  e.g. ?query=all&context=%7Bkey:'hello'%7D
    */
-  getUrlForNewPageMaintainingState () {}
+  getUrlWithCurrentState () {}
 
   /**
    * Adds a listener to the given module for a given event

--- a/tests/core/storage/storage.js
+++ b/tests/core/storage/storage.js
@@ -20,18 +20,18 @@ it('calls update and reset listeners onpopstate', () => {
 
 describe('init', () => {
   it('should be initialized with empty map w/o init', () => {
-    expect(storage.getAll()).toEqual({});
+    expect(storage.getAll()).toEqual(new Map());
   });
 
   it('should be initialized with empty map with empty string', () => {
     storage.init('');
-    expect(storage.getAll()).toEqual({});
+    expect(storage.getAll()).toEqual(new Map());
   });
 
-  const expectedResult = {
-    key1: 'val1',
-    key2: 'val2'
-  };
+  const expectedResult = new Map([
+    ['key1', 'val1'],
+    ['key2', 'val2']
+  ]);
 
   it('should be initialized with an absolute url', () => {
     storage = new GlobalStorage();
@@ -84,7 +84,7 @@ describe('set', () => {
 
       it('correctly stores javascript array', () => {
         storage.set(StorageKeys.QUERY, [1, 2, 3, 4, 5, 6]);
-        expect(storage.get(StorageKeys.QUERY)).toEqual({ key1: { key2: 'val2' } });
+        expect(storage.get(StorageKeys.QUERY)).toEqual([1, 2, 3, 4, 5, 6]);
       });
 
       it('correctly stores javascript map', () => {
@@ -98,8 +98,7 @@ describe('set', () => {
       });
 
       it('correctly handles undefined', () => {
-        storage.set(StorageKeys.QUERY, undefined);
-        expect(storage.get(StorageKeys.QUERY)).toEqual(undefined);
+        expect(() => storage.set(StorageKeys.QUERY, undefined)).toThrow();
       });
 
       it('correctly handles empty string', () => {
@@ -159,7 +158,7 @@ describe('set', () => {
 
         it('correctly stores javascript array', () => {
           storage.setWithPersist(StorageKeys.QUERY, [1, 2, 3, 4, 5, 6]);
-          expect(storage.get(StorageKeys.QUERY)).toEqual({ key1: { key2: 'val2' } });
+          expect(storage.get(StorageKeys.QUERY)).toEqual([1, 2, 3, 4, 5, 6]);
         });
 
         it('correctly stores javascript map', () => {
@@ -173,8 +172,7 @@ describe('set', () => {
         });
 
         it('correctly handles undefined', () => {
-          storage.setWithPersist(StorageKeys.QUERY, undefined);
-          expect(storage.get(StorageKeys.QUERY)).toEqual(undefined);
+          expect(() => storage.set(StorageKeys.QUERY, undefined)).toThrow();
         });
 
         it('correctly handles empty string', () => {
@@ -216,8 +214,8 @@ describe('set', () => {
 });
 
 describe('get', () => {
-  it('returns null for unset state', () => {
-    expect(storage.get(StorageKeys.QUERY)).toBeNull();
+  it('returns undefined for unset state', () => {
+    expect(storage.get(StorageKeys.QUERY)).toBeUndefined();
   });
 });
 
@@ -226,20 +224,18 @@ describe('getAll', () => {
     storage.set('key1', 'val1');
     storage.set('key2', 'val2');
     storage.set('key3', '');
-    storage.set('key4', undefined);
-    storage.set('key5', null);
-    storage.set('key6', {});
-    storage.set('key7', []);
+    storage.set('key4', null);
+    storage.set('key5', {});
+    storage.set('key6', []);
 
-    expect(storage.getAll()).toEqual({
-      key1: 'val1',
-      key2: 'val2',
-      key3: '',
-      key4: undefined,
-      key5: null,
-      key6: {},
-      key7: []
-    });
+    expect(storage.getAll()).toEqual(new Map([
+      ['key1', 'val1'],
+      ['key2', 'val2'],
+      ['key3', ''],
+      ['key4', null],
+      ['key5', {}],
+      ['key6', []]
+    ]));
   });
 
   it('returns empty map for empty get all', () => {
@@ -252,7 +248,7 @@ describe('delete', () => {
     storage.set('key1', 'val1');
     storage.set('key2', 'val2');
     storage.delete('key1');
-    expect(storage.get('key1')).toBeNull();
+    expect(storage.get('key1')).toBeUndefined();
     expect(storage.get('key2')).toEqual('val2');
   });
 
@@ -260,6 +256,7 @@ describe('delete', () => {
     storage.set('key1', 'val1');
     storage.set('key2', 'val2');
     storage.delete('key1');
+    storage.flushPersist();
     expect(storage.persistentStorage.get('key1')).toBeUndefined();
     expect(storage.persistentStorage.get('key2')).toEqual('val2');
   });
@@ -341,7 +338,7 @@ describe('flushPersist', () => {
     storage.flushPersist();
     expect(storage.persistentStorage.get('key1')).toEqual('val1');
     expect(storage.persistentStorage.get('key2')).toEqual('val2');
-    expect(storage.persistentStorageBuffer).toEqual(new Map());
+    expect(storage.persistentStorageBuffer).toEqual([]);
   });
 
   it('can flush an empty buffer', () => {
@@ -349,8 +346,8 @@ describe('flushPersist', () => {
   });
 
   it('calls update listeners on flush', () => {
-    storage = new GlobalStorage(stateUpdateListener, stateResetListener);
     storage.setWithPersist(StorageKeys.QUERY, 'val1');
+    storage.flushPersist();
     expect(stateUpdateListener).toBeCalled();
     expect(stateResetListener).not.toBeCalled();
   });

--- a/tests/core/storage/storage.js
+++ b/tests/core/storage/storage.js
@@ -311,3 +311,29 @@ describe('flushPersist', () => {
     expect(stateResetListener).not.toBeCalled();
   });
 });
+
+describe('getUrlWithCurrentState', () => {
+  it('passes from persistent storage', () => {
+    storage.setWithPersist(StorageKeys.QUERY, 'val1');
+    storage.flushPersist();
+    expect(storage.getUrlWithCurrentState()).toEqual('query=val1');
+  });
+
+  it('adds buffer entries to the url', () => {
+    storage.setWithPersist(StorageKeys.QUERY, 'val1');
+    expect(storage.getUrlWithCurrentState()).toEqual('query=val1');
+    storage.flushPersist();
+
+    storage.setWithPersist(StorageKeys.AUTOCOMPLETE, 'val2');
+    expect(storage.getUrlWithCurrentState()).toEqual('query=val1&autocomplete=val2');
+  });
+
+  it('overrides params from persistent storage with buffer', () => {
+    storage.setWithPersist(StorageKeys.QUERY, 'val1');
+    expect(storage.getUrlWithCurrentState()).toEqual('query=val1');
+    storage.flushPersist();
+
+    storage.setWithPersist(StorageKeys.QUERY, 'val2');
+    expect(storage.getUrlWithCurrentState()).toEqual('query=val2');
+  });
+});

--- a/tests/core/storage/storage.js
+++ b/tests/core/storage/storage.js
@@ -19,24 +19,33 @@ it('calls update and reset listeners onpopstate', () => {
 });
 
 describe('init', () => {
-  it('should be initialized with the correct formats', () => {
+  it('should be initialized with empty map w/o init', () => {
     expect(storage.getAll()).toEqual({});
+  });
 
+  it('should be initialized with empty map with empty string', () => {
     storage.init('');
     expect(storage.getAll()).toEqual({});
+  });
 
-    const expectedResult = {
-      key1: 'val1',
-      key2: 'val2'
-    };
+  const expectedResult = {
+    key1: 'val1',
+    key2: 'val2'
+  };
+
+  it('should be initialized with an absolute url', () => {
     storage = new GlobalStorage();
     storage.init('https://www.yext.com/?key1=val1&key2=val2');
     expect(storage.getAll()).toEqual(expectedResult);
+  });
 
+  it('should be initialized with a query param string w/ ?', () => {
     storage = new GlobalStorage();
     storage.init('?key1=val1&key2=val2');
     expect(storage.getAll()).toEqual(expectedResult);
+  });
 
+  it('should be initialized with a query param string w/o ?', () => {
     storage = new GlobalStorage();
     storage.init('key1=val1&key2=val2');
     expect(storage.getAll()).toEqual(expectedResult);
@@ -45,37 +54,58 @@ describe('init', () => {
 
 describe('set', () => {
   describe('vanilla set', () => {
-    it('correctly stores primitives', () => {
-      storage.set(StorageKeys.QUERY, 'tested');
-      expect(storage.get(StorageKeys.QUERY)).toEqual('tested');
+    describe('correctly stores various data types', () => {
+      it('correctly stores primitive string', () => {
+        storage.set(StorageKeys.QUERY, 'tested');
+        expect(storage.get(StorageKeys.QUERY)).toEqual('tested');
+      });
 
-      storage.set(StorageKeys.QUERY, true);
-      expect(storage.get(StorageKeys.QUERY)).toEqual(true);
+      it('correctly stores primitive boolean', () => {
+        storage.set(StorageKeys.QUERY, true);
+        expect(storage.get(StorageKeys.QUERY)).toEqual(true);
+      });
 
-      storage.set(StorageKeys.QUERY, 100);
-      expect(storage.get(StorageKeys.QUERY)).toEqual(100);
-    });
+      it('correctly stores primitive number', () => {
+        storage.set(StorageKeys.QUERY, 100);
+        expect(storage.get(StorageKeys.QUERY)).toEqual(100);
+      });
 
-    it('correctly stores structures', () => {
-      storage.set(StorageKeys.QUERY, { key1: { key2: 'val2' } });
-      expect(storage.get(StorageKeys.QUERY)).toEqual({ key1: { key2: 'val2' } });
+      it('correctly stores js object', () => {
+        storage.set(StorageKeys.AUTOCOMPLETE, { test: 'test autocomplete data' });
+        storage.set(StorageKeys.NAVIGATION, { test: 'test navigation data' });
+        expect(storage.get(StorageKeys.AUTOCOMPLETE).test).toBe('test autocomplete data');
+        expect(storage.get(StorageKeys.NAVIGATION).test).toBe('test navigation data');
+      });
 
-      storage.set(StorageKeys.QUERY, [1, 2, 3, 4, 5, 6]);
-      expect(storage.get(StorageKeys.QUERY)).toEqual({ key1: { key2: 'val2' } });
+      it('correct stores nested js object', () => {
+        storage.set(StorageKeys.QUERY, { key1: { key2: 'val2' } });
+        expect(storage.get(StorageKeys.QUERY)).toEqual({ key1: { key2: 'val2' } });
+      });
 
-      storage.set(StorageKeys.QUERY, new Map());
-      expect(storage.get(StorageKeys.QUERY)).toEqual(new Map());
-    });
+      it('correctly stores javascript array', () => {
+        storage.set(StorageKeys.QUERY, [1, 2, 3, 4, 5, 6]);
+        expect(storage.get(StorageKeys.QUERY)).toEqual({ key1: { key2: 'val2' } });
+      });
 
-    it('correctly handles empties', () => {
-      storage.set(StorageKeys.QUERY, null);
-      expect(storage.get(StorageKeys.QUERY)).toEqual(null);
+      it('correctly stores javascript map', () => {
+        storage.set(StorageKeys.QUERY, new Map());
+        expect(storage.get(StorageKeys.QUERY)).toEqual(new Map());
+      });
 
-      storage.set(StorageKeys.QUERY, undefined);
-      expect(storage.get(StorageKeys.QUERY)).toEqual(undefined);
+      it('correctly handles null', () => {
+        storage.set(StorageKeys.QUERY, null);
+        expect(storage.get(StorageKeys.QUERY)).toEqual(null);
+      });
 
-      storage.set(StorageKeys.QUERY, '');
-      expect(storage.get(StorageKeys.QUERY)).toEqual('');
+      it('correctly handles undefined', () => {
+        storage.set(StorageKeys.QUERY, undefined);
+        expect(storage.get(StorageKeys.QUERY)).toEqual(undefined);
+      });
+
+      it('correctly handles empty string', () => {
+        storage.set(StorageKeys.QUERY, '');
+        expect(storage.get(StorageKeys.QUERY)).toEqual('');
+      });
     });
 
     it('stores data by the provided key', () => {
@@ -99,44 +129,58 @@ describe('set', () => {
   });
   describe('set with persist', () => {
     describe('does everything set does', () => {
-      it('correctly stores primitives', () => {
-        storage.setWithPersist(StorageKeys.QUERY, 'tested');
-        expect(storage.get(StorageKeys.QUERY)).toEqual('tested');
+      describe('correctly stores various data types', () => {
+        it('correctly stores primitive string', () => {
+          storage.setWithPersist(StorageKeys.QUERY, 'tested');
+          expect(storage.get(StorageKeys.QUERY)).toEqual('tested');
+        });
 
-        storage.setWithPersist(StorageKeys.QUERY, true);
-        expect(storage.get(StorageKeys.QUERY)).toEqual(true);
+        it('correctly stores primitive boolean', () => {
+          storage.setWithPersist(StorageKeys.QUERY, true);
+          expect(storage.get(StorageKeys.QUERY)).toEqual(true);
+        });
 
-        storage.setWithPersist(StorageKeys.QUERY, 100);
-        expect(storage.get(StorageKeys.QUERY)).toEqual(100);
-      });
+        it('correctly stores primitive number', () => {
+          storage.setWithPersist(StorageKeys.QUERY, 100);
+          expect(storage.get(StorageKeys.QUERY)).toEqual(100);
+        });
 
-      it('correctly stores structures', () => {
-        storage.setWithPersist(StorageKeys.QUERY, { key1: { key2: 'val2' } });
-        expect(storage.get(StorageKeys.QUERY)).toEqual({ key1: { key2: 'val2' } });
+        it('correctly stores js object', () => {
+          storage.setWithPersist(StorageKeys.AUTOCOMPLETE, { test: 'test autocomplete data' });
+          storage.setWithPersist(StorageKeys.NAVIGATION, { test: 'test navigation data' });
+          expect(storage.get(StorageKeys.AUTOCOMPLETE).test).toBe('test autocomplete data');
+          expect(storage.get(StorageKeys.NAVIGATION).test).toBe('test navigation data');
+        });
 
-        storage.setWithPersist(StorageKeys.QUERY, [1, 2, 3, 4, 5, 6]);
-        expect(storage.get(StorageKeys.QUERY)).toEqual({ key1: { key2: 'val2' } });
+        it('correct stores nested js object', () => {
+          storage.setWithPersist(StorageKeys.QUERY, { key1: { key2: 'val2' } });
+          expect(storage.get(StorageKeys.QUERY)).toEqual({ key1: { key2: 'val2' } });
+        });
 
-        storage.setWithPersist(StorageKeys.QUERY, new Map());
-        expect(storage.get(StorageKeys.QUERY)).toEqual(new Map());
-      });
+        it('correctly stores javascript array', () => {
+          storage.setWithPersist(StorageKeys.QUERY, [1, 2, 3, 4, 5, 6]);
+          expect(storage.get(StorageKeys.QUERY)).toEqual({ key1: { key2: 'val2' } });
+        });
 
-      it('correctly handles empties', () => {
-        storage.setWithPersist(StorageKeys.QUERY, null);
-        expect(storage.get(StorageKeys.QUERY)).toEqual(null);
+        it('correctly stores javascript map', () => {
+          storage.setWithPersist(StorageKeys.QUERY, new Map());
+          expect(storage.get(StorageKeys.QUERY)).toEqual(new Map());
+        });
 
-        storage.setWithPersist(StorageKeys.QUERY, undefined);
-        expect(storage.get(StorageKeys.QUERY)).toEqual(undefined);
+        it('correctly handles null', () => {
+          storage.setWithPersist(StorageKeys.QUERY, null);
+          expect(storage.get(StorageKeys.QUERY)).toEqual(null);
+        });
 
-        storage.setWithPersist(StorageKeys.QUERY, '');
-        expect(storage.get(StorageKeys.QUERY)).toEqual('');
-      });
+        it('correctly handles undefined', () => {
+          storage.setWithPersist(StorageKeys.QUERY, undefined);
+          expect(storage.get(StorageKeys.QUERY)).toEqual(undefined);
+        });
 
-      it('stores data by the provided key', () => {
-        storage.setWithPersist(StorageKeys.AUTOCOMPLETE, { test: 'test autocomplete data' });
-        storage.setWithPersist(StorageKeys.NAVIGATION, { test: 'test navigation data' });
-        expect(storage.get(StorageKeys.AUTOCOMPLETE).test).toBe('test autocomplete data');
-        expect(storage.get(StorageKeys.NAVIGATION).test).toBe('test navigation data');
+        it('correctly handles empty string', () => {
+          storage.setWithPersist(StorageKeys.QUERY, '');
+          expect(storage.get(StorageKeys.QUERY)).toEqual('');
+        });
       });
 
       it('overwrites old data', () => {
@@ -301,7 +345,7 @@ describe('flushPersist', () => {
   });
 
   it('can flush an empty buffer', () => {
-    storage.flush();
+    storage.flushPersist();
   });
 
   it('calls update listeners on flush', () => {

--- a/tests/core/storage/storage.js
+++ b/tests/core/storage/storage.js
@@ -1,0 +1,313 @@
+import GlobalStorage from '../../../src/core/storage/storage';
+import StorageKeys from '../../../src/core/storage/storagekeys';
+
+let storage;
+let stateUpdateListener;
+let stateResetListener;
+
+beforeEach(() => {
+  storage = new GlobalStorage();
+  stateUpdateListener = jest.fn();
+  stateResetListener = jest.fn();
+});
+
+it('calls update and reset listeners onpopstate', () => {
+  storage = new GlobalStorage(stateUpdateListener, stateResetListener);
+  window.onpopstate();
+  expect(stateUpdateListener).toBeCalled();
+  expect(stateResetListener).toBeCalled();
+});
+
+describe('init', () => {
+  it('should be initialized with the correct formats', () => {
+    expect(storage.getAll()).toEqual({});
+
+    storage.init('');
+    expect(storage.getAll()).toEqual({});
+
+    const expectedResult = {
+      key1: 'val1',
+      key2: 'val2'
+    };
+    storage = new GlobalStorage();
+    storage.init('https://www.yext.com/?key1=val1&key2=val2');
+    expect(storage.getAll()).toEqual(expectedResult);
+
+    storage = new GlobalStorage();
+    storage.init('?key1=val1&key2=val2');
+    expect(storage.getAll()).toEqual(expectedResult);
+
+    storage = new GlobalStorage();
+    storage.init('key1=val1&key2=val2');
+    expect(storage.getAll()).toEqual(expectedResult);
+  });
+});
+
+describe('set', () => {
+  describe('vanilla set', () => {
+    it('correctly stores primitives', () => {
+      storage.set(StorageKeys.QUERY, 'tested');
+      expect(storage.get(StorageKeys.QUERY)).toEqual('tested');
+
+      storage.set(StorageKeys.QUERY, true);
+      expect(storage.get(StorageKeys.QUERY)).toEqual(true);
+
+      storage.set(StorageKeys.QUERY, 100);
+      expect(storage.get(StorageKeys.QUERY)).toEqual(100);
+    });
+
+    it('correctly stores structures', () => {
+      storage.set(StorageKeys.QUERY, { key1: { key2: 'val2' } });
+      expect(storage.get(StorageKeys.QUERY)).toEqual({ key1: { key2: 'val2' } });
+
+      storage.set(StorageKeys.QUERY, [1, 2, 3, 4, 5, 6]);
+      expect(storage.get(StorageKeys.QUERY)).toEqual({ key1: { key2: 'val2' } });
+
+      storage.set(StorageKeys.QUERY, new Map());
+      expect(storage.get(StorageKeys.QUERY)).toEqual(new Map());
+    });
+
+    it('correctly handles empties', () => {
+      storage.set(StorageKeys.QUERY, null);
+      expect(storage.get(StorageKeys.QUERY)).toEqual(null);
+
+      storage.set(StorageKeys.QUERY, undefined);
+      expect(storage.get(StorageKeys.QUERY)).toEqual(undefined);
+
+      storage.set(StorageKeys.QUERY, '');
+      expect(storage.get(StorageKeys.QUERY)).toEqual('');
+    });
+
+    it('stores data by the provided key', () => {
+      storage.set(StorageKeys.AUTOCOMPLETE, { test: 'test autocomplete data' });
+      storage.set(StorageKeys.NAVIGATION, { test: 'test navigation data' });
+      expect(storage.get(StorageKeys.AUTOCOMPLETE).test).toBe('test autocomplete data');
+      expect(storage.get(StorageKeys.NAVIGATION).test).toBe('test navigation data');
+    });
+
+    it('overwrites old data', () => {
+      storage.set(StorageKeys.AUTOCOMPLETE, { test: 'test autocomplete data' });
+      expect(storage.get(StorageKeys.AUTOCOMPLETE).test).toBe('test autocomplete data');
+      storage.set(StorageKeys.AUTOCOMPLETE, { test: 'test navigation data' });
+      expect(storage.get(StorageKeys.AUTOCOMPLETE).test).toBe('test navigation data');
+
+      storage.set(StorageKeys.AUTOCOMPLETE, { one: 'test data one' });
+      storage.set(StorageKeys.AUTOCOMPLETE, { two: 'test data two' });
+      expect(storage.get(StorageKeys.AUTOCOMPLETE).one).toBeUndefined();
+      expect(storage.get(StorageKeys.AUTOCOMPLETE).two).toBe('test data two');
+    });
+  });
+  describe('set with persist', () => {
+    describe('does everything set does', () => {
+      it('correctly stores primitives', () => {
+        storage.setWithPersist(StorageKeys.QUERY, 'tested');
+        expect(storage.get(StorageKeys.QUERY)).toEqual('tested');
+
+        storage.setWithPersist(StorageKeys.QUERY, true);
+        expect(storage.get(StorageKeys.QUERY)).toEqual(true);
+
+        storage.setWithPersist(StorageKeys.QUERY, 100);
+        expect(storage.get(StorageKeys.QUERY)).toEqual(100);
+      });
+
+      it('correctly stores structures', () => {
+        storage.setWithPersist(StorageKeys.QUERY, { key1: { key2: 'val2' } });
+        expect(storage.get(StorageKeys.QUERY)).toEqual({ key1: { key2: 'val2' } });
+
+        storage.setWithPersist(StorageKeys.QUERY, [1, 2, 3, 4, 5, 6]);
+        expect(storage.get(StorageKeys.QUERY)).toEqual({ key1: { key2: 'val2' } });
+
+        storage.setWithPersist(StorageKeys.QUERY, new Map());
+        expect(storage.get(StorageKeys.QUERY)).toEqual(new Map());
+      });
+
+      it('correctly handles empties', () => {
+        storage.setWithPersist(StorageKeys.QUERY, null);
+        expect(storage.get(StorageKeys.QUERY)).toEqual(null);
+
+        storage.setWithPersist(StorageKeys.QUERY, undefined);
+        expect(storage.get(StorageKeys.QUERY)).toEqual(undefined);
+
+        storage.setWithPersist(StorageKeys.QUERY, '');
+        expect(storage.get(StorageKeys.QUERY)).toEqual('');
+      });
+
+      it('stores data by the provided key', () => {
+        storage.setWithPersist(StorageKeys.AUTOCOMPLETE, { test: 'test autocomplete data' });
+        storage.setWithPersist(StorageKeys.NAVIGATION, { test: 'test navigation data' });
+        expect(storage.get(StorageKeys.AUTOCOMPLETE).test).toBe('test autocomplete data');
+        expect(storage.get(StorageKeys.NAVIGATION).test).toBe('test navigation data');
+      });
+
+      it('overwrites old data', () => {
+        storage.setWithPersist(StorageKeys.AUTOCOMPLETE, { test: 'test autocomplete data' });
+        expect(storage.get(StorageKeys.AUTOCOMPLETE).test).toBe('test autocomplete data');
+        storage.setWithPersist(StorageKeys.AUTOCOMPLETE, { test: 'test navigation data' });
+        expect(storage.get(StorageKeys.AUTOCOMPLETE).test).toBe('test navigation data');
+
+        storage.setWithPersist(StorageKeys.AUTOCOMPLETE, { one: 'test data one' });
+        storage.setWithPersist(StorageKeys.AUTOCOMPLETE, { two: 'test data two' });
+        expect(storage.get(StorageKeys.AUTOCOMPLETE).one).toBeUndefined();
+        expect(storage.get(StorageKeys.AUTOCOMPLETE).two).toBe('test data two');
+      });
+    });
+
+    it('does not push to persistent storage until flush', () => {
+      storage.setWithPersist(StorageKeys.QUERY, 'something');
+      storage.setWithPersist(StorageKeys.QUERY, 'else');
+      storage.setWithPersist(StorageKeys.AUTOCOMPLETE, 'other');
+      expect(storage.persistentStorage.get(StorageKeys.QUERY)).toBeUndefined();
+      expect(storage.persistentStorage.get(StorageKeys.AUTOCOMPLETE)).toBeUndefined();
+    });
+  });
+
+  it('accepts a combination of set and setWithPersist', () => {
+    storage.set(StorageKeys.QUERY, 'val1');
+    storage.setWithPersist(StorageKeys.QUERY, 'val2');
+    expect(storage.get(StorageKeys.QUERY, 'val2')).toEqual('val2');
+
+    storage.set(StorageKeys.QUERY, 'val3');
+    expect(storage.get(StorageKeys.QUERY, 'val3')).toEqual('val3');
+  });
+});
+
+describe('get', () => {
+  it('returns null for unset state', () => {
+    expect(storage.get(StorageKeys.QUERY)).toBeNull();
+  });
+});
+
+describe('getAll', () => {
+  it('returns the expected format', () => {
+    storage.set('key1', 'val1');
+    storage.set('key2', 'val2');
+    storage.set('key3', '');
+    storage.set('key4', undefined);
+    storage.set('key5', null);
+    storage.set('key6', {});
+    storage.set('key7', []);
+
+    expect(storage.getAll()).toEqual({
+      key1: 'val1',
+      key2: 'val2',
+      key3: '',
+      key4: undefined,
+      key5: null,
+      key6: {},
+      key7: []
+    });
+  });
+
+  it('returns empty map for empty get all', () => {
+    expect(storage.getAll()).toEqual(new Map());
+  });
+});
+
+describe('delete', () => {
+  it('removes data with delete()', () => {
+    storage.set('key1', 'val1');
+    storage.set('key2', 'val2');
+    storage.delete('key1');
+    expect(storage.get('key1')).toBeNull();
+    expect(storage.get('key2')).toEqual('val2');
+  });
+
+  it('deletes data from persistent storage', () => {
+    storage.set('key1', 'val1');
+    storage.set('key2', 'val2');
+    storage.delete('key1');
+    expect(storage.persistentStorage.get('key1')).toBeUndefined();
+    expect(storage.persistentStorage.get('key2')).toEqual('val2');
+  });
+
+  it('deletes data from persistent storage buffer', () => {
+    storage.setWithPersist('key1', 'val1');
+    storage.setWithPersist('key2', 'val2');
+    storage.delete('key1');
+    expect(storage.persistentStorageBuffer.get('key1')).toBeUndefined();
+    expect(storage.persistentStorageBuffer.get('key2')).toEqual('val2');
+  });
+});
+
+describe('on', () => {
+  it('publishes to subscribers when a new key is added', () => {
+    const spy = jest.fn();
+    storage.on('update', StorageKeys.AUTOCOMPLETE, spy);
+    storage.set(StorageKeys.AUTOCOMPLETE, { test: 'test autocomplete data' });
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('publishes to subscribers on existing keys', () => {
+    const spy = jest.fn();
+    storage.set(StorageKeys.AUTOCOMPLETE, { test: 'test autocomplete data' });
+    storage.on('update', StorageKeys.AUTOCOMPLETE, spy);
+    storage.set(StorageKeys.AUTOCOMPLETE, { test: 'new test autocomplete data' });
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('publishes to all subscribers', () => {
+    const spy1 = jest.fn();
+    const spy2 = jest.fn();
+    storage.set(StorageKeys.AUTOCOMPLETE, { test: 'test autocomplete data' });
+    storage.on('update', StorageKeys.AUTOCOMPLETE, spy1);
+    storage.on('update', StorageKeys.AUTOCOMPLETE, spy2);
+    storage.set(StorageKeys.AUTOCOMPLETE, { test: 'new test autocomplete data' });
+    expect(spy1).toHaveBeenCalled();
+    expect(spy2).toHaveBeenCalled();
+  });
+
+  it('only publishes to listeners on the key', () => {
+    const key1Spy = jest.fn();
+    const key2Spy = jest.fn();
+    storage.set(StorageKeys.AUTOCOMPLETE, { test: 'test autocomplete data' });
+    storage.set(StorageKeys.UNIVERSAL_RESULTS, { test: 'test results data' });
+    storage.on('update', StorageKeys.AUTOCOMPLETE, key1Spy);
+    storage.on('update', StorageKeys.UNIVERSAL_RESULTS, key2Spy);
+    storage.set(StorageKeys.AUTOCOMPLETE, { test: 'new test autocomplete data' });
+    expect(key1Spy).toHaveBeenCalled();
+    expect(key2Spy).not.toHaveBeenCalled();
+  });
+});
+
+describe('off', () => {
+  it('can be unsubscribed from a new key', () => {
+    const spy = jest.fn();
+    storage.on('update', StorageKeys.VERTICAL_RESULTS, spy);
+    storage.off('update', StorageKeys.VERTICAL_RESULTS, spy);
+    storage.set(StorageKeys.VERTICAL_RESULTS, { test: 'test results data' });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('can be unsubscribed from an existing key', () => {
+    const spy = jest.fn();
+    storage.set(StorageKeys.VERTICAL_RESULTS, { test: 'test results data' });
+    storage.on('update', StorageKeys.VERTICAL_RESULTS, spy);
+    storage.off('update', StorageKeys.VERTICAL_RESULTS, spy);
+    storage.set(StorageKeys.VERTICAL_RESULTS, { test: 'new test results data' });
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe('flushPersist', () => {
+  it('can flush the persistent storage buffer', () => {
+    storage.setWithPersist('key1', 'val1');
+    storage.setWithPersist('key2', 'val2');
+    expect(storage.persistentStorage.get('key1')).toBeUndefined();
+    expect(storage.persistentStorage.get('key2')).toBeUndefined();
+    storage.flushPersist();
+    expect(storage.persistentStorage.get('key1')).toEqual('val1');
+    expect(storage.persistentStorage.get('key2')).toEqual('val2');
+    expect(storage.persistentStorageBuffer).toEqual(new Map());
+  });
+
+  it('can flush an empty buffer', () => {
+    storage.flush();
+  });
+
+  it('calls update listeners on flush', () => {
+    storage = new GlobalStorage(stateUpdateListener, stateResetListener);
+    storage.setWithPersist(StorageKeys.QUERY, 'val1');
+    expect(stateUpdateListener).toBeCalled();
+    expect(stateResetListener).not.toBeCalled();
+  });
+});


### PR DESCRIPTION
Add the scaffolded global storage to the SDK (for storage 2.0). Add
tests for the new functions assuming new functionality. Note: The unit
tests are not expected to pass at this time as the global storage has
not been implemented yet. The linter is supposed to pass, though.

All tests from globalstorage are added except for the setAll and the
previous implementation of getAll (which was really a `getAllWithPrefix`).

J=SLAP-867
TEST=unit