### PR TITLE
Cut over UNIVERSAL_RESULTS to new global storage

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -259,8 +259,8 @@ export default class Core {
     this.globalStorage.set(StorageKeys.ALTERNATIVE_VERTICALS, new AlternativeVerticals({}));
     this.globalStorage.set(StorageKeys.DIRECT_ANSWER, new DirectAnswer({}));
     this.globalStorage.set(StorageKeys.LOCATION_BIAS, new LocationBias({}));
+    this.storage.set(StorageKeys.UNIVERSAL_RESULTS, new UniversalResults({}));
     this.storage.set(StorageKeys.VERTICAL_RESULTS, new VerticalResults({}));
-    this.globalStorage.set(StorageKeys.UNIVERSAL_RESULTS, new UniversalResults({}));
   }
 
   /**
@@ -291,7 +291,7 @@ export default class Core {
     }
 
     this.globalStorage.set(StorageKeys.DIRECT_ANSWER, {});
-    this.globalStorage.set(StorageKeys.UNIVERSAL_RESULTS, UniversalResults.searchLoading());
+    this.storage.set(StorageKeys.UNIVERSAL_RESULTS, UniversalResults.searchLoading());
     this.globalStorage.set(StorageKeys.QUESTION_SUBMISSION, {});
     this.globalStorage.set(StorageKeys.SPELL_CHECK, {});
     this.globalStorage.set(StorageKeys.LOCATION_BIAS, {});
@@ -314,7 +314,7 @@ export default class Core {
         this.globalStorage.set(StorageKeys.QUERY_ID, data[StorageKeys.QUERY_ID]);
         this.storage.set(StorageKeys.NAVIGATION, data[StorageKeys.NAVIGATION]);
         this.globalStorage.set(StorageKeys.DIRECT_ANSWER, data[StorageKeys.DIRECT_ANSWER]);
-        this.globalStorage.set(StorageKeys.UNIVERSAL_RESULTS, data[StorageKeys.UNIVERSAL_RESULTS], urls);
+        this.storage.set(StorageKeys.UNIVERSAL_RESULTS, data[StorageKeys.UNIVERSAL_RESULTS], urls);
         this.globalStorage.set(StorageKeys.INTENTS, data[StorageKeys.INTENTS]);
         this.globalStorage.set(StorageKeys.SPELL_CHECK, data[StorageKeys.SPELL_CHECK]);
         this.globalStorage.set(StorageKeys.LOCATION_BIAS, data[StorageKeys.LOCATION_BIAS]);

--- a/src/core/storage/storagekeys.js
+++ b/src/core/storage/storagekeys.js
@@ -8,7 +8,7 @@
  */
 export default {
   NAVIGATION: 'navigation', // Has been cut over to the new global storage
-  UNIVERSAL_RESULTS: 'universal-results',
+  UNIVERSAL_RESULTS: 'universal-results', // Has been cut over to the new global storage
   VERTICAL_RESULTS: 'vertical-results', // Has been cut over to the new global storage
   ALTERNATIVE_VERTICALS: 'alternative-verticals',
   AUTOCOMPLETE: 'autocomplete',

--- a/src/ui/components/questions/questionsubmissioncomponent.js
+++ b/src/ui/components/questions/questionsubmissioncomponent.js
@@ -223,7 +223,12 @@ export default class QuestionSubmissionComponent extends Component {
       storageKey: StorageKeys.VERTICAL_RESULTS,
       callback: onResultsUpdate
     });
-    this.core.globalStorage.on('update', StorageKeys.UNIVERSAL_RESULTS, onResultsUpdate);
+
+    this.core.storage.registerListener({
+      eventType: 'update',
+      storageKey: StorageKeys.UNIVERSAL_RESULTS,
+      callback: onResultsUpdate
+    });
   }
 
   /**

--- a/src/ui/components/results/universalresultscomponent.js
+++ b/src/ui/components/results/universalresultscomponent.js
@@ -26,7 +26,7 @@ export default class UniversalResultsComponent extends Component {
     };
 
     const reRender = () =>
-      this.setState(this.core.globalStorage.getState(StorageKeys.UNIVERSAL_RESULTS) || {});
+      this.setState(this.core.storage.get(StorageKeys.UNIVERSAL_RESULTS) || {});
     this.core.globalStorage.on('update', StorageKeys.API_CONTEXT, reRender);
     this.core.globalStorage.on('update', StorageKeys.SESSIONS_OPT_IN, reRender);
   }

--- a/tests/ui/components/questions/questionsubmissioncomponent.js
+++ b/tests/ui/components/questions/questionsubmissioncomponent.js
@@ -26,9 +26,19 @@ describe('QASubmission component', () => {
     const wrapper = mount(component);
     expect(wrapper.find('.yxt-QuestionSubmission')).toHaveLength(0);
     storage.set(StorageKeys.VERTICAL_RESULTS, {
-      searchState: SearchStates.SEARCH_COMPLETE,
-      resultsCount: 1,
-      results: ['result0']
+      searchState: SearchStates.SEARCH_COMPLETE
+    });
+    wrapper.update();
+    expect(wrapper.find('.yxt-QuestionSubmission')).toHaveLength(1);
+  });
+
+  it('listens to updates to UNIVERSAL_RESULTS in global storage', () => {
+    const storage = COMPONENT_MANAGER.core.storage;
+    const component = COMPONENT_MANAGER.create(QuestionSubmissionComponent.type, defaultConfig);
+    const wrapper = mount(component);
+    expect(wrapper.find('.yxt-QuestionSubmission')).toHaveLength(0);
+    storage.set(StorageKeys.UNIVERSAL_RESULTS, {
+      searchState: SearchStates.SEARCH_COMPLETE
     });
     wrapper.update();
     expect(wrapper.find('.yxt-QuestionSubmission')).toHaveLength(1);

--- a/tests/ui/components/results/universalresultscomponent.js
+++ b/tests/ui/components/results/universalresultscomponent.js
@@ -1,0 +1,33 @@
+import { mount } from 'enzyme';
+import mockManager from '../../../setup/managermocker';
+import DOM from '../../../../src/ui/dom/dom';
+import StorageKeys from '../../../../src/core/storage/storagekeys';
+import SearchStates from '../../../../src/core/storage/searchstates';
+import UniversalResultsComponent from '../../../../src/ui/components/results/universalresultscomponent';
+
+DOM.setup(document, new DOMParser());
+let COMPONENT_MANAGER, defaultConfig;
+beforeEach(() => {
+  COMPONENT_MANAGER = mockManager();
+  const bodyEl = DOM.query('body');
+  DOM.empty(bodyEl);
+  DOM.append(bodyEl, DOM.createEl('div', { id: 'test-component' }));
+
+  defaultConfig = {
+    container: '#test-component'
+  };
+});
+
+describe('UniversalResults component', () => {
+  it('listens to updates to UNIVERSAL_RESULTS in global storage', () => {
+    const storage = COMPONENT_MANAGER.core.storage;
+    const component = COMPONENT_MANAGER.create(UniversalResultsComponent.type, defaultConfig);
+    const wrapper = mount(component);
+    expect(wrapper.find('.universal-result-list')).toHaveLength(0);
+    storage.set(StorageKeys.UNIVERSAL_RESULTS, {
+      searchState: SearchStates.SEARCH_COMPLETE
+    });
+    wrapper.update();
+    expect(wrapper.find('.universal-result-list')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
J=SLAP-1019
TEST=manual

test that a universal page can still run searches, and that
I can search for "virginia", search for "office space", and then
hitting the back button will take me back to virginia

check that the qa submission component rerenders with universal
results, and is hidden while the search is loading