### PR TITLE
readme: add note on supported locales for map component

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Outline:
    - [LocationBias Component](#location-bias-component)
    - [SortOptions Component](#sort-options-component)
    - [Map Component](#map-component)
+     - [Supported Map Locales](#supported-map-locales)
    - [Icon Component](#icon-component)
 5. [Customizing Components](#customizing-components)
    - [Using a Custom Renderer](#using-a-custom-renderer)
@@ -1929,6 +1930,7 @@ ANSWERS.addComponent('Map', {
   // Optional, can be used for Google Maps in place of the API key
   clientId: '',
   // Optional, used to determine the language of the map. Defaults to the locale specified in the ANSWERS init.
+  // Refer to the section "Supported Map Locales" below for the list of supported locales.
   locale: 'en',
   // Optional, determines whether or not to collapse pins at the same lat/lng
   collapsePins: false,
@@ -1968,6 +1970,8 @@ ANSWERS.addComponent('Map', {
 };
 ```
 
+### Supported Map Locales
+
 When using MapBox (`mapBox`) as the `mapProvider`, the valid locale options
 are the ones listed here:
 
@@ -1982,12 +1986,7 @@ are the ones listed here:
 + Russian: `ru`
 + Spanish: `es`
 
-If using a locale not listed above, there are two options:
-
-1. Use Google Maps (`google`) as the `mapProvider`.
-2. Specify a locale from the list above in the map component's config. This is
-not ideal, but if there is a standard fallback language, then this may be an
-acceptable option.
+When using Google Maps (`google`) as the `mapProvider`, the valid locale options can be found [here](https://developers.google.com/maps/faq#languagesupport).
 
 ## Icon Component
 The Icon Component will typically be created by other components, but it can be used as a standalone component as well.

--- a/README.md
+++ b/README.md
@@ -1968,6 +1968,27 @@ ANSWERS.addComponent('Map', {
 };
 ```
 
+When using MapBox (`mapBox`) as the `mapProvider`, the valid locale options
+are the ones listed here:
+
++ Arabic: `ar`
++ Chinese: `zh`
++ English: `en`
++ French: `fr`
++ German: `de`
++ Japanese: `ja`
++ Korean: `ko`
++ Portuguese: `pt`
++ Russian: `ru`
++ Spanish: `es`
+
+If using a locale not listed above, there are two options:
+
+1. Use Google Maps (`google`) as the `mapProvider`.
+2. Specify a locale from the list above in the map component's config. This is
+not ideal, but if there is a standard fallback language, then this may be an
+acceptable option.
+
 ## Icon Component
 The Icon Component will typically be created by other components, but it can be used as a standalone component as well.
 


### PR DESCRIPTION
Adds a note to the README's map component section on
supported locales for map providers.

J=SLAP-913
TEST=manual
Previewed added markdown in VSCode and saw that it is
rendered correctly.