### PR TITLE
README fix for autcompleteOnLoad

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ ANSWERS.addComponent('SearchBar', {
   // Optional, defaults to false
   autoFocus: true,
   // Optional, when auto focus on load,  open the autocomplete
-  autoCompleteOnLoad: false,
+  autocompleteOnLoad: false,
   // Optional, on vertical search, allow a user to conduct an empty search. Should be set to true if the defaultInitialSearch is "".
   allowEmptySearch: false,
   // Optional, defaults to 300ms (0.3 seconds)


### PR DESCRIPTION
Update from 'autoCompleteOnLoad' to 'autocompleteOnLoad' to match the code in the SpellCheck component

J=SLAP-980
TEST=manual

Build a site with autocompleteOnLoad and observe the feature working