### PR TITLE
pass queryTrigger: suggest when clicking spell check

### DIFF
--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -205,7 +205,9 @@ class Answers {
     }
 
     parsedConfig.noResults && globalStorage.set(StorageKeys.NO_RESULTS_CONFIG, parsedConfig.noResults);
-    if (globalStorage.getState(StorageKeys.QUERY)) {
+    const isSuggestQueryTrigger =
+      globalStorage.getState(StorageKeys.QUERY_TRIGGER) === QueryTriggers.SUGGEST;
+    if (globalStorage.getState(StorageKeys.QUERY) && !isSuggestQueryTrigger) {
       globalStorage.set(StorageKeys.QUERY_TRIGGER, QueryTriggers.QUERY_PARAMETER);
     }
 

--- a/src/core/models/querytriggers.js
+++ b/src/core/models/querytriggers.js
@@ -8,5 +8,6 @@
  */
 export default {
   INITIALIZE: 'initialize',
-  QUERY_PARAMETER: 'query-parameter'
+  QUERY_PARAMETER: 'query-parameter',
+  SUGGEST: 'suggest'
 };

--- a/tests/acceptance/acceptancesuite.js
+++ b/tests/acceptance/acceptancesuite.js
@@ -83,6 +83,7 @@ test.requestHooks(spellCheckLogger)('spell check flow', async t => {
   await t.expect(pageNum).eql('Page 1');
 
   // Check that clicking spell check sends a queryTrigger=suggest url param
+  // TODO(oshi) investigate making this an integration test
   const requestUrl = spellCheckLogger.requests[spellCheckLogger.requests.length - 1].request.url;
   const queryTriggerParam = new URLSearchParams(requestUrl).get('queryTrigger');
   await t.expect(queryTriggerParam).eql('suggest');

--- a/tests/acceptance/acceptancesuite.js
+++ b/tests/acceptance/acceptancesuite.js
@@ -66,29 +66,27 @@ test('navigating and refreshing mantains that page number', async t => {
 const spellCheckLogger = RequestLogger({
   url: /v2\/accounts\/me\/answers\/vertical\/query/
 });
-test
-  .requestHooks(spellCheckLogger)
-  ('spell check flow', async t => {
-    const searchComponent = VerticalPage.getSearchComponent();
-    await searchComponent.enterQuery('varginia');
-    await searchComponent.submitQuery();
+test.requestHooks(spellCheckLogger)('spell check flow', async t => {
+  const searchComponent = VerticalPage.getSearchComponent();
+  await searchComponent.enterQuery('varginia');
+  await searchComponent.submitQuery();
 
-    // Check that clicking spell check resets pagination to page 1
-    const paginationComponent = VerticalPage.getPaginationComponent();
-    await paginationComponent.clickNextButton();
-    let pageNum = await paginationComponent.getActivePageLabelAndNumber();
-    await t.expect(pageNum).eql('Page 2');
+  // Check that clicking spell check resets pagination to page 1
+  const paginationComponent = VerticalPage.getPaginationComponent();
+  await paginationComponent.clickNextButton();
+  let pageNum = await paginationComponent.getActivePageLabelAndNumber();
+  await t.expect(pageNum).eql('Page 2');
 
-    const spellCheckComponent = VerticalPage.getSpellCheckComponent();
-    await spellCheckComponent.clickLink();
-    pageNum = await paginationComponent.getActivePageLabelAndNumber();
-    await t.expect(pageNum).eql('Page 1');
+  const spellCheckComponent = VerticalPage.getSpellCheckComponent();
+  await spellCheckComponent.clickLink();
+  pageNum = await paginationComponent.getActivePageLabelAndNumber();
+  await t.expect(pageNum).eql('Page 1');
 
-    // Check that clicking spell check sends a queryTrigger=suggest url param
-    const requestUrl = spellCheckLogger.requests[spellCheckLogger.requests.length - 1].request.url;
-    const queryTriggerParam = new URLSearchParams(requestUrl).get('queryTrigger');
-    await t.expect(queryTriggerParam).eql('suggest');
-  });
+  // Check that clicking spell check sends a queryTrigger=suggest url param
+  const requestUrl = spellCheckLogger.requests[spellCheckLogger.requests.length - 1].request.url;
+  const queryTriggerParam = new URLSearchParams(requestUrl).get('queryTrigger');
+  await t.expect(queryTriggerParam).eql('suggest');
+});
 
 test('navigating pages and hitting the browser back button lands you on the right page', async t => {
   await t.navigateTo(`${VERTICAL_PAGE}?query=Virginia`);

--- a/tests/acceptance/blocks/spellcheckcomponent.js
+++ b/tests/acceptance/blocks/spellcheckcomponent.js
@@ -1,0 +1,17 @@
+import { Selector, t } from 'testcafe';
+
+/**
+ * This class models user interactions with the {@link SpellCheckComponent}.
+ */
+export default class SpellCheckComponentBlock {
+  constructor () {
+    this._spellCheck = Selector('.yxt-SpellCheck');
+  }
+
+  /**
+   * Clicks the suggested
+   */
+  async clickLink () {
+    await t.click(this._spellCheck.find('a'));
+  }
+}

--- a/tests/acceptance/fixtures/html/vertical.html
+++ b/tests/acceptance/fixtures/html/vertical.html
@@ -9,6 +9,7 @@
     <body>
         <div class="answers-container">
             <div class="search-bar-container"></div>
+            <div class="spell-check-container"></div>
             <div class="navigation-container"></div>
             <div class="results-container"></div>
             <div class="pagination-container"></div>
@@ -25,6 +26,9 @@
                 search: {
                   verticalKey: 'KM',
                   limit: 15,
+                },
+                noResults: {
+                  displayAllResults: true
                 },
                 onReady: function() {
                     this.addComponent('SearchBar', {
@@ -56,12 +60,17 @@
 
                     this.addComponent('VerticalResults', {
                         container: '.results-container',
-                        verticalKey:'KM',
+                        verticalKey:'KM'
                     });
 
                     this.addComponent('Pagination', {
                       container:'.pagination-container',
-                    })
+                    });
+
+                    this.addComponent('SpellCheck', {
+                      container: '.spell-check-container',
+                    });
+
                 }
             })
         </script>

--- a/tests/acceptance/pageobjects/verticalpage.js
+++ b/tests/acceptance/pageobjects/verticalpage.js
@@ -1,6 +1,7 @@
 import SearchComponentBlock from '../blocks/searchcomponent';
 import VerticalResultsComponentBlock from '../blocks/verticalresultscomponent';
 import PaginationComponentBlock from '../blocks/paginationcomponent';
+import SpellCheckComponentBlock from '../blocks/spellcheckcomponent';
 
 /**
  * A model of a vertical search page, containing block representations
@@ -11,18 +12,19 @@ class VerticalPage {
     this._searchComponent = new SearchComponentBlock();
     this._verticalResultsComponent = new VerticalResultsComponentBlock();
     this._paginationComponent = new PaginationComponentBlock();
+    this._spellCheckComponent = new SpellCheckComponentBlock();
   }
 
   /**
-     * Returns the {@link SearchComponentBlock} on the page.
-     */
+   * Returns the {@link SearchComponentBlock} on the page.
+   */
   getSearchComponent () {
     return this._searchComponent;
   }
 
   /**
-     * Returns the {@link VerticalResultsComponentBlock} on the page.
-     */
+   * Returns the {@link VerticalResultsComponentBlock} on the page.
+   */
   getVerticalResultsComponent () {
     return this._verticalResultsComponent;
   }
@@ -32,6 +34,13 @@ class VerticalPage {
    */
   getPaginationComponent () {
     return this._paginationComponent;
+  }
+
+  /**
+   * Returns the {@link SpellCheckComponentBlock} on the page.
+   */
+  getSpellCheckComponent () {
+    return this._spellCheckComponent;
   }
 }
 


### PR DESCRIPTION
This ensures that we pass the queryTrigger: suggest param
after clicking a spell check link. Previously, this would
be overriden to query-parameter

This also fixes a bug where clicking a spell check link would
not reset the pagination from say page 2 to page 1. So if I were
to search for "varginia", go to page 2, then click the spell check,
prior to this I would be on page 2 instead of page 1 (though this
is probably exceptionally rare).

J=SLAP-979
TEST=manual, auto

test that clicking an autocomplete link will send queryTrigger: suggest

added acceptance test for spell check flow on a vertical page