### PR TITLE
core-adapter: add autocomplete core adapter

### DIFF
--- a/src/core/core-adapter.js
+++ b/src/core/core-adapter.js
@@ -17,6 +17,7 @@ import AnalyticsEvent from './analytics/analyticsevent';
 import FilterRegistry from './filters/filterregistry';
 import { AnswersEndpointError } from './errors/errors';
 import DirectAnswer from './models/directanswer';
+import AutoCompleteResponseTransformer from './search/autocompleteresponsetransformer';
 
 /** @typedef {import('./services/searchservice').default} SearchService */
 /** @typedef {import('./services/autocompleteservice').default} AutoCompleteService */
@@ -382,8 +383,11 @@ export default class CoreAdapter {
    * @param {string} namespace the namespace to use for the storage key
    */
   autoCompleteUniversal (input, namespace) {
-    return this._autoComplete
-      .queryUniversal(input)
+    return this._coreLibrary
+      .universalAutoComplete({
+        input: input
+      })
+      .then(response => AutoCompleteResponseTransformer.transformAutoCompleteResponse(response))
       .then(data => {
         this.globalStorage.set(`${StorageKeys.AUTOCOMPLETE}.${namespace}`, data);
         return data;
@@ -399,8 +403,12 @@ export default class CoreAdapter {
    * @param {string} verticalKey the vertical key for the experience
    */
   autoCompleteVertical (input, namespace, verticalKey) {
-    return this._autoComplete
-      .queryVertical(input, verticalKey)
+    return this._coreLibrary
+      .verticalAutoComplete({
+        input: input,
+        verticalKey: verticalKey
+      })
+      .then(response => AutoCompleteResponseTransformer.transformAutoCompleteResponse(response))
       .then(data => {
         this.globalStorage.set(`${StorageKeys.AUTOCOMPLETE}.${namespace}`, data);
         return data;
@@ -417,10 +425,16 @@ export default class CoreAdapter {
    * @param {object} config.searchParameters  the search parameters for the config v2
    */
   autoCompleteFilter (input, config) {
-    return this._autoComplete
-      .queryFilter(input, config)
+    return this._coreLibrary
+      .verticalAutoComplete({
+        input: input,
+        verticalKey: config.verticalKey,
+        searchParameters: config.searchParameters
+      })
+      .then(response => AutoCompleteResponseTransformer.transformFilterAutoCompleteResponse(response))
       .then(data => {
         this.globalStorage.set(`${StorageKeys.AUTOCOMPLETE}.${config.namespace}`, data);
+        return data;
       });
   }
 

--- a/src/core/core-adapter.js
+++ b/src/core/core-adapter.js
@@ -425,16 +425,24 @@ export default class CoreAdapter {
    * @param {object} config.searchParameters  the search parameters for the config v2
    */
   autoCompleteFilter (input, config) {
+    const searchParamFields = config.searchParameters.fields.map(field => ({
+      fieldApiName: field.fieldId,
+      entityType: field.entityTypeId,
+      fetchEntities: field.shouldFetchEntities
+    }));
+    const searchParams = {
+      sectioned: config.searchParameters.sectioned,
+      fields: searchParamFields
+    };
     return this._coreLibrary
-      .verticalAutoComplete({
+      .filterAutoComplete({
         input: input,
         verticalKey: config.verticalKey,
-        searchParameters: config.searchParameters
+        searchParameters: searchParams
       })
       .then(response => AutoCompleteResponseTransformer.transformFilterAutoCompleteResponse(response))
       .then(data => {
         this.globalStorage.set(`${StorageKeys.AUTOCOMPLETE}.${config.namespace}`, data);
-        return data;
       });
   }
 

--- a/src/core/search/autocompleteresponsetransformer.js
+++ b/src/core/search/autocompleteresponsetransformer.js
@@ -13,6 +13,7 @@ export default class AutoCompleteResponseTransformer {
    *
    * @param {import('@yext/answers-core').AutoCompleteResponse} response
    *  the response passed from the core library
+   * @return {AutoCompleteData}
    */
   static transformAutoCompleteResponse (response) {
     const sections = [{
@@ -32,6 +33,7 @@ export default class AutoCompleteResponseTransformer {
    *
    * @param {import('@yext/answers-core').FilterAutoCompleteResponse} response
    *  the response passed from the core library
+   * @return {AutoCompleteData}
    */
   static transformFilterAutoCompleteResponse (response) {
     if (response.sectioned && response.sections) {

--- a/src/core/search/autocompleteresponsetransformer.js
+++ b/src/core/search/autocompleteresponsetransformer.js
@@ -13,7 +13,7 @@ export default class AutoCompleteResponseTransformer {
    *
    * @param {import('@yext/answers-core').AutoCompleteResponse} response
    *  the response passed from the core library
-   * @return {AutoCompleteData}
+   * @returns {AutoCompleteData}
    */
   static transformAutoCompleteResponse (response) {
     const sections = [{
@@ -33,7 +33,7 @@ export default class AutoCompleteResponseTransformer {
    *
    * @param {import('@yext/answers-core').FilterAutoCompleteResponse} response
    *  the response passed from the core library
-   * @return {AutoCompleteData}
+   * @returns {AutoCompleteData}
    */
   static transformFilterAutoCompleteResponse (response) {
     if (response.sectioned && response.sections) {

--- a/src/core/search/autocompleteresponsetransformer.js
+++ b/src/core/search/autocompleteresponsetransformer.js
@@ -6,7 +6,6 @@ import AutoCompleteData, { AutoCompleteResult } from '../models/autocompletedata
  * data structure that our component library and core storage understand.
  */
 export default class AutoCompleteResponseTransformer {
-
   /**
    * Converts a universal or vertical autocomplete response from the
    * core library into an object that the SDK understands.
@@ -17,7 +16,7 @@ export default class AutoCompleteResponseTransformer {
    */
   static transformAutoCompleteResponse (response) {
     const sections = [{
-      results: response.results.map(result => new AutoCompleteResult(result)),
+      results: response.results.map(result => this._transformAutoCompleteResult(result)),
       resultsCount: response.results.length
     }];
     return new AutoCompleteData({
@@ -39,7 +38,7 @@ export default class AutoCompleteResponseTransformer {
     if (response.sectioned && response.sections) {
       const transformedSections = response.sections.map(section => ({
         label: section.label,
-        results: section.results.map(result => new AutoCompleteResult(result)),
+        results: section.results.map(result => this._transformAutoCompleteResult(result)),
         resultsCount: section.results.length
       }));
       return new AutoCompleteData({
@@ -50,5 +49,23 @@ export default class AutoCompleteResponseTransformer {
     } else {
       return this.transformAutoCompleteResponse(response);
     }
+  }
+
+  static _transformAutoCompleteResult (result) {
+    if (result.filter) {
+      result.filter = this._transformFilter(result.filter);
+    }
+    return new AutoCompleteResult(result);
+  }
+
+  static _transformFilter (filter) {
+    const fieldId = filter.fieldId;
+    const comparator = filter.comparator;
+    const comparedValue = filter.comparedValue;
+    return {
+      [fieldId]: {
+        [comparator]: comparedValue
+      }
+    };
   }
 }

--- a/src/core/search/autocompleteresponsetransformer.js
+++ b/src/core/search/autocompleteresponsetransformer.js
@@ -6,6 +6,14 @@ import AutoCompleteData, { AutoCompleteResult } from '../models/autocompletedata
  * data structure that our component library and core storage understand.
  */
 export default class AutoCompleteResponseTransformer {
+
+  /**
+   * Converts a universal or vertical autocomplete response from the
+   * core library into an object that the SDK understands.
+   *
+   * @param {import('@yext/answers-core').AutoCompleteResponse} response
+   *  the response passed from the core library
+   */
   static transformAutoCompleteResponse (response) {
     const sections = [{
       results: response.results.map(result => new AutoCompleteResult(result)),
@@ -18,6 +26,13 @@ export default class AutoCompleteResponseTransformer {
     });
   }
 
+  /**
+   * Converts a filter autocomplete response from the
+   * core library into an object that the SDK understands.
+   *
+   * @param {import('@yext/answers-core').FilterAutoCompleteResponse} response
+   *  the response passed from the core library
+   */
   static transformFilterAutoCompleteResponse (response) {
     if (response.sectioned && response.sections) {
       const transformedSections = response.sections.map(section => ({

--- a/src/core/search/autocompleteresponsetransformer.js
+++ b/src/core/search/autocompleteresponsetransformer.js
@@ -19,7 +19,7 @@ export default class AutoCompleteResponseTransformer {
   }
 
   static transformFilterAutoCompleteResponse (response) {
-    if (response.sections) {
+    if (response.sectioned && response.sections) {
       const transformedSections = response.sections.map(section => ({
         label: section.label,
         results: section.results.map(result => new AutoCompleteResult(result)),

--- a/src/core/search/autocompleteresponsetransformer.js
+++ b/src/core/search/autocompleteresponsetransformer.js
@@ -1,0 +1,37 @@
+import AutoCompleteData, { AutoCompleteResult } from '../models/autocompletedata';
+
+/**
+ * A data transformer that takes the response object from an
+ * AutoComplete request and transforms it into a front-end oriented
+ * data structure that our component library and core storage understand.
+ */
+export default class AutoCompleteResponseTransformer {
+  static transformAutoCompleteResponse (response) {
+    const sections = [{
+      results: response.results.map(result => new AutoCompleteResult(result)),
+      resultsCount: response.results.length
+    }];
+    return new AutoCompleteData({
+      sections: sections,
+      queryId: response.queryId,
+      inputIntents: response.inputIntents
+    });
+  }
+
+  static transformFilterAutoCompleteResponse (response) {
+    if (response.sections) {
+      const transformedSections = response.sections.map(section => ({
+        label: section.label,
+        results: section.results.map(result => new AutoCompleteResult(result)),
+        resultsCount: section.results.length
+      }));
+      return new AutoCompleteData({
+        sections: transformedSections,
+        queryId: response.queryId,
+        inputIntents: response.inputIntents
+      });
+    } else {
+      return this.transformAutoCompleteResponse(response);
+    }
+  }
+}

--- a/tests/core/search/autocompleteresponsetransformer.js
+++ b/tests/core/search/autocompleteresponsetransformer.js
@@ -83,9 +83,9 @@ describe('transform autocomplete response', () => {
           results: [
             {
               filter: {
-                comparator: '$eq',
-                comparedValue: 'Virginia Beach',
-                fieldId: 'name'
+                name: {
+                  $eq: 'Virginia Beach'
+                }
               },
               intents: [],
               key: 'name',

--- a/tests/core/search/autocompleteresponsetransformer.js
+++ b/tests/core/search/autocompleteresponsetransformer.js
@@ -1,0 +1,110 @@
+const { default: AutoCompleteResponseTransformer } = require('../../../src/core/search/autocompleteresponsetransformer');
+
+describe('transform autocomplete response', () => {
+  it('transforms universal/vertical autocomplete response', () => {
+    const responseFromCore = {
+      inputIntents: ['NEAR_ME'],
+      results: [
+        {
+          value: 'salesforce',
+          matchedSubstrings: [
+            {
+              offset: 0,
+              length: 10
+            }
+          ]
+        }
+      ]
+    };
+    const expectedTransformedResponse = {
+      inputIntents: ['NEAR_ME'],
+      queryId: '',
+      sections: [
+        {
+          results: [
+            {
+              filter: {},
+              intents: [],
+              key: '',
+              matchedSubstrings: [
+                {
+                  length: 10,
+                  offset: 0
+                }
+              ],
+              shortValue: 'salesforce',
+              value: 'salesforce'
+            }
+          ],
+          resultsCount: 1
+        }
+      ]
+    };
+    const actualTransformedResponse =
+      AutoCompleteResponseTransformer.transformAutoCompleteResponse(responseFromCore);
+    expect(actualTransformedResponse).toEqual(expectedTransformedResponse);
+  });
+
+  it('transforms filter autocomplete response with sections', () => {
+    const responseFromCore = {
+      sectioned: true,
+      sections: [
+        {
+          label: 'Name',
+          results: [
+            {
+              value: 'Virginia Beach',
+              matchedSubstrings: [
+                {
+                  offset: 0,
+                  length: 8
+                }
+              ],
+              filter: {
+                comparator: '$eq',
+                comparedValue: 'Virginia Beach',
+                fieldId: 'name'
+              },
+              key: 'name'
+            }
+          ]
+        }
+      ],
+      results: [],
+      inputIntents: [],
+      queryId: '42d5b709-3b9f-464a-b9b5-764467cbf540'
+    };
+    const expectedTransformedResponse = {
+      inputIntents: [],
+      queryId: '42d5b709-3b9f-464a-b9b5-764467cbf540',
+      sections: [
+        {
+          label: 'Name',
+          results: [
+            {
+              filter: {
+                comparator: '$eq',
+                comparedValue: 'Virginia Beach',
+                fieldId: 'name'
+              },
+              intents: [],
+              key: 'name',
+              matchedSubstrings: [
+                {
+                  length: 8,
+                  offset: 0
+                }
+              ],
+              shortValue: 'Virginia Beach',
+              value: 'Virginia Beach'
+            }
+          ],
+          resultsCount: 1
+        }
+      ]
+    };
+    const actualTransformedResponse =
+      AutoCompleteResponseTransformer.transformFilterAutoCompleteResponse(responseFromCore);
+    expect(actualTransformedResponse).toEqual(expectedTransformedResponse);
+  });
+});


### PR DESCRIPTION
Updates core-adapter.js to use the core library's
autocomplete functions.

Adds an `AutoCompleteResponseTransformer` class to
transform responses from the core library into a format
that the SDK understands and uses.

J=884
TEST=manual
Set up a test site to use my local version of the SDK
with the core adapter and saw that the autocomplete data
that is being generated via the core library and transformer
is equivalent to that being generated via just the SDK.