### PR TITLE
storage: use new setEntries for resetListener and post-search

### DIFF
--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -182,6 +182,7 @@ class Answers {
           this.core.globalStorage.set(StorageKeys.SEARCH_OFFSET, 0);
         }
         globalStorage.setAll(data);
+        this.core.storage.setEntries(new Map(Object.entries(data)));
       }
     });
     globalStorage.setAll(persistentStorage.getAll());

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -207,17 +207,18 @@ export default class Core {
       })
       .then(response => SearchDataTransformer.transformVertical(response, this._fieldFormatters, verticalKey))
       .then(data => {
+        const storageData = new Map();
         this.globalStorage.set(StorageKeys.QUERY_ID, data[StorageKeys.QUERY_ID]);
-        this.storage.set(StorageKeys.NAVIGATION, data[StorageKeys.NAVIGATION]);
+        storageData.set(StorageKeys.NAVIGATION, data[StorageKeys.NAVIGATION]);
         this.globalStorage.set(StorageKeys.INTENTS, data[StorageKeys.INTENTS]);
-        this.storage.set(StorageKeys.ALTERNATIVE_VERTICALS, data[StorageKeys.ALTERNATIVE_VERTICALS]);
+        storageData.set(StorageKeys.ALTERNATIVE_VERTICALS, data[StorageKeys.ALTERNATIVE_VERTICALS]);
 
         if (query.append) {
           const mergedResults = this.storage.get(StorageKeys.VERTICAL_RESULTS)
             .append(data[StorageKeys.VERTICAL_RESULTS]);
-          this.storage.set(StorageKeys.VERTICAL_RESULTS, mergedResults);
+          storageData.set(StorageKeys.VERTICAL_RESULTS, mergedResults);
         } else {
-          this.storage.set(StorageKeys.VERTICAL_RESULTS, data[StorageKeys.VERTICAL_RESULTS]);
+          storageData.set(StorageKeys.VERTICAL_RESULTS, data[StorageKeys.VERTICAL_RESULTS]);
         }
 
         if (data[StorageKeys.DYNAMIC_FILTERS]) {
@@ -232,6 +233,7 @@ export default class Core {
         }
         this.globalStorage.delete('skipSpellCheck');
         this.globalStorage.delete(StorageKeys.QUERY_TRIGGER);
+        this.storage.setEntries(storageData);
 
         const exposedParams = {
           verticalKey: verticalKey,
@@ -248,6 +250,7 @@ export default class Core {
   }
 
   clearResults () {
+    const storageData = new Map();
     this.globalStorage.set(StorageKeys.QUERY, null);
     this.globalStorage.set(StorageKeys.QUERY_ID, '');
     this.globalStorage.set(StorageKeys.RESULTS_HEADER, {});
@@ -255,12 +258,13 @@ export default class Core {
     this.globalStorage.set(StorageKeys.DYNAMIC_FILTERS, {}); // TODO has a model but not cleared w new
     this.globalStorage.set(StorageKeys.QUESTION_SUBMISSION, new QuestionSubmission({}));
     this.globalStorage.set(StorageKeys.INTENTS, new SearchIntents({}));
-    this.storage.set(StorageKeys.NAVIGATION, new Navigation());
-    this.storage.set(StorageKeys.ALTERNATIVE_VERTICALS, new AlternativeVerticals({}));
+    storageData.set(StorageKeys.NAVIGATION, new Navigation());
+    storageData.set(StorageKeys.ALTERNATIVE_VERTICALS, new AlternativeVerticals({}));
     this.globalStorage.set(StorageKeys.DIRECT_ANSWER, new DirectAnswer({}));
     this.globalStorage.set(StorageKeys.LOCATION_BIAS, new LocationBias({}));
-    this.storage.set(StorageKeys.VERTICAL_RESULTS, new VerticalResults({}));
+    storageData.set(StorageKeys.VERTICAL_RESULTS, new VerticalResults({}));
     this.globalStorage.set(StorageKeys.UNIVERSAL_RESULTS, new UniversalResults({}));
+    this.storage.setEntries(storageData);
   }
 
   /**

--- a/src/core/storage/storage.js
+++ b/src/core/storage/storage.js
@@ -47,7 +47,7 @@ export default class GlobalStorage {
     this.persistentStorage = new DefaultPersistentStorage(this.popListener);
 
     /**
-     * A map of storage key to StorageListener, which apply on
+     * A map of storage key to StorageListener[], which apply on
      * changes to global storage.
      *
      * @type {Map<string, StorageListener[]>}

--- a/src/core/storage/storage.js
+++ b/src/core/storage/storage.js
@@ -50,7 +50,7 @@ export default class GlobalStorage {
      * A map of storage key to StorageListener, which apply on
      * changes to global storage.
      *
-     * @type {Map<string, Array<StorageListener[]>}
+     * @type {Map<string, StorageListener[]>}
      */
     this.listeners = new Map();
   }

--- a/src/core/storage/storage.js
+++ b/src/core/storage/storage.js
@@ -50,7 +50,7 @@ export default class GlobalStorage {
      * A map of storage key to StorageListener, which apply on
      * changes to global storage.
      *
-     * @type {Map<string, Array<StorageListener[]?>}
+     * @type {Map<string, Array<StorageListener[]>}
      */
     this.listeners = new Map();
   }

--- a/tests/core/storage/storage.js
+++ b/tests/core/storage/storage.js
@@ -445,14 +445,14 @@ describe('setEntries', () => {
   it('calls listeners only AFTER all data has been updated', () => {
     const callbackA = jest.fn();
     const callbackB = jest.fn();
-    storage.registerListener(new StorageListener('update', 'aKey', callbackA));
-    storage.registerListener(new StorageListener('update', 'bKey', callbackB));
+    storage.registerListener(new StorageListener('update', 'aKey', () => callbackA(storage.get('bKey'))));
+    storage.registerListener(new StorageListener('update', 'bKey', () => callbackB(storage.get('bKey'))));
     const entries = new Map(Object.entries({
       'aKey': 'aa',
       'bKey': 'bb'
     }));
     storage.setEntries(entries);
-    expect(callbackA).toHaveBeenCalledWith('aa');
+    expect(callbackA).toHaveBeenCalledWith('bb');
     expect(callbackB).toHaveBeenCalledWith('bb');
   });
 });

--- a/tests/core/storage/storage.js
+++ b/tests/core/storage/storage.js
@@ -440,3 +440,19 @@ describe('getUrlWithCurrentState', () => {
     expect(storage.getUrlWithCurrentState()).toEqual('query=val2');
   });
 });
+
+describe('setEntries', () => {
+  it('calls listeners only AFTER all data has been updated', () => {
+    const callbackA = jest.fn();
+    const callbackB = jest.fn();
+    storage.registerListener(new StorageListener('update', 'aKey', callbackA));
+    storage.registerListener(new StorageListener('update', 'bKey', callbackB));
+    const entries = new Map(Object.entries({
+      'aKey': 'aa',
+      'bKey': 'bb'
+    }));
+    storage.setEntries(entries);
+    expect(callbackA).toHaveBeenCalledWith('aa');
+    expect(callbackB).toHaveBeenCalledWith('bb');
+  });
+});

--- a/tests/core/storage/storage.js
+++ b/tests/core/storage/storage.js
@@ -445,14 +445,20 @@ describe('setEntries', () => {
   it('calls listeners only AFTER all data has been updated', () => {
     const callbackA = jest.fn();
     const callbackB = jest.fn();
-    storage.registerListener(new StorageListener('update', 'aKey', () => callbackA(storage.get('bKey'))));
-    storage.registerListener(new StorageListener('update', 'bKey', () => callbackB(storage.get('bKey'))));
+    const listenerA = new StorageListener('update', 'aKey', () => {
+      callbackA(storage.get('aKey'), storage.get('bKey'));
+    });
+    const listenerB = new StorageListener('update', 'bKey', () => {
+      callbackB(storage.get('aKey'), storage.get('bKey'));
+    });
+    storage.registerListener(listenerA);
+    storage.registerListener(listenerB);
     const entries = new Map(Object.entries({
       'aKey': 'aa',
       'bKey': 'bb'
     }));
     storage.setEntries(entries);
-    expect(callbackA).toHaveBeenCalledWith('bb');
-    expect(callbackB).toHaveBeenCalledWith('bb');
+    expect(callbackA).toHaveBeenCalledWith('aa', 'bb');
+    expect(callbackB).toHaveBeenCalledWith('aa', 'bb');
   });
 });


### PR DESCRIPTION
This commit updates the current persistent storage resetListener
to also reseed the new storage in addition with the old storage.

To do this a new setEntries() method was added to the new storage,
which will set all entries given BEFORE calling any listeners, so
we don't need to worry about the order of storage listeners are called
anymore (see logic around StorageKeys.QUERY in  current
GlobalStorage's setAll()).
This was also added to core.search() and core.verticalSearch().

It also refactors the new storage listeners to be a map of
storage key to listener, so that setEntries() doesn't do a
double for loop when calling listeners.

J=SLAP-869
TEST=manual,auto

test that after searching for "virginia", then searching for "technology",
then hitting backspace, that ANSWERS.core.storage.get('query') returns
"virginia"

unit test that makes sure setEntries() will only call listeners after all data has been updated