### PR TITLE
Storage Acceptance Tests

### DIFF
--- a/tests/acceptance/acceptancesuite.js
+++ b/tests/acceptance/acceptancesuite.js
@@ -3,7 +3,7 @@ import VerticalPage from './pageobjects/verticalpage';
 import { setupServer, shutdownServer } from './server';
 import FacetsPage from './pageobjects/facetspage';
 import { Selector } from 'testcafe';
-import { getURLSearchParams, hitBrowserBackButton, reloadPage, waitForResultsToRender } from './utils';
+import { getURLSearchParams, browserBackButton, browserRefreshPage } from './utils';
 
 const UNIVERSAL_PAGE = 'http://localhost:9999/tests/acceptance/fixtures/html/universal';
 const VERTICAL_PAGE = 'http://localhost:9999/tests/acceptance/fixtures/html/vertical';
@@ -15,6 +15,7 @@ const FACETS_PAGE = 'http://localhost:9999/tests/acceptance/fixtures/html/facets
  * up to serve the search page and the dist directory of Answers.
  * This server is closed once all tests have completed.
  */
+
 fixture`Universal search page works as expected`
   .before(setupServer)
   .after(shutdownServer)
@@ -56,7 +57,7 @@ test('navigating and refreshing mantains that page number', async t => {
   await t.navigateTo(`${VERTICAL_PAGE}?query=Virginia`);
   const paginationComponent = VerticalPage.getPaginationComponent();
   await paginationComponent.clickNextButton();
-  await reloadPage();
+  await browserRefreshPage();
   const pageNum = await paginationComponent.getActivePageLabelAndNumber();
   await t.expect(pageNum).eql('Page 2');
 });
@@ -65,8 +66,7 @@ test('navigating pages and hitting the browser back button lands you on the righ
   const paginationComponent = VerticalPage.getPaginationComponent();
   await paginationComponent.clickNextButton();
   await paginationComponent.clickNextButton();
-  await t.eval(() => window.history.back());
-  await t.wait(1000);
+  await browserBackButton();
   const pageNum = await paginationComponent.getActivePageLabelAndNumber();
   await t.expect(pageNum).eql('Page 2');
 });

--- a/tests/acceptance/acceptancesuite.js
+++ b/tests/acceptance/acceptancesuite.js
@@ -43,7 +43,7 @@ fixture`Vertical search page works as expected`
   .after(shutdownServer)
   .page`${VERTICAL_PAGE}`;
 
-test('navigating pages works', async t => {
+test('pagination flow', async t => {
   const searchComponent = VerticalPage.getSearchComponent();
   await searchComponent.enterQuery('Virginia');
   await searchComponent.submitQuery();
@@ -55,14 +55,17 @@ test('navigating pages works', async t => {
 
 test('navigating and refreshing mantains that page number', async t => {
   await t.navigateTo(`${VERTICAL_PAGE}?query=Virginia`);
+
   const paginationComponent = VerticalPage.getPaginationComponent();
   await paginationComponent.clickNextButton();
   await browserRefreshPage();
   const pageNum = await paginationComponent.getActivePageLabelAndNumber();
   await t.expect(pageNum).eql('Page 2');
 });
+
 test('navigating pages and hitting the browser back button lands you on the right page', async t => {
   await t.navigateTo(`${VERTICAL_PAGE}?query=Virginia`);
+
   const paginationComponent = VerticalPage.getPaginationComponent();
   await paginationComponent.clickNextButton();
   await paginationComponent.clickNextButton();
@@ -215,14 +218,11 @@ test('Navigation tab order respects persistent storage tab order', async t => {
 
   const expectedDefaultTabLabels = ['home', 'facets', 'vertical'];
   const actualDefaultTabLabels = await navigationComponent.getTabLabelsLowerCase();
-
   await t.expect(actualDefaultTabLabels).eql(expectedDefaultTabLabels);
 
   await t.navigateTo(`${UNIVERSAL_PAGE}?tabOrder=./universal,./vertical,./facets`);
-
   const expectedCustomTabLabels = ['home', 'vertical', 'facets'];
   const actualCustomTabLabels = await navigationComponent.getTabLabelsLowerCase();
-
   await t.expect(actualCustomTabLabels).eql(expectedCustomTabLabels);
 });
 
@@ -230,12 +230,10 @@ test('Navigation tab links contain the persistent storage referrerPageUrl', asyn
   await t.navigateTo(`${UNIVERSAL_PAGE}?referrerPageUrl=yext.com`);
 
   const navigationComponent = UniversalPage.getNavigationComponent();
-
   const firstTabLink = (await navigationComponent.getTabLinks())[0];
   const indexOfQuestionMark = firstTabLink.indexOf('?');
   const queryString = firstTabLink.substring(indexOfQuestionMark);
   const urlParams = new URLSearchParams(queryString);
-
   await t.expect(urlParams.get('referrerPageUrl')).eql('yext.com');
 });
 
@@ -243,7 +241,6 @@ test('the spell check component deletes skipSpellCheck and queryTrigger url para
   await t.navigateTo(`${VERTICAL_PAGE}?query=mansfield&referrerPageUrl=yext.com&skipSpellCheck=true&queryTrigger=suggest`);
 
   const urlParams = await getURLSearchParams();
-
   await t.expect(urlParams.get('skipSpellCheck')).eql(null);
   await t.expect(urlParams.get('queryTrigger')).eql(null);
 });
@@ -256,20 +253,16 @@ fixture`Persistent Storage works as expected for Sorts and Filters`
 test(`selecting a facet option updates persistent storage`, async t => {
   const searchComponent = FacetsPage.getSearchComponent();
   await searchComponent.submitQuery();
-
   const facets = FacetsPage.getFacetsComponent();
   const filterBox = facets.getFilterBox();
-
   const employeeDepartment = await filterBox.getFilterOptions('Puppy Preference');
   await employeeDepartment.toggleOption('Frodo');
-
   const urlParamsBeforeApply = await getURLSearchParams();
   const filterBeforeApply = urlParamsBeforeApply.get('Facets.filterbox.filter0');
 
   await t.expect(filterBeforeApply).eql('[]');
 
   await filterBox.applyFilters();
-
   const urlParamsAfterApply = await getURLSearchParams();
   const filterAfterApply = urlParamsAfterApply.get('Facets.filterbox.filter0');
 
@@ -279,14 +272,12 @@ test(`selecting a facet option updates persistent storage`, async t => {
 test(`selecting a sort option updates persistent storage`, async t => {
   const searchComponent = FacetsPage.getSearchComponent();
   await searchComponent.submitQuery();
-
   const urlParamsBeforeApply = await getURLSearchParams();
   const sortOptionsBeforeApply = urlParamsBeforeApply.get('SortOptions');
 
   await t.expect(sortOptionsBeforeApply).eql(null);
 
   await t.click(await Selector('.yxt-SortOptions-optionSelector').nth(2));
-
   const urlParamsAfterApply = await getURLSearchParams();
   const sortOptionsAfterApply = urlParamsAfterApply.get('SortOptions');
 

--- a/tests/acceptance/acceptancesuite.js
+++ b/tests/acceptance/acceptancesuite.js
@@ -213,15 +213,15 @@ fixture`Persistent Storage behavior for various components`
 test('Navigation tab order respects persistent storage tab order', async t => {
   const navigationComponent = UniversalPage.getNavigationComponent();
 
-  const expectedDefaultTabLabels = ['HOME', 'FACETS', 'VERTICAL'];
-  const actualDefaultTabLabels = await navigationComponent.getTabLabels();
+  const expectedDefaultTabLabels = ['home', 'facets', 'vertical'];
+  const actualDefaultTabLabels = await navigationComponent.getTabLabelsLowerCase();
 
   await t.expect(actualDefaultTabLabels).eql(expectedDefaultTabLabels);
 
   await t.navigateTo(`${UNIVERSAL_PAGE}?tabOrder=./universal,./vertical,./facets`);
 
-  const expectedCustomTabLabels = ['HOME', 'VERTICAL', 'FACETS'];
-  const actualCustomTabLabels = await navigationComponent.getTabLabels();
+  const expectedCustomTabLabels = ['home', 'vertical', 'facets'];
+  const actualCustomTabLabels = await navigationComponent.getTabLabelsLowerCase();
 
   await t.expect(actualCustomTabLabels).eql(expectedCustomTabLabels);
 });

--- a/tests/acceptance/blocks/navigationcomponent.js
+++ b/tests/acceptance/blocks/navigationcomponent.js
@@ -13,14 +13,15 @@ export default class NavigationComponentBlock {
    *
    * @returns {Array<string>}
    */
-  async getTabLabels () {
+  async getTabLabelsLowerCase () {
     const tabList = this._navList.child();
     const tabListCount = await tabList.count;
     const tabLabels = [];
 
     for (let i = 0; i < tabListCount; i++) {
       const nthTab = tabList.nth(i);
-      tabLabels[i] = await nthTab.find('a').innerText;
+      const innerText = await nthTab.find('a').innerText;
+      tabLabels[i] = innerText.toLowerCase();
     }
 
     return tabLabels;

--- a/tests/acceptance/blocks/navigationcomponent.js
+++ b/tests/acceptance/blocks/navigationcomponent.js
@@ -21,7 +21,7 @@ export default class NavigationComponentBlock {
     for (let i = 0; i < tabListCount; i++) {
       const nthTab = tabList.nth(i);
       const innerText = await nthTab.find('a').innerText;
-      tabLabels[i] = innerText.toLowerCase();
+      tabLabels[i] = innerText.toLowerCase().trim();
     }
 
     return tabLabels;

--- a/tests/acceptance/blocks/navigationcomponent.js
+++ b/tests/acceptance/blocks/navigationcomponent.js
@@ -25,4 +25,22 @@ export default class NavigationComponentBlock {
 
     return tabLabels;
   }
+
+  /**
+   * Get an array of the links of the nav bar tabs
+   *
+   * @returns {Array<string>}
+   */
+  async getTabLinks () {
+    const tabList = this._navList.child();
+    const tabListCount = await tabList.count;
+    const tabLinks = [];
+
+    for (let i = 0; i < tabListCount; i++) {
+      const nthTab = tabList.nth(i);
+      tabLinks[i] = await nthTab.find('a').getAttribute('href');
+    }
+
+    return tabLinks;
+  }
 }

--- a/tests/acceptance/blocks/navigationcomponent.js
+++ b/tests/acceptance/blocks/navigationcomponent.js
@@ -1,0 +1,28 @@
+import { Selector } from 'testcafe';
+
+/**
+ * This class models user interactions with the {@link NavigationComponent}.
+ */
+export default class NavigationComponentBlock {
+  constructor () {
+    this._navList = Selector('.yxt-Nav-expanded');
+  }
+
+  /**
+   * Get an array of the labels of the nav bar tabs
+   *
+   * @returns {Array<string>}
+   */
+  async getTabLabels () {
+    const tabList = this._navList.child();
+    const tabListCount = await tabList.count;
+    const tabLabels = [];
+
+    for (let i = 0; i < tabListCount; i++) {
+      const nthTab = tabList.nth(i);
+      tabLabels[i] = await nthTab.find('a').innerText;
+    }
+
+    return tabLabels;
+  }
+}

--- a/tests/acceptance/fixtures/html/facets.html
+++ b/tests/acceptance/fixtures/html/facets.html
@@ -48,7 +48,7 @@
             },
             {
               label: 'Facets',
-              url: './links',
+              url: './facets',
               isActive: true
             },
             {

--- a/tests/acceptance/fixtures/html/universal.html
+++ b/tests/acceptance/fixtures/html/universal.html
@@ -38,7 +38,7 @@
                         },
                         {
                           label: 'Facets',
-                          url: './links',
+                          url: './facets',
                         },
                         {
                           label: 'Vertical',

--- a/tests/acceptance/fixtures/html/vertical.html
+++ b/tests/acceptance/fixtures/html/vertical.html
@@ -44,7 +44,7 @@
                         },
                         {
                           label: 'Facets',
-                          url: './links',
+                          url: './facets',
                         },
                         {
                           label: 'Vertical',

--- a/tests/acceptance/fixtures/html/vertical.html
+++ b/tests/acceptance/fixtures/html/vertical.html
@@ -10,6 +10,7 @@
         <div class="answers-container">
             <div class="search-bar-container"></div>
             <div class="navigation-container"></div>
+            <div class="spell-check-container"></div>
             <div class="results-container"></div>
             <div class="pagination-container"></div>
         </div>
@@ -61,6 +62,10 @@
 
                     this.addComponent('Pagination', {
                       container:'.pagination-container',
+                    });
+
+                    this.addComponent('SpellCheck', {
+                      container: '.spell-check-container',
                     })
                 }
             })

--- a/tests/acceptance/pageobjects/universalpage.js
+++ b/tests/acceptance/pageobjects/universalpage.js
@@ -1,3 +1,4 @@
+import NavigationComponentBlock from '../blocks/navigationcomponent';
 import SearchComponentBlock from '../blocks/searchcomponent';
 import UniversalResultsComponentBlock from '../blocks/universalresultscomponent';
 
@@ -9,6 +10,7 @@ class UniversalPage {
   constructor () {
     this._searchComponent = new SearchComponentBlock();
     this._universalResultsComponent = new UniversalResultsComponentBlock();
+    this._navigationComponent = new NavigationComponentBlock();
   }
 
   /**
@@ -23,6 +25,13 @@ class UniversalPage {
      */
   getUniversalResultsComponent () {
     return this._universalResultsComponent;
+  }
+
+  /**
+   * Returns the {@link NavigationComponentBlock} on the page.
+   */
+  getNavigationComponent () {
+    return this._navigationComponent;
   }
 }
 

--- a/tests/acceptance/utils.js
+++ b/tests/acceptance/utils.js
@@ -4,20 +4,20 @@ import { ClientFunction } from 'testcafe';
 
 const getPageUrl = ClientFunction(() => window.location.href);
 
-exports.getURLSearchParams = async () => {
+export async function getURLSearchParams () {
   const pageUrl = await getPageUrl();
   const indexOfQuestionMark = pageUrl.indexOf('?');
   const queryString = pageUrl.substring(indexOfQuestionMark);
 
   return new URLSearchParams(queryString);
-};
+}
 
-exports.browserRefreshPage = async () => {
+export async function browserRefreshPage () {
   await ClientFunction(() => location.reload())();
   await new Promise(resolve => setTimeout(resolve, 2500));
-};
+}
 
-exports.browserBackButton = async () => {
+export async function browserBackButton () {
   await ClientFunction(() => window.history.back())();
   await new Promise(resolve => setTimeout(resolve, 2500));
-};
+}

--- a/tests/acceptance/utils.js
+++ b/tests/acceptance/utils.js
@@ -14,10 +14,10 @@ exports.getURLSearchParams = async () => {
 
 exports.browserRefreshPage = async () => {
   await ClientFunction(() => location.reload())();
-  await new Promise(resolve => setTimeout(resolve, 1500));
+  await new Promise(resolve => setTimeout(resolve, 2500));
 };
 
 exports.browserBackButton = async () => {
   await ClientFunction(() => window.history.back())();
-  await new Promise(resolve => setTimeout(resolve, 1500));
+  await new Promise(resolve => setTimeout(resolve, 2500));
 };

--- a/tests/acceptance/utils.js
+++ b/tests/acceptance/utils.js
@@ -1,0 +1,15 @@
+import { ClientFunction } from 'testcafe';
+
+/* global location */
+
+const getPageUrl = ClientFunction(() => window.location.href);
+
+exports.getURLSearchParams = async () => {
+  const pageUrl = await getPageUrl();
+  const indexOfQuestionMark = pageUrl.indexOf('?');
+  const queryString = pageUrl.substring(indexOfQuestionMark);
+
+  return new URLSearchParams(queryString);
+};
+
+exports.reloadPage = ClientFunction(() => location.reload());

--- a/tests/acceptance/utils.js
+++ b/tests/acceptance/utils.js
@@ -12,4 +12,12 @@ exports.getURLSearchParams = async () => {
   return new URLSearchParams(queryString);
 };
 
-exports.reloadPage = ClientFunction(() => location.reload());
+exports.browserRefreshPage = async () => {
+  await ClientFunction(() => location.reload())();
+  await new Promise(resolve => setTimeout(resolve, 1500));
+};
+
+exports.browserBackButton = async () => {
+  await ClientFunction(() => window.history.back())();
+  await new Promise(resolve => setTimeout(resolve, 1500));
+};


### PR DESCRIPTION
Add various acceptance tests related to storage

Components tested include Navigation, Spellcheck, Pagination, Facets, and SortOptions. The basic usage of storage for the SearchBar component is covered by existing acceptance tests, so I didn't add any.

These tests cover the persistence bugs that Christian addressed in #1060 , and they more broadly cover usages of persistent storage set, get, and delete functions. Global storage is tested indirectly through the test suite, so I didn't add tests targeted at global storage. Examples of global storage being tested include the SearchComponent setting query on search, the VerticalResultsCount component reading the search offset from the pagination component, and filters being applied during the use of the facets.

I also added some helper functions in a utils file.

J=SLAP-868
TEST=auto

Run the acceptance tests and confirm that they pass