### PR TITLE
cut over NAVIGATION to new global storage

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -208,7 +208,7 @@ export default class Core {
       .then(response => SearchDataTransformer.transformVertical(response, this._fieldFormatters, verticalKey))
       .then(data => {
         this.globalStorage.set(StorageKeys.QUERY_ID, data[StorageKeys.QUERY_ID]);
-        this.globalStorage.set(StorageKeys.NAVIGATION, data[StorageKeys.NAVIGATION]);
+        this.storage.set(StorageKeys.NAVIGATION, data[StorageKeys.NAVIGATION]);
         this.globalStorage.set(StorageKeys.INTENTS, data[StorageKeys.INTENTS]);
         this.globalStorage.set(StorageKeys.ALTERNATIVE_VERTICALS, data[StorageKeys.ALTERNATIVE_VERTICALS]);
 
@@ -255,7 +255,7 @@ export default class Core {
     this.globalStorage.set(StorageKeys.DYNAMIC_FILTERS, {}); // TODO has a model but not cleared w new
     this.globalStorage.set(StorageKeys.QUESTION_SUBMISSION, new QuestionSubmission({}));
     this.globalStorage.set(StorageKeys.INTENTS, new SearchIntents({}));
-    this.globalStorage.set(StorageKeys.NAVIGATION, new Navigation());
+    this.storage.set(StorageKeys.NAVIGATION, new Navigation());
     this.globalStorage.set(StorageKeys.ALTERNATIVE_VERTICALS, new AlternativeVerticals({}));
     this.globalStorage.set(StorageKeys.DIRECT_ANSWER, new DirectAnswer({}));
     this.globalStorage.set(StorageKeys.LOCATION_BIAS, new LocationBias({}));
@@ -312,7 +312,7 @@ export default class Core {
       .then(response => SearchDataTransformer.transform(response, urls, this._fieldFormatters))
       .then(data => {
         this.globalStorage.set(StorageKeys.QUERY_ID, data[StorageKeys.QUERY_ID]);
-        this.globalStorage.set(StorageKeys.NAVIGATION, data[StorageKeys.NAVIGATION]);
+        this.storage.set(StorageKeys.NAVIGATION, data[StorageKeys.NAVIGATION]);
         this.globalStorage.set(StorageKeys.DIRECT_ANSWER, data[StorageKeys.DIRECT_ANSWER]);
         this.globalStorage.set(StorageKeys.UNIVERSAL_RESULTS, data[StorageKeys.UNIVERSAL_RESULTS], urls);
         this.globalStorage.set(StorageKeys.INTENTS, data[StorageKeys.INTENTS]);

--- a/src/core/storage/storage.js
+++ b/src/core/storage/storage.js
@@ -1,6 +1,8 @@
 import DefaultPersistentStorage from '@yext/answers-storage';
 import { AnswersStorageError } from '../errors/errors';
 
+/** @typedef {import('./listener').default} StorageListener */
+
 /**
  * GlobalStorage is a container around application state.  It
  * exposes an interface for CRUD operations as well as listening
@@ -164,7 +166,7 @@ export default class GlobalStorage {
   /**
    * Adds a listener to the given module for a given event
    *
-   * @param {StorageListener} the listener to add
+   * @param {StorageListener} listener the listener to add
    */
   registerListener (listener) {
     if (!listener.eventType || !listener.storageKey ||
@@ -177,7 +179,7 @@ export default class GlobalStorage {
   /**
    * Removes a given listener from the set of listeners
    *
-   * @param {StorageListener} the listener to remove
+   * @param {StorageListener} listener the listener to remove
    */
   removeListener (listener) {
     this.listeners = this.listeners.filter(l => l !== listener);

--- a/src/core/storage/storagekeys.js
+++ b/src/core/storage/storagekeys.js
@@ -7,7 +7,7 @@
  * @enum {string}
  */
 export default {
-  NAVIGATION: 'navigation',
+  NAVIGATION: 'navigation', // Has been cut over to the new global storage
   UNIVERSAL_RESULTS: 'universal-results',
   VERTICAL_RESULTS: 'vertical-results',
   ALTERNATIVE_VERTICALS: 'alternative-verticals',
@@ -30,7 +30,7 @@ export default {
   SESSIONS_OPT_IN: 'sessions-opt-in',
   VERTICAL_PAGES_CONFIG: 'vertical-pages-config',
   LOCALE: 'locale',
-  SORT_BYS: 'sort-bys', // Has been cut over to new global storage
+  SORT_BYS: 'sort-bys', // Has been cut over to the new global storage
   NO_RESULTS_CONFIG: 'no-results-config',
   LOCATION_RADIUS: 'location-radius',
   RESULTS_HEADER: 'results-header',

--- a/src/ui/components/componentmanager.js
+++ b/src/ui/components/componentmanager.js
@@ -4,6 +4,8 @@ import { AnswersComponentError } from '../../core/errors/errors';
 import DOM from '../dom/dom';
 import { COMPONENT_REGISTRY } from './registry';
 
+/** @typedef {import('../../core/core').default} Core */
+
 /**
  * ComponentManager is a Singletone that contains both an internal registry of
  * eligible components to be created, as well as keeps track of the current
@@ -152,6 +154,16 @@ export default class ComponentManager {
         return component;
       }
 
+      this._core.storage.registerListener({
+        eventType: 'update',
+        storageKey: component.moduleId,
+        callback: (data) => {
+          component.setState(data);
+        }
+      });
+
+      // TODO(SLAP-869) remove this._core.globalStorage.on()
+      // when the new global storage is fully cut over
       this._core.globalStorage
         .on('update', component.moduleId, (data) => {
           component.setState(data);

--- a/src/ui/components/navigation/navigationcomponent.js
+++ b/src/ui/components/navigation/navigationcomponent.js
@@ -190,7 +190,7 @@ export default class NavigationComponent extends Component {
     this.checkMobileOverflowBehavior = this.checkMobileOverflowBehavior.bind(this);
 
     const reRender = () => {
-      this.setState(this.core.globalStorage.getState(StorageKeys.NAVIGATION) || {});
+      this.setState(this.core.storage.get(StorageKeys.NAVIGATION) || {});
     };
 
     this.core.globalStorage.on('update', StorageKeys.API_CONTEXT, reRender);

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -284,9 +284,8 @@ export default class VerticalResultsComponent extends Component {
     const verticalURL = this._config.verticalURL || verticalConfig.url ||
       data.verticalURL || this.verticalKey + '.html';
 
-    const dataTabOrder = this.core.globalStorage.getState(StorageKeys.NAVIGATION)
-      ? this.core.globalStorage.getState(StorageKeys.NAVIGATION).tabOrder
-      : [];
+    const navigationData = this.core.storage.get(StorageKeys.NAVIGATION);
+    const dataTabOrder = navigationData ? navigationData.tabOrder : [];
     const tabOrder = getTabOrder(this._verticalsConfig, dataTabOrder);
     const params = new SearchParams(window.location.search.substring(1));
     params.set('tabOrder', tabOrder);

--- a/tests/setup/managermocker.js
+++ b/tests/setup/managermocker.js
@@ -18,6 +18,11 @@ export default function mockManager (mockedCore) {
       get: () => {},
       delete: () => {}
     },
+    storage: {
+      set: () => {},
+      get: () => {},
+      registerListener: () => {}
+    },
     ...mockedCore
   };
   const COMPONENT_MANAGER = new MockComponentManager(core);


### PR DESCRIPTION
Also adds support for component.moduleId in ComponentManager using
the new storage, and adds support for new core in managermocker.js
for our jest tests.

J=SLAP-1019
TEST=manual

test that searching "amani farooque phone number" will reorder
the navigation component tabs to have the people vertical first
(this is with the rosetest experience)