### PR TITLE
core-adapter: don't replace autocomplete result filter

### DIFF
--- a/src/core/core-adapter.js
+++ b/src/core/core-adapter.js
@@ -445,7 +445,6 @@ export default class CoreAdapter {
       })
       .then(response => AutoCompleteResponseTransformer.transformFilterAutoCompleteResponse(response))
       .then(data => {
-        console.log(data);
         this.globalStorage.set(`${StorageKeys.AUTOCOMPLETE}.${config.namespace}`, data);
       });
   }

--- a/src/core/core-adapter.js
+++ b/src/core/core-adapter.js
@@ -385,7 +385,8 @@ export default class CoreAdapter {
   autoCompleteUniversal (input, namespace) {
     return this._coreLibrary
       .universalAutoComplete({
-        input: input
+        input: input,
+        sessionTrackingEnabled: this.globalStorage.getState(StorageKeys.SESSIONS_OPT_IN).value
       })
       .then(response => AutoCompleteResponseTransformer.transformAutoCompleteResponse(response))
       .then(data => {
@@ -406,7 +407,8 @@ export default class CoreAdapter {
     return this._coreLibrary
       .verticalAutoComplete({
         input: input,
-        verticalKey: verticalKey
+        verticalKey: verticalKey,
+        sessionTrackingEnabled: this.globalStorage.getState(StorageKeys.SESSIONS_OPT_IN).value
       })
       .then(response => AutoCompleteResponseTransformer.transformAutoCompleteResponse(response))
       .then(data => {
@@ -438,10 +440,12 @@ export default class CoreAdapter {
       .filterAutoComplete({
         input: input,
         verticalKey: config.verticalKey,
-        searchParameters: searchParams
+        searchParameters: searchParams,
+        sessionTrackingEnabled: this.globalStorage.getState(StorageKeys.SESSIONS_OPT_IN).value
       })
       .then(response => AutoCompleteResponseTransformer.transformFilterAutoCompleteResponse(response))
       .then(data => {
+        console.log(data);
         this.globalStorage.set(`${StorageKeys.AUTOCOMPLETE}.${config.namespace}`, data);
       });
   }

--- a/src/core/search/autocompleteresponsetransformer.js
+++ b/src/core/search/autocompleteresponsetransformer.js
@@ -52,10 +52,7 @@ export default class AutoCompleteResponseTransformer {
   }
 
   static _transformAutoCompleteResult (result) {
-    let transformedFilter = {};
-    if (result.filter) {
-      transformedFilter = this._transformFilter(result.filter);
-    }
+    const transformedFilter = result.filter ? this._transformFilter(result.filter) : {};
     return new AutoCompleteResult({
       filter: transformedFilter,
       key: result.key,

--- a/src/core/search/autocompleteresponsetransformer.js
+++ b/src/core/search/autocompleteresponsetransformer.js
@@ -52,10 +52,17 @@ export default class AutoCompleteResponseTransformer {
   }
 
   static _transformAutoCompleteResult (result) {
+    let transformedFilter = {};
     if (result.filter) {
-      result.filter = this._transformFilter(result.filter);
+      transformedFilter = this._transformFilter(result.filter);
     }
-    return new AutoCompleteResult(result);
+    return new AutoCompleteResult({
+      filter: transformedFilter,
+      key: result.key,
+      matchedSubstrings: result.matchedSubstrings,
+      value: result.value,
+      shortValue: result.shortValue
+    });
   }
 
   static _transformFilter (filter) {


### PR DESCRIPTION
Attempting to assign result.filter another value in
the autocompleteresponsetransformer results in an
error because result.filter is readonly.

This makes the change so that in the response transformer,
we pass data from the result into the constructor for
AutoCompleteResult in a new object that contains
transformed filters and the rest of the data from the result, instead of attempting to reassigned result.filter.

Also passes the sessionTrackingEnabled field to the
autocomplete request.

TEST=auto, manual
Ran automated tests and saw them pass.
On a local test site, verified that the readonly error
is gone and that the results have been transformed
corrected. Also using the same site, verified that
sessionTrackingEnabled is being passed as a request
paramter to the backend.