### PR TITLE
cut over ALTERNATIVE_VERTICALS to new global storage

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -210,7 +210,7 @@ export default class Core {
         this.globalStorage.set(StorageKeys.QUERY_ID, data[StorageKeys.QUERY_ID]);
         this.storage.set(StorageKeys.NAVIGATION, data[StorageKeys.NAVIGATION]);
         this.globalStorage.set(StorageKeys.INTENTS, data[StorageKeys.INTENTS]);
-        this.globalStorage.set(StorageKeys.ALTERNATIVE_VERTICALS, data[StorageKeys.ALTERNATIVE_VERTICALS]);
+        this.storage.set(StorageKeys.ALTERNATIVE_VERTICALS, data[StorageKeys.ALTERNATIVE_VERTICALS]);
 
         if (query.append) {
           const mergedResults = this.storage.get(StorageKeys.VERTICAL_RESULTS)
@@ -256,7 +256,7 @@ export default class Core {
     this.globalStorage.set(StorageKeys.QUESTION_SUBMISSION, new QuestionSubmission({}));
     this.globalStorage.set(StorageKeys.INTENTS, new SearchIntents({}));
     this.storage.set(StorageKeys.NAVIGATION, new Navigation());
-    this.globalStorage.set(StorageKeys.ALTERNATIVE_VERTICALS, new AlternativeVerticals({}));
+    this.storage.set(StorageKeys.ALTERNATIVE_VERTICALS, new AlternativeVerticals({}));
     this.globalStorage.set(StorageKeys.DIRECT_ANSWER, new DirectAnswer({}));
     this.globalStorage.set(StorageKeys.LOCATION_BIAS, new LocationBias({}));
     this.storage.set(StorageKeys.UNIVERSAL_RESULTS, new UniversalResults({}));

--- a/src/core/storage/storagekeys.js
+++ b/src/core/storage/storagekeys.js
@@ -10,7 +10,7 @@ export default {
   NAVIGATION: 'navigation', // Has been cut over to the new global storage
   UNIVERSAL_RESULTS: 'universal-results', // Has been cut over to the new global storage
   VERTICAL_RESULTS: 'vertical-results', // Has been cut over to the new global storage
-  ALTERNATIVE_VERTICALS: 'alternative-verticals',
+  ALTERNATIVE_VERTICALS: 'alternative-verticals', // Has been cut over to the new global storage
   AUTOCOMPLETE: 'autocomplete',
   DIRECT_ANSWER: 'direct-answer',
   FILTER: 'filter', // DEPRECATED

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -414,7 +414,7 @@ export default class VerticalResultsComponent extends Component {
       return super.addChild(updatedData, type, newOpts);
     } else if (type === AlternativeVerticalsComponent.type) {
       const hasResults = this.results && this.results.length > 0;
-      data = this.core.globalStorage.getState(StorageKeys.ALTERNATIVE_VERTICALS);
+      data = this.core.storage.get(StorageKeys.ALTERNATIVE_VERTICALS);
       const newOpts = {
         template: this._noResultsTemplate,
         baseUniversalUrl: this.getBaseUniversalUrl(),


### PR DESCRIPTION
J=SLAP-1019
TEST=manual

test that no results will still display when
I search for "office space" on the "people"
vertical (using the rosetest experience)
see that I still get a suggesstion for the KM vertical