### PR TITLE
Cut over SORT_BYS to new global storage

### DIFF
--- a/conf/gulp-tasks/bundle/bundle.js
+++ b/conf/gulp-tasks/bundle/bundle.js
@@ -68,7 +68,7 @@ exports.legacyBundle = function (callback, outputConfig, bundleName, locale, lib
       babel({
         runtimeHelpers: true,
         babelrc: false,
-        exclude: /node_modules\/(?!whatwg-fetch).*/,
+        exclude: /node_modules\/(?!whatwg-fetch)(?!@yext\/answers-storage).*/,
         presets: [
           [
             '@babel/preset-env',

--- a/package-lock.json
+++ b/package-lock.json
@@ -2637,8 +2637,9 @@
       }
     },
     "@yext/answers-storage": {
-      "version": "github:yext/answers-storage#2e479b6147ecd32782bbcacfef2508ffa5608d08",
-      "from": "github:yext/answers-storage#main"
+      "version": "1.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@yext/answers-storage/-/answers-storage-1.0.0-beta.0.tgz",
+      "integrity": "sha512-WdNPXN5nwvZEa97EgtagW3Ub7doFZeV0XokoyMLWKdwooWe51nwSXSSzto6u4gb3c4JK7ufAKWH/dwnHHEqc8Q=="
     },
     "@yext/rtf-converter": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,8 @@
       "DOMParser",
       "ytag",
       "test",
-      "fixture"
+      "fixture",
+      "CustomEvent"
     ],
     "ignore": [
       "docs/"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "@mapbox/mapbox-gl-language": "^0.10.1",
-    "@yext/answers-storage": "yext/answers-storage#main",
+    "@yext/answers-storage": "^1.0.0-beta.0",
     "@yext/rtf-converter": "^1.2.0",
     "css-vars-ponyfill": "^2.3.1",
     "gulp-sourcemaps": "^2.6.5",

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -16,6 +16,7 @@ import ConsoleErrorReporter from './core/errors/consoleerrorreporter';
 import { AnalyticsReporter, NoopAnalyticsReporter } from './core';
 import PersistentStorage from './ui/storage/persistentstorage';
 import GlobalStorage from './core/storage/globalstorage';
+import Storage from './core/storage/storage';
 import { AnswersComponentError } from './core/errors/errors';
 import AnalyticsEvent from './core/analytics/analyticsevent';
 import StorageKeys from './core/storage/storagekeys';
@@ -254,10 +255,13 @@ class Answers {
       initScrollListener(this._analyticsReporterService);
     }
 
+    const storage = new Storage().init(window.location.search);
+
     this.core = new Core({
       apiKey: parsedConfig.apiKey,
       globalStorage: globalStorage,
       persistentStorage: persistentStorage,
+      storage: storage,
       experienceKey: parsedConfig.experienceKey,
       fieldFormatters: parsedConfig.fieldFormatters,
       experienceVersion: parsedConfig.experienceVersion,

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -19,6 +19,7 @@ import FilterRegistry from './filters/filterregistry';
 /** @typedef {import('./services/searchservice').default} SearchService */
 /** @typedef {import('./services/autocompleteservice').default} AutoCompleteService */
 /** @typedef {import('./services/questionanswerservice').default} QuestionAnswerService */
+/** @typedef {import('./storage/storage').default} Storage */
 
 /**
  * Core is the main application container for all of the network and storage
@@ -75,6 +76,12 @@ export default class Core {
      * @private
      */
     this.persistentStorage = config.persistentStorage;
+
+    /**
+     * A reference to the core data storage that powers the UI
+     * @type {Storage}
+     */
+    this.storage = config.storage;
 
     /**
      * The filterRegistry is in charge of setting, removing, and retrieving filters
@@ -192,7 +199,7 @@ export default class Core {
         skipSpellCheck: this.globalStorage.getState('skipSpellCheck'),
         queryTrigger: queryTrigger,
         sessionTrackingEnabled: this.globalStorage.getState(StorageKeys.SESSIONS_OPT_IN).value,
-        sortBys: this.globalStorage.getState(StorageKeys.SORT_BYS),
+        sortBys: this.storage.get(StorageKeys.SORT_BYS),
         locationRadius: locationRadiusFilterNode ? locationRadiusFilterNode.getFilter().value : null,
         context: context,
         referrerPageUrl: referrerPageUrl,
@@ -435,14 +442,14 @@ export default class Core {
         direction: option.direction
       };
     });
-    this.globalStorage.set(StorageKeys.SORT_BYS, JSON.stringify(sortBys));
+    this.storage.set(StorageKeys.SORT_BYS, JSON.stringify(sortBys));
   }
 
   /**
    * Clears the sortBys key in global storage.
    */
   clearSortBys () {
-    this.globalStorage.delete(StorageKeys.SORT_BYS);
+    this.storage.delete(StorageKeys.SORT_BYS);
   }
 
   /**

--- a/src/core/storage/storage.js
+++ b/src/core/storage/storage.js
@@ -40,7 +40,7 @@ export default class GlobalStorage {
      * The persistent storage implementation to store state
      * across browser sessions and URLs
      *
-     * @type {PersistentStorage}
+     * @type {DefaultPersistentStorage}
      */
     this.persistentStorage = new DefaultPersistentStorage(this.popListener);
 
@@ -58,12 +58,14 @@ export default class GlobalStorage {
    * could fetch a sessionId from some backend
    *
    * @param {string} url The starting URL
+   * @returns {GlobalStorage}
    */
   init (url) {
     this.persistentStorage.init(url);
     this.persistentStorage.getAll().forEach((value, key) => {
       this.set(key, value);
     });
+    return this;
   }
 
   /**

--- a/src/core/storage/storagekeys.js
+++ b/src/core/storage/storagekeys.js
@@ -30,7 +30,7 @@ export default {
   SESSIONS_OPT_IN: 'sessions-opt-in',
   VERTICAL_PAGES_CONFIG: 'vertical-pages-config',
   LOCALE: 'locale',
-  SORT_BYS: 'sort-bys', // Cut over to new global storage
+  SORT_BYS: 'sort-bys', // Has been cut over to new global storage
   NO_RESULTS_CONFIG: 'no-results-config',
   LOCATION_RADIUS: 'location-radius',
   RESULTS_HEADER: 'results-header',

--- a/src/core/storage/storagekeys.js
+++ b/src/core/storage/storagekeys.js
@@ -30,7 +30,7 @@ export default {
   SESSIONS_OPT_IN: 'sessions-opt-in',
   VERTICAL_PAGES_CONFIG: 'vertical-pages-config',
   LOCALE: 'locale',
-  SORT_BYS: 'sort-bys',
+  SORT_BYS: 'sort-bys', // Cut over to new global storage
   NO_RESULTS_CONFIG: 'no-results-config',
   LOCATION_RADIUS: 'location-radius',
   RESULTS_HEADER: 'results-header',

--- a/tests/core/storage/storage.js
+++ b/tests/core/storage/storage.js
@@ -14,7 +14,7 @@ beforeEach(() => {
 
 it('calls update and reset listeners onpopstate', () => {
   storage = new GlobalStorage({ update: stateUpdateListener, reset: stateResetListener });
-  window.onpopstate();
+  window.dispatchEvent(new CustomEvent('popstate'))
   expect(stateUpdateListener).toBeCalled();
   expect(stateResetListener).toBeCalled();
 });

--- a/tests/core/storage/storage.js
+++ b/tests/core/storage/storage.js
@@ -14,7 +14,7 @@ beforeEach(() => {
 
 it('calls update and reset listeners onpopstate', () => {
   storage = new GlobalStorage({ update: stateUpdateListener, reset: stateResetListener });
-  window.dispatchEvent(new CustomEvent('popstate'))
+  window.dispatchEvent(new CustomEvent('popstate'));
   expect(stateUpdateListener).toBeCalled();
   expect(stateResetListener).toBeCalled();
 });


### PR DESCRIPTION
Cuts over SORT_BYS to the new global storage
(chosen because it's the simplest storage key)
and adds the new storage to core.

J=SLAP-1019
TEST=manual

chrome + ie11: test that the sort component still sorts, and passes the correct
sort_bys to the liveapi query
