### PR TITLE
cut over AUTOCOMPLETE to new global storage

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -259,8 +259,8 @@ export default class Core {
     this.globalStorage.set(StorageKeys.ALTERNATIVE_VERTICALS, new AlternativeVerticals({}));
     this.globalStorage.set(StorageKeys.DIRECT_ANSWER, new DirectAnswer({}));
     this.globalStorage.set(StorageKeys.LOCATION_BIAS, new LocationBias({}));
+    this.storage.set(StorageKeys.UNIVERSAL_RESULTS, new UniversalResults({}));
     this.storage.set(StorageKeys.VERTICAL_RESULTS, new VerticalResults({}));
-    this.globalStorage.set(StorageKeys.UNIVERSAL_RESULTS, new UniversalResults({}));
   }
 
   /**
@@ -291,7 +291,7 @@ export default class Core {
     }
 
     this.globalStorage.set(StorageKeys.DIRECT_ANSWER, {});
-    this.globalStorage.set(StorageKeys.UNIVERSAL_RESULTS, UniversalResults.searchLoading());
+    this.storage.set(StorageKeys.UNIVERSAL_RESULTS, UniversalResults.searchLoading());
     this.globalStorage.set(StorageKeys.QUESTION_SUBMISSION, {});
     this.globalStorage.set(StorageKeys.SPELL_CHECK, {});
     this.globalStorage.set(StorageKeys.LOCATION_BIAS, {});
@@ -314,7 +314,7 @@ export default class Core {
         this.globalStorage.set(StorageKeys.QUERY_ID, data[StorageKeys.QUERY_ID]);
         this.storage.set(StorageKeys.NAVIGATION, data[StorageKeys.NAVIGATION]);
         this.globalStorage.set(StorageKeys.DIRECT_ANSWER, data[StorageKeys.DIRECT_ANSWER]);
-        this.globalStorage.set(StorageKeys.UNIVERSAL_RESULTS, data[StorageKeys.UNIVERSAL_RESULTS], urls);
+        this.storage.set(StorageKeys.UNIVERSAL_RESULTS, data[StorageKeys.UNIVERSAL_RESULTS], urls);
         this.globalStorage.set(StorageKeys.INTENTS, data[StorageKeys.INTENTS]);
         this.globalStorage.set(StorageKeys.SPELL_CHECK, data[StorageKeys.SPELL_CHECK]);
         this.globalStorage.set(StorageKeys.LOCATION_BIAS, data[StorageKeys.LOCATION_BIAS]);

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -370,7 +370,7 @@ export default class Core {
     return this._autoComplete
       .queryUniversal(input)
       .then(data => {
-        this.globalStorage.set(`${StorageKeys.AUTOCOMPLETE}.${namespace}`, data);
+        this.storage.set(`${StorageKeys.AUTOCOMPLETE}.${namespace}`, data);
         return data;
       });
   }
@@ -387,7 +387,7 @@ export default class Core {
     return this._autoComplete
       .queryVertical(input, verticalKey)
       .then(data => {
-        this.globalStorage.set(`${StorageKeys.AUTOCOMPLETE}.${namespace}`, data);
+        this.storage.set(`${StorageKeys.AUTOCOMPLETE}.${namespace}`, data);
         return data;
       });
   }
@@ -405,7 +405,7 @@ export default class Core {
     return this._autoComplete
       .queryFilter(input, config)
       .then(data => {
-        this.globalStorage.set(`${StorageKeys.AUTOCOMPLETE}.${config.namespace}`, data);
+        this.storage.set(`${StorageKeys.AUTOCOMPLETE}.${config.namespace}`, data);
       });
   }
 

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -210,7 +210,7 @@ export default class Core {
         this.globalStorage.set(StorageKeys.QUERY_ID, data[StorageKeys.QUERY_ID]);
         this.storage.set(StorageKeys.NAVIGATION, data[StorageKeys.NAVIGATION]);
         this.globalStorage.set(StorageKeys.INTENTS, data[StorageKeys.INTENTS]);
-        this.globalStorage.set(StorageKeys.ALTERNATIVE_VERTICALS, data[StorageKeys.ALTERNATIVE_VERTICALS]);
+        this.storage.set(StorageKeys.ALTERNATIVE_VERTICALS, data[StorageKeys.ALTERNATIVE_VERTICALS]);
 
         if (query.append) {
           const mergedResults = this.storage.get(StorageKeys.VERTICAL_RESULTS)
@@ -256,7 +256,7 @@ export default class Core {
     this.globalStorage.set(StorageKeys.QUESTION_SUBMISSION, new QuestionSubmission({}));
     this.globalStorage.set(StorageKeys.INTENTS, new SearchIntents({}));
     this.storage.set(StorageKeys.NAVIGATION, new Navigation());
-    this.globalStorage.set(StorageKeys.ALTERNATIVE_VERTICALS, new AlternativeVerticals({}));
+    this.storage.set(StorageKeys.ALTERNATIVE_VERTICALS, new AlternativeVerticals({}));
     this.globalStorage.set(StorageKeys.DIRECT_ANSWER, new DirectAnswer({}));
     this.globalStorage.set(StorageKeys.LOCATION_BIAS, new LocationBias({}));
     this.storage.set(StorageKeys.UNIVERSAL_RESULTS, new UniversalResults({}));

--- a/src/core/storage/storagekeys.js
+++ b/src/core/storage/storagekeys.js
@@ -8,7 +8,7 @@
  */
 export default {
   NAVIGATION: 'navigation', // Has been cut over to the new global storage
-  UNIVERSAL_RESULTS: 'universal-results',
+  UNIVERSAL_RESULTS: 'universal-results', // Has been cut over to the new global storage
   VERTICAL_RESULTS: 'vertical-results', // Has been cut over to the new global storage
   ALTERNATIVE_VERTICALS: 'alternative-verticals',
   AUTOCOMPLETE: 'autocomplete',

--- a/src/core/storage/storagekeys.js
+++ b/src/core/storage/storagekeys.js
@@ -11,7 +11,7 @@ export default {
   UNIVERSAL_RESULTS: 'universal-results', // Has been cut over to the new global storage
   VERTICAL_RESULTS: 'vertical-results', // Has been cut over to the new global storage
   ALTERNATIVE_VERTICALS: 'alternative-verticals', // Has been cut over to the new global storage
-  AUTOCOMPLETE: 'autocomplete',
+  AUTOCOMPLETE: 'autocomplete', // Has been cut over to the new global storage
   DIRECT_ANSWER: 'direct-answer',
   FILTER: 'filter', // DEPRECATED
   STATIC_FILTER_NODE: 'static-filter-node',

--- a/src/core/storage/storagekeys.js
+++ b/src/core/storage/storagekeys.js
@@ -10,7 +10,7 @@ export default {
   NAVIGATION: 'navigation', // Has been cut over to the new global storage
   UNIVERSAL_RESULTS: 'universal-results', // Has been cut over to the new global storage
   VERTICAL_RESULTS: 'vertical-results', // Has been cut over to the new global storage
-  ALTERNATIVE_VERTICALS: 'alternative-verticals',
+  ALTERNATIVE_VERTICALS: 'alternative-verticals', // Has been cut over to the new global storage
   AUTOCOMPLETE: 'autocomplete',
   DIRECT_ANSWER: 'direct-answer',
   FILTER: 'filter', // DEPRECATED

--- a/src/ui/components/questions/questionsubmissioncomponent.js
+++ b/src/ui/components/questions/questionsubmissioncomponent.js
@@ -223,7 +223,12 @@ export default class QuestionSubmissionComponent extends Component {
       storageKey: StorageKeys.VERTICAL_RESULTS,
       callback: onResultsUpdate
     });
-    this.core.globalStorage.on('update', StorageKeys.UNIVERSAL_RESULTS, onResultsUpdate);
+
+    this.core.storage.registerListener({
+      eventType: 'update',
+      storageKey: StorageKeys.UNIVERSAL_RESULTS,
+      callback: onResultsUpdate
+    });
   }
 
   /**

--- a/src/ui/components/results/universalresultscomponent.js
+++ b/src/ui/components/results/universalresultscomponent.js
@@ -26,7 +26,7 @@ export default class UniversalResultsComponent extends Component {
     };
 
     const reRender = () =>
-      this.setState(this.core.globalStorage.getState(StorageKeys.UNIVERSAL_RESULTS) || {});
+      this.setState(this.core.storage.get(StorageKeys.UNIVERSAL_RESULTS) || {});
     this.core.globalStorage.on('update', StorageKeys.API_CONTEXT, reRender);
     this.core.globalStorage.on('update', StorageKeys.SESSIONS_OPT_IN, reRender);
   }

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -414,7 +414,7 @@ export default class VerticalResultsComponent extends Component {
       return super.addChild(updatedData, type, newOpts);
     } else if (type === AlternativeVerticalsComponent.type) {
       const hasResults = this.results && this.results.length > 0;
-      data = this.core.globalStorage.getState(StorageKeys.ALTERNATIVE_VERTICALS);
+      data = this.core.storage.get(StorageKeys.ALTERNATIVE_VERTICALS);
       const newOpts = {
         template: this._noResultsTemplate,
         baseUniversalUrl: this.getBaseUniversalUrl(),

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -687,7 +687,7 @@ export default class SearchComponent extends Component {
    */
   fetchQueryIntents (query) {
     const autocompleteData =
-      this.core.globalStorage.getState(`${StorageKeys.AUTOCOMPLETE}.${this._autoCompleteName}`);
+      this.core.storage.get(`${StorageKeys.AUTOCOMPLETE}.${this._autoCompleteName}`);
     if (!autocompleteData) {
       const autocompleteRequest = this._verticalKey
         ? this.core.autoCompleteVertical(

--- a/tests/ui/components/questions/questionsubmissioncomponent.js
+++ b/tests/ui/components/questions/questionsubmissioncomponent.js
@@ -24,13 +24,11 @@ describe('QASubmission component', () => {
     const storage = COMPONENT_MANAGER.core.storage;
     const component = COMPONENT_MANAGER.create(QuestionSubmissionComponent.type, defaultConfig);
     const wrapper = mount(component);
-    expect(wrapper.find('.yxt-QuestionSubmission')).toHaveLength(0);
+    expect(wrapper.find('.yxt-QuestionSubmission').exists()).toBeFalsy();
     storage.set(StorageKeys.VERTICAL_RESULTS, {
-      searchState: SearchStates.SEARCH_COMPLETE,
-      resultsCount: 1,
-      results: ['result0']
+      searchState: SearchStates.SEARCH_COMPLETE
     });
     wrapper.update();
-    expect(wrapper.find('.yxt-QuestionSubmission')).toHaveLength(1);
+    expect(wrapper.find('.yxt-QuestionSubmission').exists()).toBeTruthy();
   });
 });

--- a/tests/ui/components/questions/questionsubmissioncomponent.js
+++ b/tests/ui/components/questions/questionsubmissioncomponent.js
@@ -31,4 +31,16 @@ describe('QASubmission component', () => {
     wrapper.update();
     expect(wrapper.exists('.yxt-QuestionSubmission')).toBeTruthy();
   });
+
+  it('listens to updates to UNIVERSAL_RESULTS in global storage', () => {
+    const storage = COMPONENT_MANAGER.core.storage;
+    const component = COMPONENT_MANAGER.create(QuestionSubmissionComponent.type, defaultConfig);
+    const wrapper = mount(component);
+    expect(wrapper.exists('.yxt-QuestionSubmission')).toBeFalsy();
+    storage.set(StorageKeys.UNIVERSAL_RESULTS, {
+      searchState: SearchStates.SEARCH_COMPLETE
+    });
+    wrapper.update();
+    expect(wrapper.exists('.yxt-QuestionSubmission')).toBeTruthy();
+  });
 });

--- a/tests/ui/components/questions/questionsubmissioncomponent.js
+++ b/tests/ui/components/questions/questionsubmissioncomponent.js
@@ -24,11 +24,11 @@ describe('QASubmission component', () => {
     const storage = COMPONENT_MANAGER.core.storage;
     const component = COMPONENT_MANAGER.create(QuestionSubmissionComponent.type, defaultConfig);
     const wrapper = mount(component);
-    expect(wrapper.find('.yxt-QuestionSubmission').exists()).toBeFalsy();
+    expect(wrapper.exists('.yxt-QuestionSubmission')).toBeFalsy();
     storage.set(StorageKeys.VERTICAL_RESULTS, {
       searchState: SearchStates.SEARCH_COMPLETE
     });
     wrapper.update();
-    expect(wrapper.find('.yxt-QuestionSubmission').exists()).toBeTruthy();
+    expect(wrapper.exists('.yxt-QuestionSubmission')).toBeTruthy();
   });
 });

--- a/tests/ui/components/results/appliedfilterscomponent.js
+++ b/tests/ui/components/results/appliedfilterscomponent.js
@@ -28,7 +28,7 @@ describe('AppliedFilters component', () => {
     const storage = COMPONENT_MANAGER.core.storage;
     const component = COMPONENT_MANAGER.create(AppliedFiltersComponent.type, defaultConfig);
     const wrapper = mount(component);
-    expect(wrapper.find('.yxt-AppliedFilters')).toHaveLength(0);
+    expect(wrapper.exists('.yxt-AppliedFilters')).toBeFalsy();
     storage.set(StorageKeys.VERTICAL_RESULTS, {
       searchState: SearchStates.SEARCH_COMPLETE,
       appliedQueryFilters: [
@@ -40,6 +40,6 @@ describe('AppliedFilters component', () => {
       ]
     });
     wrapper.update();
-    expect(wrapper.find('.yxt-AppliedFilters')).toHaveLength(1);
+    expect(wrapper.exists('.yxt-AppliedFilters')).toBeTruthy();
   });
 });

--- a/tests/ui/components/results/paginationcomponent.js
+++ b/tests/ui/components/results/paginationcomponent.js
@@ -203,13 +203,13 @@ describe('properly interacts with storage', () => {
     storage.delete(StorageKeys.VERTICAL_RESULTS);
     const component = COMPONENT_MANAGER.create(PaginationComponent.type, defaultConfig);
     const wrapper = mount(component);
-    expect(wrapper.find('.yxt-Pagination')).toHaveLength(0);
+    expect(wrapper.exists('.yxt-Pagination')).toBeFalsy;
     storage.set(StorageKeys.VERTICAL_RESULTS, {
       searchState: SearchStates.SEARCH_COMPLETE,
       resultsCount: 21,
       results: Array.from({ length: 21 })
     });
     wrapper.update();
-    expect(wrapper.find('.yxt-Pagination')).toHaveLength(1);
+    expect(wrapper.exists('.yxt-Pagination')).toBeTruthy();
   });
 });

--- a/tests/ui/components/results/paginationcomponent.js
+++ b/tests/ui/components/results/paginationcomponent.js
@@ -203,7 +203,7 @@ describe('properly interacts with storage', () => {
     storage.delete(StorageKeys.VERTICAL_RESULTS);
     const component = COMPONENT_MANAGER.create(PaginationComponent.type, defaultConfig);
     const wrapper = mount(component);
-    expect(wrapper.exists('.yxt-Pagination')).toBeFalsy;
+    expect(wrapper.exists('.yxt-Pagination')).toBeFalsy();
     storage.set(StorageKeys.VERTICAL_RESULTS, {
       searchState: SearchStates.SEARCH_COMPLETE,
       resultsCount: 21,

--- a/tests/ui/components/results/universalresultscomponent.js
+++ b/tests/ui/components/results/universalresultscomponent.js
@@ -1,0 +1,33 @@
+import { mount } from 'enzyme';
+import mockManager from '../../../setup/managermocker';
+import DOM from '../../../../src/ui/dom/dom';
+import StorageKeys from '../../../../src/core/storage/storagekeys';
+import SearchStates from '../../../../src/core/storage/searchstates';
+import UniversalResultsComponent from '../../../../src/ui/components/results/universalresultscomponent';
+
+DOM.setup(document, new DOMParser());
+let COMPONENT_MANAGER, defaultConfig;
+beforeEach(() => {
+  COMPONENT_MANAGER = mockManager();
+  const bodyEl = DOM.query('body');
+  DOM.empty(bodyEl);
+  DOM.append(bodyEl, DOM.createEl('div', { id: 'test-component' }));
+
+  defaultConfig = {
+    container: '#test-component'
+  };
+});
+
+describe('UniversalResults component', () => {
+  it('listens to updates to UNIVERSAL_RESULTS in global storage', () => {
+    const storage = COMPONENT_MANAGER.core.storage;
+    const component = COMPONENT_MANAGER.create(UniversalResultsComponent.type, defaultConfig);
+    const wrapper = mount(component);
+    expect(wrapper.find('.universal-result-list')).toHaveLength(0);
+    storage.set(StorageKeys.UNIVERSAL_RESULTS, {
+      searchState: SearchStates.SEARCH_COMPLETE
+    });
+    wrapper.update();
+    expect(wrapper.find('.universal-result-list')).toHaveLength(1);
+  });
+});

--- a/tests/ui/components/results/verticalresultscountcomponent.js
+++ b/tests/ui/components/results/verticalresultscountcomponent.js
@@ -99,13 +99,13 @@ describe('results count component', () => {
     const storage = COMPONENT_MANAGER.core.storage;
     const component = COMPONENT_MANAGER.create(VerticalResultsCountComponent.type, defaultConfig);
     const wrapper = mount(component);
-    expect(wrapper.find('.yxt-VerticalResultsCount')).toHaveLength(0);
+    expect(wrapper.exists('.yxt-VerticalResultsCount')).toBeFalsy();
     storage.set(StorageKeys.VERTICAL_RESULTS, {
       searchState: SearchStates.SEARCH_COMPLETE,
       resultsCount: 3,
       results: ['a', 'b', 'cOoOoOkie']
     });
     wrapper.update();
-    expect(wrapper.find('.yxt-VerticalResultsCount')).toHaveLength(1);
+    expect(wrapper.exists('.yxt-VerticalResultsCount')).toBeTruthy();
   });
 });


### PR DESCRIPTION
TEST=manual

test that autocomplete still works for universal and vertical search

test that I can search for a filter in filtersearch, apply it, and
that the network tab shows a filter was applied to the query

test that I can search for a filter in the geolocation filter,
apply it, and that the network tab shows a filter was applied to the query