### PR TITLE
Navigation integration tests

### DIFF
--- a/tests/setup/mockcomponentmanager.js
+++ b/tests/setup/mockcomponentmanager.js
@@ -42,11 +42,11 @@ export default class MockComponentManager {
 
     const component = new COMPONENT_REGISTRY[componentType](componentConfig, systemConfig).init(componentConfig);
 
-    if (component.moduleId === undefined || component.moduleId === null) {
-      return component;
-    }
-
     if (this.core && this.core.globalStorage) {
+      if (component.moduleId === undefined || component.moduleId === null) {
+        return component;
+      }
+
       this.core.globalStorage
         .on('update', component.moduleId, (data) => {
           component.setState(data);

--- a/tests/setup/mockcomponentmanager.js
+++ b/tests/setup/mockcomponentmanager.js
@@ -41,6 +41,18 @@ export default class MockComponentManager {
     };
 
     const component = new COMPONENT_REGISTRY[componentType](componentConfig, systemConfig).init(componentConfig);
+
+    if (component.moduleId === undefined || component.moduleId === null) {
+      return component;
+    }
+
+    if (this.core && this.core.globalStorage) {
+      this.core.globalStorage
+        .on('update', component.moduleId, (data) => {
+          component.setState(data);
+        });
+    }
+
     return component;
   }
 

--- a/tests/ui/components/navigation/navigationcomponent.js
+++ b/tests/ui/components/navigation/navigationcomponent.js
@@ -158,6 +158,21 @@ describe('navigation tab links are correct', () => {
     expect(tabLink).toContain('context=some+context');
   });
 
+  it('updating the context in global storage updates the context in tab links', () => {
+    const component = COMPONENT_MANAGER.create('Navigation', defaultConfig);
+    const wrapper = mount(component);
+
+    COMPONENT_MANAGER.core.globalStorage.set(StorageKeys.API_CONTEXT, 'new context');
+
+    // Re-render because the component state changed
+    wrapper.update();
+
+    const navItem = wrapper.find('.js-yxt-navItem').first();
+    const tabLink = navItem.prop('href');
+
+    expect(tabLink).toContain('context=new+context');
+  });
+
   it('tab links default to the tab order from global storage', () => {
     const verticalPagesConfig = new VerticalPagesConfig([
       { label: 'Home', url: './index.html' },

--- a/tests/ui/components/navigation/navigationcomponent.js
+++ b/tests/ui/components/navigation/navigationcomponent.js
@@ -194,3 +194,49 @@ describe('navigation tab links are correct', () => {
     expect(tabLink).toContain('tabOrder=.%2Findex.html%2Cpeople');
   });
 });
+
+describe('navigation tab order', () => {
+  let COMPONENT_MANAGER;
+
+  const defaultConfig = {
+    container: '#test-component',
+    verticalKey: 'verticalKey',
+    verticalPages: [
+      { verticalKey: 'first', url: './first', label: 'first' },
+      { verticalKey: 'second', url: './second', label: 'second' },
+      { verticalKey: 'third', url: './third', label: 'third' }
+    ]
+  };
+
+  COMPONENT_MANAGER = mockManager({
+    globalStorage: new GlobalStorage(),
+    persistentStorage: new PersistentStorage()
+  });
+
+  COMPONENT_MANAGER.getComponentNamesForComponentTypes = () => [];
+
+  it('tab order changes in response to the server', () => {
+    const component = COMPONENT_MANAGER.create('Navigation', defaultConfig);
+    const wrapper = mount(component);
+
+    const navStateWithReversedTabs = {
+      tabOrder: ['third', 'second', 'first']
+    };
+
+    component.core.globalStorage.set(StorageKeys.NAVIGATION, navStateWithReversedTabs);
+    wrapper.update();
+
+    const firstTab = wrapper.find('.js-yxt-navItem').at(0);
+    const firstTabText = (firstTab.text()).trim();
+
+    const secondTab = wrapper.find('.js-yxt-navItem').at(1);
+    const secondTabText = (secondTab.text()).trim();
+
+    const thirdTab = wrapper.find('.js-yxt-navItem').at(2);
+    const thirdTabText = (thirdTab.text()).trim();
+
+    expect(firstTabText).toEqual('third');
+    expect(secondTabText).toEqual('second');
+    expect(thirdTabText).toEqual('first');
+  });
+});


### PR DESCRIPTION
Ensure that tab links encode tabOrder, referrerPageUrl, and context from global storage

Update the mockmanager to call component setState() on updates to keys matching a component's moduleId

J=SLAP-1005
TEST=auto