### PR TITLE
Spellcheck storage deletion tests

### DIFF
--- a/tests/ui/components/search/spellcheckcomponent.js
+++ b/tests/ui/components/search/spellcheckcomponent.js
@@ -3,9 +3,12 @@ import mockManager from '../../../setup/managermocker';
 import StorageKeys from '../../../../src/core/storage/storagekeys';
 import SpellCheckComponent from '../../../../src/ui/components/search/spellcheckcomponent';
 import GlobalStorage from '../../../../src/core/storage/globalstorage';
+import PersistentStorage from '../../../../src/ui/storage/persistentstorage';
+import QueryTriggers from '../../../../src/core/models/querytriggers';
 
 const mockCore = {
-  globalStorage: new GlobalStorage()
+  globalStorage: new GlobalStorage(),
+  persistentStorage: new PersistentStorage()
 };
 
 const COMPONENT_MANAGER = mockManager(mockCore);
@@ -40,6 +43,33 @@ describe('spellcheck redirect links', () => {
   it('redirect links contain a query trigger url param', () => {
     const queryTrigger = linkUrlParams.get(StorageKeys.QUERY_TRIGGER);
     expect(queryTrigger).toEqual('suggest');
+  });
+});
+
+describe('spellcheck interaction with storage', () => {
+  setupDOM();
+
+  const persistentStorage = COMPONENT_MANAGER.core.persistentStorage;
+
+  it('creating a spellcheck component deletes skipSpellCheck from persistent storage', () => {
+    const SKIP_SPELL_CHECK = 'skipSpellCheck';
+    persistentStorage.set(SKIP_SPELL_CHECK, true);
+
+    expect(persistentStorage.get(SKIP_SPELL_CHECK)).toBeTruthy();
+
+    createSpellcheckComponent();
+
+    expect(persistentStorage.get(SKIP_SPELL_CHECK)).toBeFalsy();
+  });
+
+  it('creating a spellcheck component deletes queryTrigger from persistent storage', () => {
+    persistentStorage.set(StorageKeys.QUERY_TRIGGER, QueryTriggers.QUERY_PARAMETER);
+
+    expect(persistentStorage.get(StorageKeys.QUERY_TRIGGER)).toBeTruthy();
+
+    createSpellcheckComponent();
+
+    expect(persistentStorage.get(StorageKeys.QUERY_TRIGGER)).toBeFalsy();
   });
 });
 


### PR DESCRIPTION
Add tests that confirm the spellcheck component deletes 'skipSpellCheck' and and 'queryTrigger' values from persistent storage when the component is created

J=SLAP-1005
TEST=auto