### PR TITLE
README: Update the 'fields' option for Facets component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1339,12 +1339,32 @@ ANSWERS.addComponent('Facets', {
     'c_customFieldName':  { // Field id to override e.g. c_customFieldName, builtin.location
       // Optional, the placeholder text used for the filter option search input
       placeholderText: 'Search here...',
+      // Optional, show a reset button per facet group
+      showReset: false,
+      // Optional, the label to use for the reset button above
+      resetLabel: 'reset',
       // Optional, if true, display the filter option search input
       searchable: false,
+      // Optional, the form label text for the search input, defaults to 'Search for a filter option'
+      searchLabelText: 'Search for a filter option',
       // Optional, control type, singleoption or multioption
       control: 'singleoption',
       // Optional, override the field name for this facet
       label: 'My custom field'
+      // Optional, allow collapsing excess facet options after a limit
+      showMore: true,
+      // Optional, the max number of facets to show before collapsing extras
+      showMoreLimit: 5,
+      // Optional, the label to show for displaying more facets
+      showMoreLabel: 'show more',
+      // Optional, the label to show for displaying less facets
+      showLessLabel: 'show less',
+      // Optional, allow expanding and collapsing entire groups of facets
+      expand: true,
+      // Optional, callback function for when a facet is changed
+      onChange: function() { console.log('Facet changed'); },
+      // Optional, the selector used for options in the template, defaults to '.js-yext-filter-option'
+      optionSelector: '.js-yext-filter-option',
     }
   },
   // Optional, the label to show on the apply button


### PR DESCRIPTION
The fields option is used/passed down through many components. Thus we
have a few options we can specify in this field. (In my opinion, we
should be explicit about what is passed down from Facets to its child
component instead of passing through, as that makes it easier to reason
what is being passed where).

Here we add the configuration that we are missing. Many (but not all) of
these options are options already in the general Facets component. It
would be hard to say "all configuration from the Facets component", as
some would not work in the fields option.

from FacetsComponent
[x] control
[x] searchable
[x] placeholderText
[no] type
[add] searchLabelText
[add] expand

from FilterBoxComponent
[no] parentContainer
[no] name
[no] storeOnChange
[no] container
[no] isDynamic
[add] showReset
[add] resetLabel
[add] onChange

from FilterOptionsComponent
[x] searchable
[x] label
[above] onChange
[above] searchLabelText
[above] showReset
[above] resetLabel
[no] optionType
[no] initialOptions
[no] options
[no] storeOnChange
[no] isDynamic
[add] showMoreLimit
[add] showMoreLabel
[add] showLessLabel
[add] showMore
[add] showNumberApplied
[add] optionSelector (e.g. .js-yext-filter-options)

J=SLAP-943
TEST=manual

Tested on a site off of latest SDK that options work on Facets