### PR TITLE
cut over FILTER to new global storage

### DIFF
--- a/src/core/storage/storagekeys.js
+++ b/src/core/storage/storagekeys.js
@@ -13,7 +13,7 @@ export default {
   ALTERNATIVE_VERTICALS: 'alternative-verticals',
   AUTOCOMPLETE: 'autocomplete',
   DIRECT_ANSWER: 'direct-answer',
-  FILTER: 'filter', // DEPRECATED
+  FILTER: 'filter', // DEPRECATED // Has been cut over to the new global storage
   STATIC_FILTER_NODE: 'static-filter-node',
   QUERY: 'query',
   QUERY_ID: 'query-id',

--- a/src/ui/components/search/filtersearchcomponent.js
+++ b/src/ui/components/search/filtersearchcomponent.js
@@ -106,7 +106,7 @@ export default class FilterSearchComponent extends Component {
      * Optionally provided
      * @type {string}
      */
-    this.filter = config.filter || this.core.globalStorage.getState(`${StorageKeys.FILTER}.${this.name}`);
+    this.filter = config.filter || this.core.storage.get(`${StorageKeys.FILTER}.${this.name}`);
     if (typeof this.filter === 'string') {
       try {
         this.filter = JSON.parse(this.filter);


### PR DESCRIPTION
J=SLAP-1019
TEST=manual

Test that I can use filtersearch to select a filter,
then if I refresh the page, the filter will still be applied
to the page, and also be displayed in the applied filters bar