### PR TITLE
core-adapter: more tests for autocompleteresponsetransformer

### DIFF
--- a/src/core/search/autocompleteresponsetransformer.js
+++ b/src/core/search/autocompleteresponsetransformer.js
@@ -57,8 +57,7 @@ export default class AutoCompleteResponseTransformer {
       filter: transformedFilter,
       key: result.key,
       matchedSubstrings: result.matchedSubstrings,
-      value: result.value,
-      shortValue: result.shortValue
+      value: result.value
     });
   }
 

--- a/tests/core/search/autocompleteresponsetransformer.js
+++ b/tests/core/search/autocompleteresponsetransformer.js
@@ -1,7 +1,7 @@
 const { default: AutoCompleteResponseTransformer } = require('../../../src/core/search/autocompleteresponsetransformer');
 
 describe('transform autocomplete response', () => {
-  it('transforms universal/vertical autocomplete response', () => {
+  it('transform universal/vertical autocomplete response', () => {
     const responseFromCore = {
       inputIntents: ['NEAR_ME'],
       results: [
@@ -45,7 +45,7 @@ describe('transform autocomplete response', () => {
     expect(actualTransformedResponse).toEqual(expectedTransformedResponse);
   });
 
-  it('transforms filter autocomplete response with sections', () => {
+  it('transform filter autocomplete response with sections', () => {
     const responseFromCore = {
       sectioned: true,
       sections: [
@@ -106,5 +106,144 @@ describe('transform autocomplete response', () => {
     const actualTransformedResponse =
       AutoCompleteResponseTransformer.transformFilterAutoCompleteResponse(responseFromCore);
     expect(actualTransformedResponse).toEqual(expectedTransformedResponse);
+  });
+
+  it('transform filter autocomplete response without sections', () => {
+    const responseFromCore = {
+      sectioned: false,
+      sections: [],
+      results: [
+        {
+          value: 'Virginia Beach',
+          matchedSubstrings: [
+            {
+              offset: 0,
+              length: 8
+            }
+          ],
+          filter: {
+            comparator: '$eq',
+            comparedValue: 'Virginia Beach',
+            fieldId: 'name'
+          },
+          key: 'name'
+        }
+      ],
+      inputIntents: [],
+      queryId: '42d5b709-3b9f-464a-b9b5-764467cbf540'
+    };
+    const expectedTransformedResponse = {
+      inputIntents: [],
+      queryId: '42d5b709-3b9f-464a-b9b5-764467cbf540',
+      sections: [
+        {
+          results: [
+            {
+              filter: {
+                name: {
+                  $eq: 'Virginia Beach'
+                }
+              },
+              intents: [],
+              key: 'name',
+              matchedSubstrings: [
+                {
+                  length: 8,
+                  offset: 0
+                }
+              ],
+              shortValue: 'Virginia Beach',
+              value: 'Virginia Beach'
+            }
+          ],
+          resultsCount: 1
+        }
+      ]
+    };
+    const actualTransformedResponse =
+      AutoCompleteResponseTransformer.transformFilterAutoCompleteResponse(responseFromCore);
+    expect(actualTransformedResponse).toEqual(expectedTransformedResponse);
+  });
+
+  it('transform filter', () => {
+    const filterFromCore = {
+      comparator: '$eq',
+      comparedValue: 'Arlington',
+      fieldId: 'c_name'
+    };
+    const expectedTransformedFilter = {
+      c_name: {
+        $eq: 'Arlington'
+      }
+    };
+    const actualTransformedFilter =
+      AutoCompleteResponseTransformer._transformFilter(filterFromCore);
+    expect(actualTransformedFilter).toEqual(expectedTransformedFilter);
+  });
+
+  it('transform autocomplete result with filter', () => {
+    const resultFromCore = {
+      value: 'Virginia Beach',
+      matchedSubstrings: [
+        {
+          offset: 0,
+          length: 8
+        }
+      ],
+      filter: {
+        comparator: '$eq',
+        comparedValue: 'Virginia Beach',
+        fieldId: 'name'
+      },
+      key: 'name'
+    };
+    const expectedTransformedResult = {
+      filter: {
+        name: {
+          $eq: 'Virginia Beach'
+        }
+      },
+      intents: [],
+      key: 'name',
+      matchedSubstrings: [
+        {
+          length: 8,
+          offset: 0
+        }
+      ],
+      shortValue: 'Virginia Beach',
+      value: 'Virginia Beach'
+    };
+    const actualTransformedResult =
+      AutoCompleteResponseTransformer._transformAutoCompleteResult(resultFromCore);
+    expect(actualTransformedResult).toEqual(expectedTransformedResult);
+  });
+
+  it('transform autocomplete result without filter', () => {
+    const resultFromCore = {
+      value: 'salesforce',
+      matchedSubstrings: [
+        {
+          offset: 0,
+          length: 10
+        }
+      ]
+    };
+    const expectedTransformedResult = {
+      filter: {},
+      intents: [],
+      key: '',
+      matchedSubstrings: [
+        {
+          length: 10,
+          offset: 0
+        }
+      ],
+      shortValue: 'salesforce',
+      value: 'salesforce'
+    };
+    const actualTransformedResult =
+      AutoCompleteResponseTransformer._transformAutoCompleteResult(resultFromCore);
+    expect(actualTransformedResult).toEqual(expectedTransformedResult);
   });
 });


### PR DESCRIPTION
Adds more test cases for autocompleteresponsetransformer.js.

Makes a change in autocompleteresponsetransformer.js to not
pass in `result.shortValue` to the AutoCompleteResult constructor
in `_transformAutoCompleteResult` since it is no longer part
of the response from the core library.

J=SLAP-941
TEST=auto
Ran tests with `npm run test` and saw that all of them passed.