### PR TITLE
cut over FilterRegistry to new global storage

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -88,7 +88,7 @@ export default class Core {
      * and facet filters from global storage.
      * @type {FilterRegistry}
      */
-    this.filterRegistry = new FilterRegistry(this.globalStorage);
+    this.filterRegistry = new FilterRegistry(this.storage);
 
     /**
      * An abstraction containing the integration with the RESTful search API

--- a/src/core/filters/filterregistry.js
+++ b/src/core/filters/filterregistry.js
@@ -4,6 +4,8 @@ import FilterNodeFactory from './filternodefactory';
 import Facet from '../models/facet';
 import StorageKeys from '../storage/storagekeys';
 
+/** @typedef {import('../storage/storage').default} GlobalStorage */
+
 /**
  * FilterRegistry is a structure that manages static {@link Filter}s and {@link Facet} filters.
  *
@@ -14,6 +16,7 @@ export default class FilterRegistry {
     /**
      * FilterRegistry uses {@link GlobalStorage} for storing FilterNodes.
      * Each node is given a unique key in global storage.
+     * @type {GlobalStorage}
      */
     this.globalStorage = globalStorage;
 
@@ -46,7 +49,13 @@ export default class FilterRegistry {
    * @returns {Array<FilterNode>}
    */
   getStaticFilterNodes () {
-    return this.globalStorage.getAll(StorageKeys.STATIC_FILTER_NODE);
+    const staticFilterNodes = [];
+    this.globalStorage.getAll().forEach((value, key) => {
+      if (key.startsWith(StorageKeys.STATIC_FILTER_NODE)) {
+        staticFilterNodes.push(value);
+      }
+    });
+    return staticFilterNodes;
   }
 
   /**
@@ -54,7 +63,7 @@ export default class FilterRegistry {
    * @returns {Array<FilterNode>}
    */
   getFacetFilterNodes () {
-    return this.globalStorage.getState(StorageKeys.FACET_FILTER_NODE) || [];
+    return this.globalStorage.get(StorageKeys.FACET_FILTER_NODE) || [];
   }
 
   /**
@@ -93,7 +102,7 @@ export default class FilterRegistry {
    * @param {string} key
    */
   getFilterNodeByKey (key) {
-    return this.globalStorage.getState(key);
+    return this.globalStorage.get(key);
   }
 
   /**

--- a/src/core/storage/storagekeys.js
+++ b/src/core/storage/storagekeys.js
@@ -14,10 +14,10 @@ export default {
   AUTOCOMPLETE: 'autocomplete', // Has been cut over to the new global storage
   DIRECT_ANSWER: 'direct-answer',
   FILTER: 'filter', // DEPRECATED // Has been cut over to the new global storage
-  STATIC_FILTER_NODE: 'static-filter-node',
+  STATIC_FILTER_NODE: 'static-filter-node', // Has been cut over to the new global storage
   QUERY: 'query',
   QUERY_ID: 'query-id',
-  FACET_FILTER_NODE: 'facet-filter-node',
+  FACET_FILTER_NODE: 'facet-filter-node', // Has been cut over to the new global storage
   DYNAMIC_FILTERS: 'dynamic-filters',
   PARAMS: 'params',
   GEOLOCATION: 'geolocation',
@@ -32,7 +32,7 @@ export default {
   LOCALE: 'locale',
   SORT_BYS: 'sort-bys', // Has been cut over to the new global storage
   NO_RESULTS_CONFIG: 'no-results-config',
-  LOCATION_RADIUS: 'location-radius',
+  LOCATION_RADIUS: 'location-radius', // Has been cut over to the new global storage
   RESULTS_HEADER: 'results-header',
   API_CONTEXT: 'context',
   REFERRER_PAGE_URL: 'referrerPageUrl',

--- a/tests/core/filters/filterregistry.js
+++ b/tests/core/filters/filterregistry.js
@@ -3,7 +3,7 @@ import FilterRegistry from '../../../src/core/filters/filterregistry';
 import FilterNodeFactory from '../../../src/core/filters/filternodefactory';
 import Facet from '../../../src/core/models/facet';
 import Filter from '../../../src/core/models/filter';
-import GlobalStorage from '../../../src/core/storage/globalstorage';
+import GlobalStorage from '../../../src/core/storage/storage';
 import FilterMetadata from '../../../src/core/filters/filtermetadata';
 import StorageKeys from '../../../src/core/storage/storagekeys';
 
@@ -39,7 +39,7 @@ describe('FilterRegistry', () => {
       metadata: metadata2
     });
 
-    registry = new FilterRegistry(new GlobalStorage());
+    registry = new FilterRegistry(new GlobalStorage().init());
   });
 
   it('returns empty array for getStaticFilterNodes when no values set', () => {


### PR DESCRIPTION
This commit cuts over the STATIC_FILTER_NODE,
FACET_FILTER_NODE, and LOCATION_RADIUS storage keys
to the new global storage. This is done by updating
FilterRegistry to use the new storage.

J=SLAP-1019
TEST=manual

Test that I can set a static filter, distance filter, and facets
test that I can reset all of them through removable filters