### PR TITLE
cut over QUERY_ID to new global storage

### DIFF
--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -168,6 +168,7 @@ class Answers {
     parsedConfig.search = new SearchConfig(parsedConfig.search);
     parsedConfig.verticalPages = new VerticalPagesConfig(parsedConfig.verticalPages);
 
+    const storage = new Storage().init(window.location.search);
     const globalStorage = new GlobalStorage();
     const persistentStorage = new PersistentStorage({
       updateListener: parsedConfig.onStateChange,
@@ -247,15 +248,15 @@ class Answers {
         parsedConfig.environment);
 
       // listen to query id updates
-      globalStorage.on('update', StorageKeys.QUERY_ID, id =>
-        this._analyticsReporterService.setQueryId(id)
-      );
+      storage.registerListener({
+        eventType: 'update',
+        storageKey: StorageKeys.QUERY_ID,
+        callback: id => this._analyticsReporterService.setQueryId(id)
+      });
 
       this.components.setAnalyticsReporter(this._analyticsReporterService);
       initScrollListener(this._analyticsReporterService);
     }
-
-    const storage = new Storage().init(window.location.search);
 
     this.core = new Core({
       apiKey: parsedConfig.apiKey,

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -207,7 +207,7 @@ export default class Core {
       })
       .then(response => SearchDataTransformer.transformVertical(response, this._fieldFormatters, verticalKey))
       .then(data => {
-        this.globalStorage.set(StorageKeys.QUERY_ID, data[StorageKeys.QUERY_ID]);
+        this.storage.set(StorageKeys.QUERY_ID, data[StorageKeys.QUERY_ID]);
         this.storage.set(StorageKeys.NAVIGATION, data[StorageKeys.NAVIGATION]);
         this.globalStorage.set(StorageKeys.INTENTS, data[StorageKeys.INTENTS]);
         this.storage.set(StorageKeys.ALTERNATIVE_VERTICALS, data[StorageKeys.ALTERNATIVE_VERTICALS]);
@@ -249,7 +249,7 @@ export default class Core {
 
   clearResults () {
     this.globalStorage.set(StorageKeys.QUERY, null);
-    this.globalStorage.set(StorageKeys.QUERY_ID, '');
+    this.storage.set(StorageKeys.QUERY_ID, '');
     this.globalStorage.set(StorageKeys.RESULTS_HEADER, {});
     this.globalStorage.set(StorageKeys.SPELL_CHECK, {}); // TODO has a model but not cleared w new
     this.globalStorage.set(StorageKeys.DYNAMIC_FILTERS, {}); // TODO has a model but not cleared w new
@@ -271,7 +271,7 @@ export default class Core {
    */
   verticalPage (verticalKey) {
     this.verticalSearch(verticalKey, { useFacets: true, setQueryParams: true }, {
-      id: this.globalStorage.getState(StorageKeys.QUERY_ID)
+      id: this.storage.get(StorageKeys.QUERY_ID)
     });
   }
 
@@ -311,7 +311,7 @@ export default class Core {
       })
       .then(response => SearchDataTransformer.transform(response, urls, this._fieldFormatters))
       .then(data => {
-        this.globalStorage.set(StorageKeys.QUERY_ID, data[StorageKeys.QUERY_ID]);
+        this.storage.set(StorageKeys.QUERY_ID, data[StorageKeys.QUERY_ID]);
         this.storage.set(StorageKeys.NAVIGATION, data[StorageKeys.NAVIGATION]);
         this.globalStorage.set(StorageKeys.DIRECT_ANSWER, data[StorageKeys.DIRECT_ANSWER]);
         this.globalStorage.set(StorageKeys.UNIVERSAL_RESULTS, data[StorageKeys.UNIVERSAL_RESULTS], urls);
@@ -465,7 +465,7 @@ export default class Core {
    * @param {string} queryId The query id to store
    */
   setQueryId (queryId) {
-    this.globalStorage.set(StorageKeys.QUERY_ID, queryId);
+    this.storage.set(StorageKeys.QUERY_ID, queryId);
   }
 
   /**

--- a/src/core/storage/storagekeys.js
+++ b/src/core/storage/storagekeys.js
@@ -16,7 +16,7 @@ export default {
   FILTER: 'filter', // DEPRECATED // Has been cut over to the new global storage
   STATIC_FILTER_NODE: 'static-filter-node', // Has been cut over to the new global storage
   QUERY: 'query',
-  QUERY_ID: 'query-id',
+  QUERY_ID: 'query-id', // Has been cut over to the new global storage
   FACET_FILTER_NODE: 'facet-filter-node', // Has been cut over to the new global storage
   DYNAMIC_FILTERS: 'dynamic-filters',
   PARAMS: 'params',

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -713,7 +713,7 @@ export default class SearchComponent extends Component {
    * analytics event.
    */
   eventOptions () {
-    const queryId = this.core.globalStorage.getState(StorageKeys.QUERY_ID);
+    const queryId = this.core.storage.get(StorageKeys.QUERY_ID);
     const options = Object.assign(
       {},
       queryId && { queryId },


### PR DESCRIPTION
J=SLAP-1019
TEST=manual

test that I can run a search, and then the query id
of that search will be sent in the SCROLL_TO_BOTTOM_OF_PAGE
event

test that I can run a new search, log the new query id in the console,
and then scrolling to bottom will use the new query id