### PR TITLE
cut over AUTOCOMPLETE to new global storage

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -370,7 +370,7 @@ export default class Core {
     return this._autoComplete
       .queryUniversal(input)
       .then(data => {
-        this.globalStorage.set(`${StorageKeys.AUTOCOMPLETE}.${namespace}`, data);
+        this.storage.set(`${StorageKeys.AUTOCOMPLETE}.${namespace}`, data);
         return data;
       });
   }
@@ -387,7 +387,7 @@ export default class Core {
     return this._autoComplete
       .queryVertical(input, verticalKey)
       .then(data => {
-        this.globalStorage.set(`${StorageKeys.AUTOCOMPLETE}.${namespace}`, data);
+        this.storage.set(`${StorageKeys.AUTOCOMPLETE}.${namespace}`, data);
         return data;
       });
   }
@@ -405,7 +405,7 @@ export default class Core {
     return this._autoComplete
       .queryFilter(input, config)
       .then(data => {
-        this.globalStorage.set(`${StorageKeys.AUTOCOMPLETE}.${config.namespace}`, data);
+        this.storage.set(`${StorageKeys.AUTOCOMPLETE}.${config.namespace}`, data);
       });
   }
 

--- a/src/core/storage/storagekeys.js
+++ b/src/core/storage/storagekeys.js
@@ -11,7 +11,7 @@ export default {
   UNIVERSAL_RESULTS: 'universal-results',
   VERTICAL_RESULTS: 'vertical-results',
   ALTERNATIVE_VERTICALS: 'alternative-verticals',
-  AUTOCOMPLETE: 'autocomplete',
+  AUTOCOMPLETE: 'autocomplete', // Has been cut over to the new global storage
   DIRECT_ANSWER: 'direct-answer',
   FILTER: 'filter', // DEPRECATED
   STATIC_FILTER_NODE: 'static-filter-node',

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -687,7 +687,7 @@ export default class SearchComponent extends Component {
    */
   fetchQueryIntents (query) {
     const autocompleteData =
-      this.core.globalStorage.getState(`${StorageKeys.AUTOCOMPLETE}.${this._autoCompleteName}`);
+      this.core.storage.get(`${StorageKeys.AUTOCOMPLETE}.${this._autoCompleteName}`);
     if (!autocompleteData) {
       const autocompleteRequest = this._verticalKey
         ? this.core.autoCompleteVertical(


### PR DESCRIPTION
J=SLAP-1019
TEST=manual

test that autocomplete still works for universal and vertical search

test that I can search for a filter in filtersearch, apply it, and
that the network tab shows a filter was applied to the query

test that I can search for a filter in the geolocation filter,
apply it, and that the network tab shows a filter was applied to the query