### PR TITLE
Fix search bar buttons on very small screens

### DIFF
--- a/src/ui/sass/modules/_SearchBar.scss
+++ b/src/ui/sass/modules/_SearchBar.scss
@@ -87,6 +87,7 @@ $searchbar-button-text-color-active: var(--yxt-searchbar-button-text-color-base)
 
     background-color: transparent;
     flex-grow: 1;
+    width: 100%;
     padding-top: calc(var(--yxt-base-spacing) / 2);
     padding-bottom: calc(var(--yxt-base-spacing) / 2);
     padding-left: var(--yxt-base-spacing);
@@ -121,6 +122,7 @@ $searchbar-button-text-color-active: var(--yxt-searchbar-button-text-color-base)
   &-clear
   {
     display: flex;
+    flex: 0 0 auto;
     align-items: center;
     font: inherit;
     padding-top: calc(var(--yxt-base-spacing) / 2);

--- a/src/ui/sass/modules/_SearchBar.scss
+++ b/src/ui/sass/modules/_SearchBar.scss
@@ -86,7 +86,6 @@ $searchbar-button-text-color-active: var(--yxt-searchbar-button-text-color-base)
     border: none;
 
     background-color: transparent;
-    flex-grow: 1;
     width: 100%;
     padding-top: calc(var(--yxt-base-spacing) / 2);
     padding-bottom: calc(var(--yxt-base-spacing) / 2);
@@ -122,7 +121,7 @@ $searchbar-button-text-color-active: var(--yxt-searchbar-button-text-color-base)
   &-clear
   {
     display: flex;
-    flex: 0 0 auto;
+    flex-shrink: 0;
     align-items: center;
     font: inherit;
     padding-top: calc(var(--yxt-base-spacing) / 2);


### PR DESCRIPTION
Fix the search bar styling so that the buttons don't disappear on small screens

On screens with very small widths (<350px width), the search bar clear and search buttons shrink and eventually disappear as the screen width decreases. This PR prevents the buttons from shrinking and disappearing on very small screens.

J=SLAP-999
TEST=visual

Build a site and view it at various sizes between 300px and 400px wide and confirm that the search bar buttons no longer shrink or disappear. Test on a browswerstack iphone 8 with safare and on a windows laptop on IE11.