### PR TITLE
Use defaulted verticalKey in the LocationBias component.

### DIFF
--- a/src/ui/components/search/locationbiascomponent.js
+++ b/src/ui/components/search/locationbiascomponent.js
@@ -155,7 +155,7 @@ export default class LocationBiasComponent extends Component {
 
   _doSearch () {
     if (this._verticalKey) {
-      this.core.verticalSearch(this._config.verticalKey, {
+      this.core.verticalSearch(this._verticalKey, {
         setQueryParams: true,
         useFacets: true
       });


### PR DESCRIPTION
The LocationBias component has the ability to provide a default for the
verticalKey, if one is not provided in the component config. The default is
the Search Config's verticalKey (if it exists). In the component's _doSearch
method, we were not using the defaulted key. This led to a TechOps reported
by the Hitchhikers. Specifically, in the Theme they had set a Search Config
with a verticalKey. They were not passing verticalKey to the LocationBias
component itself, however. This was causing the component to try and execute
a vertical search with an undefined verticalKey.

T=377422
TEST=manual

Pointed the failing HH site to my local version of the SDK. I verified that
the vertical search issued by the LocationBias component gave a 200 response.