### PR TITLE
Add custom formatter support to core adapters

### DIFF
--- a/src/core/core-adapter.js
+++ b/src/core/core-adapter.js
@@ -60,7 +60,7 @@ export default class CoreAdapter {
 
     /**
      * A map of field formatters used to format results, if present
-     * @type {Object.<string, function>}
+     * @type {Object<string, function>}
      * @private
      */
     this._fieldFormatters = config.fieldFormatters || {};

--- a/src/core/models/alternativeverticals.js
+++ b/src/core/models/alternativeverticals.js
@@ -15,7 +15,7 @@ export default class AlternativeVerticals {
    * Create alternative verticals from server data
    *
    * @param {Object[]} alternativeVerticals
-   * @param {Object.<string, function>} formatters to apply to the result fields
+   * @param {Object<string, function>} formatters applied to the result fields
    */
   static fromCore (alternativeVerticals, formatters) {
     if (!alternativeVerticals || alternativeVerticals.length === 0) {

--- a/src/core/models/alternativeverticals.js
+++ b/src/core/models/alternativeverticals.js
@@ -13,15 +13,17 @@ export default class AlternativeVerticals {
 
   /**
    * Create alternative verticals from server data
+   *
    * @param {Object[]} alternativeVerticals
+   * @param {Object.<string, function>} formatters to apply to the result fields
    */
-  static fromCore (alternativeVerticals) {
+  static fromCore (alternativeVerticals, formatters) {
     if (!alternativeVerticals || alternativeVerticals.length === 0) {
       return new AlternativeVerticals();
     }
 
     return new AlternativeVerticals(alternativeVerticals.map(alternativeVertical => {
-      return VerticalResults.fromCore(alternativeVertical);
+      return VerticalResults.fromCore(alternativeVertical, {}, formatters);
     }));
   }
 }

--- a/src/core/models/directanswer.js
+++ b/src/core/models/directanswer.js
@@ -45,7 +45,7 @@ export default class DirectAnswer {
    * @param {Object.<string, function>} formatters
    */
   format (formatters) {
-    if (!this.answer || !this.relateditem) {
+    if (!this.answer || !this.relatedItem) {
       return this;
     }
 

--- a/src/core/models/directanswer.js
+++ b/src/core/models/directanswer.js
@@ -38,4 +38,28 @@ export default class DirectAnswer {
       }
     });
   }
+
+  /**
+   * Applies a formatter to the direct answer if a formatter exists for the direct answer field
+   *
+   * @param {Object.<string, function>} formatters
+   */
+  format (formatters) {
+    if (!this.answer || !this.relateditem) {
+      return this;
+    }
+
+    const answer = this.answer;
+    const relatedItem = this.relatedItem;
+
+    if (formatters[answer.fieldApiName]) {
+      answer.value = formatters[answer.fieldApiName](
+        answer.value,
+        relatedItem.data.fieldValues,
+        relatedItem.verticalConfigId,
+        true);
+    }
+
+    return this;
+  }
 }

--- a/src/core/models/directanswer.js
+++ b/src/core/models/directanswer.js
@@ -44,7 +44,8 @@ export default class DirectAnswer {
     const formatterExistsForDirectAnswer = formatters && directAnswerFieldApiName in formatters;
 
     if (formatterExistsForDirectAnswer) {
-      directAnswerData.answer.value = this._getFormattedValue(directAnswerData, formatters[directAnswerFieldApiName]);
+      const formattedValue = this._getFormattedValue(directAnswerData, formatters[directAnswerFieldApiName]);
+      directAnswerData.answer.value = formattedValue || directAnswerData.answer.value;
     }
 
     return new DirectAnswer(directAnswerData);
@@ -55,6 +56,7 @@ export default class DirectAnswer {
    *
    * @param {Object} data directAnswerData
    * @param {function} formatter a field formatter to apply to the answer value field
+   * @returns {string|null} the formatted value, or null if the formatter could not be applied
    */
   static _getFormattedValue (data, formatter) {
     if (!data.answer || !data.relatedItem) {

--- a/src/core/models/result.js
+++ b/src/core/models/result.js
@@ -131,6 +131,10 @@ export default class Result {
       highlighted: highlightedData
     };
 
+    if (result.source !== 'KNOWLEDGE_MANAGER') {
+      return new Result(resultData);
+    }
+
     const formattedData = this._getFormattedData(resultData, formatters, verticalKey);
     resultData.formatted = formattedData;
 
@@ -144,6 +148,7 @@ export default class Result {
   /**
    * Returns an object which contains formatted fields
    *
+   * @param {Object} resultData the same shape as the input to the Result constructor
    * @param {Object<string, function>} formatters to apply to the result fields
    * @param {string} verticalKey the verticalKey associated with the result
    * @returns {Object<string, string>} keys are field names and values are the formatted data

--- a/src/core/models/result.js
+++ b/src/core/models/result.js
@@ -133,7 +133,7 @@ export default class Result {
   /**
    * Applies formatters to the result
    *
-   * @param {Object.<string, function>} formatters applied to the result fields
+   * @param {Object.<string, function>} formatters to apply to the result fields
    * @param {string} verticalKey
    */
   format (formatters, verticalKey) {

--- a/src/core/models/result.js
+++ b/src/core/models/result.js
@@ -110,14 +110,16 @@ export default class Result {
    * Constructs an SDK Result from an answers-core Result
    *
    * @param {Result} result from answers-core
+   * @param {Object<string, function>} formatters applied to the result fields
+   * @param {string} verticalKey the verticalKey associated with the result
    * @returns {@link Result}
    */
-  static fromCore (result) {
+  static fromCore (result, formatters, verticalKey) {
     const highlightedData = HighlightedFieldMap.fromCore(result.highlightedValues);
     const details = highlightedData.description || result.description;
     const truncatedDetails = truncate(details);
 
-    return new Result({
+    const resultData = {
       raw: result.rawData,
       ordinal: result.index,
       title: result.name,
@@ -127,27 +129,37 @@ export default class Result {
       distance: result.distance,
       distanceFromFilter: result.distanceFromFilter,
       highlighted: highlightedData
-    });
+    };
+
+    const formattedData = this._getFormattedData(resultData, formatters, verticalKey);
+    resultData.formatted = formattedData;
+
+    if (formattedData.description !== undefined) {
+      resultData.details = formattedData.description;
+    }
+
+    return new Result(resultData);
   }
 
   /**
-   * Applies formatters to the result
+   * Returns an object which contains formatted fields
    *
-   * @param {Object.<string, function>} formatters to apply to the result fields
-   * @param {string} verticalKey
+   * @param {Object<string, function>} formatters to apply to the result fields
+   * @param {string} verticalKey the verticalKey associated with the result
+   * @returns {Object<string, string>} keys are field names and values are the formatted data
    */
-  format (formatters, verticalKey) {
-    if (!formatters || !this._raw) {
-      return this;
+  static _getFormattedData (resultData, formatters, verticalKey) {
+    const formattedData = {};
+
+    if (!formatters || !resultData.raw) {
+      return formattedData;
     }
 
     if (Object.keys(formatters).length === 0) {
-      return this;
+      return formattedData;
     }
 
-    const formattedData = {};
-
-    Object.entries(this._raw).forEach(([fieldName, fieldVal]) => {
+    Object.entries(resultData.raw).forEach(([fieldName, fieldVal]) => {
       // check if a field formatter exists for the current entity profile field
       if (formatters[fieldName] === undefined) {
         return;
@@ -159,14 +171,14 @@ export default class Result {
 
       // if highlighted version of field value is available, make it available to field formatter
       let highlightedFieldVal = null;
-      if (this._highlighted && this._highlighted[fieldName]) {
-        highlightedFieldVal = this._highlighted[fieldName];
+      if (resultData.highlighted && resultData.highlighted[fieldName]) {
+        highlightedFieldVal = resultData.highlighted[fieldName];
       }
 
       // call formatter function associated with the field name
       // the input object defines the interface that field formatter functions work with
       formattedData[fieldName] = formatters[fieldName]({
-        entityProfileData: this._raw,
+        entityProfileData: resultData.raw,
         entityFieldValue: fieldVal,
         highlightedEntityFieldValue: highlightedFieldVal,
         verticalId: verticalKey,
@@ -174,12 +186,6 @@ export default class Result {
       });
     });
 
-    this._formatted = formattedData;
-
-    if (this._formatted.description !== undefined) {
-      this.details = this._formatted.description;
-    }
-
-    return this;
+    return formattedData;
   }
 }

--- a/src/core/models/section.js
+++ b/src/core/models/section.js
@@ -3,14 +3,14 @@
 import SearchStates from '../storage/searchstates';
 
 export default class Section {
-  constructor (data = {}, url, formatters, resultsContext) {
+  constructor (data = {}, url, resultsContext) {
     this.searchState = SearchStates.SEARCH_COMPLETE;
     this.verticalConfigId = data.verticalConfigId || null;
     this.resultsCount = data.resultsCount || 0;
     this.encodedState = data.encodedState || '';
     this.appliedQueryFilters = data.appliedQueryFilters;
     this.facets = data.facets || null;
-    this.results = data.results; // TODO use formatters on results
+    this.results = data.results;
     this.map = Section.parseMap(data.results);
     this.verticalURL = url || null;
     this.resultsContext = resultsContext;

--- a/src/core/models/universalresults.js
+++ b/src/core/models/universalresults.js
@@ -29,9 +29,10 @@ export default class UniversalResults {
    *
    * @param {UniversalSearchResponse} response from answers-core
    * @param {Object<string, string>} urls keyed by vertical key
+   * @param {Object.<string, function>} formatters to apply to the result fields
    * @returns {@link UniversalResults}
    */
-  static fromCore (response, urls) {
+  static fromCore (response, urls, formatters) {
     if (!response) {
       return new UniversalResults();
     }
@@ -39,7 +40,7 @@ export default class UniversalResults {
     return new UniversalResults({
       queryId: response.queryId,
       sections: response.verticalResults.map(verticalResults => {
-        return VerticalResults.fromCore(verticalResults, urls);
+        return VerticalResults.fromCore(verticalResults, urls, formatters);
       })
     });
   }

--- a/src/core/models/universalresults.js
+++ b/src/core/models/universalresults.js
@@ -29,7 +29,7 @@ export default class UniversalResults {
    *
    * @param {UniversalSearchResponse} response from answers-core
    * @param {Object<string, string>} urls keyed by vertical key
-   * @param {Object.<string, function>} formatters to apply to the result fields
+   * @param {Object<string, function>} formatters applied to the result fields
    * @returns {@link UniversalResults}
    */
   static fromCore (response, urls, formatters) {

--- a/src/core/models/verticalresults.js
+++ b/src/core/models/verticalresults.js
@@ -41,7 +41,7 @@ export default class VerticalResults {
    *
    * @param {VerticalResults} verticalResults
    * @param {Object<string, string>} urls keyed by vertical key
-   * @param {Object.<string, function>} formatters Field formatters for results
+   * @param {Object<string, function>} formatters applied to the result fields
    * @param {ResultsContext} resultsContext
    * @param {string} verticalKeyFromRequest
    * @returns {@link Section}
@@ -59,7 +59,7 @@ export default class VerticalResults {
         resultsCount: verticalResults.resultsCount,
         appliedQueryFilters: verticalResults.appliedQueryFilters.map(AppliedQueryFilter.fromCore),
         results: verticalResults.results.map(result => {
-          return Result.fromCore(result).format(formatters, verticalKey);
+          return Result.fromCore(result, formatters, verticalKey);
         })
       },
       urls[verticalKey],

--- a/src/core/models/verticalresults.js
+++ b/src/core/models/verticalresults.js
@@ -52,15 +52,17 @@ export default class VerticalResults {
     }
 
     const verticalKey = verticalResults.verticalKey || verticalKeyFromRequest;
+
     return new Section(
       {
         verticalConfigId: verticalKey,
         resultsCount: verticalResults.resultsCount,
         appliedQueryFilters: verticalResults.appliedQueryFilters.map(AppliedQueryFilter.fromCore),
-        results: verticalResults.results.map(Result.fromCore)
+        results: verticalResults.results.map(result => {
+          return Result.fromCore(result).format(formatters, verticalKey);
+        })
       },
       urls[verticalKey],
-      formatters,
       resultsContext
     );
   }

--- a/src/core/search/searchdatatransformer.js
+++ b/src/core/search/searchdatatransformer.js
@@ -22,7 +22,7 @@ export default class SearchDataTransformer {
     return {
       [StorageKeys.QUERY_ID]: data.queryId,
       [StorageKeys.NAVIGATION]: Navigation.fromCore(data.verticalResults),
-      [StorageKeys.DIRECT_ANSWER]: DirectAnswer.fromCore(data.directAnswer).format(formatters),
+      [StorageKeys.DIRECT_ANSWER]: DirectAnswer.fromCore(data.directAnswer, formatters),
       [StorageKeys.UNIVERSAL_RESULTS]: UniversalResults.fromCore(data, urls, formatters),
       [StorageKeys.INTENTS]: SearchIntents.fromCore(data.searchIntents),
       [StorageKeys.SPELL_CHECK]: SpellCheck.fromCore(data.spellCheck),

--- a/src/core/search/searchdatatransformer.js
+++ b/src/core/search/searchdatatransformer.js
@@ -22,8 +22,8 @@ export default class SearchDataTransformer {
     return {
       [StorageKeys.QUERY_ID]: data.queryId,
       [StorageKeys.NAVIGATION]: Navigation.fromCore(data.verticalResults),
-      [StorageKeys.DIRECT_ANSWER]: DirectAnswer.fromCore(data.directAnswer),
-      [StorageKeys.UNIVERSAL_RESULTS]: UniversalResults.fromCore(data, urls),
+      [StorageKeys.DIRECT_ANSWER]: DirectAnswer.fromCore(data.directAnswer).format(formatters),
+      [StorageKeys.UNIVERSAL_RESULTS]: UniversalResults.fromCore(data, urls, formatters),
       [StorageKeys.INTENTS]: SearchIntents.fromCore(data.searchIntents),
       [StorageKeys.SPELL_CHECK]: SpellCheck.fromCore(data.spellCheck),
       [StorageKeys.LOCATION_BIAS]: LocationBias.fromCore(data.locationBias)
@@ -50,7 +50,7 @@ export default class SearchDataTransformer {
       [StorageKeys.DYNAMIC_FILTERS]: DynamicFilters.fromCore(response.facets, resultsContext),
       [StorageKeys.INTENTS]: SearchIntents.fromCore(response.searchIntents),
       [StorageKeys.SPELL_CHECK]: SpellCheck.fromCore(response.spellCheck),
-      [StorageKeys.ALTERNATIVE_VERTICALS]: AlternativeVerticals.fromCore(response.alternativeVerticals),
+      [StorageKeys.ALTERNATIVE_VERTICALS]: AlternativeVerticals.fromCore(response.alternativeVerticals, formatters),
       [StorageKeys.LOCATION_BIAS]: LocationBias.fromCore(response.locationBias)
     };
   }


### PR DESCRIPTION
Add support for a custom formatting object which formats result fields

J=SLAP-918
Test=manual

Test the formatters on with universal search, vertical search, and direct answers. View the formatted results on a test site. Use toUpperCase() as the test formatter. Also confirm that the formatters have access to highlighted fields.
