### PR TITLE
cut over GEOLOCATION to new global storage

### DIFF
--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -492,7 +492,7 @@ class Answers {
    * @param {number} long
    */
   setGeolocation (lat, lng) {
-    this.core.globalStorage.set(StorageKeys.GEOLOCATION, {
+    this.core.storage.set(StorageKeys.GEOLOCATION, {
       lat, lng, radius: 0
     });
   }

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -190,7 +190,7 @@ export default class Core {
     return this._searcher
       .verticalSearch(verticalKey, {
         limit: this.globalStorage.getState(StorageKeys.SEARCH_CONFIG).limit,
-        geolocation: this.globalStorage.getState(StorageKeys.GEOLOCATION),
+        geolocation: this.storage.get(StorageKeys.GEOLOCATION),
         ...parsedQuery,
         filter: this.filterRegistry.getStaticFilterPayload(),
         facetFilter: this.filterRegistry.getFacetFilterPayload(),
@@ -301,7 +301,7 @@ export default class Core {
     );
     return this._searcher
       .universalSearch(queryString, {
-        geolocation: this.globalStorage.getState(StorageKeys.GEOLOCATION),
+        geolocation: this.storage.get(StorageKeys.GEOLOCATION),
         skipSpellCheck: this.globalStorage.getState('skipSpellCheck'),
         queryTrigger: queryTrigger,
         sessionTrackingEnabled: this.globalStorage.getState(StorageKeys.SESSIONS_OPT_IN).value,

--- a/src/core/storage/storagekeys.js
+++ b/src/core/storage/storagekeys.js
@@ -19,8 +19,7 @@ export default {
   QUERY_ID: 'query-id',
   FACET_FILTER_NODE: 'facet-filter-node', // Has been cut over to the new global storage
   DYNAMIC_FILTERS: 'dynamic-filters',
-  PARAMS: 'params',
-  GEOLOCATION: 'geolocation',
+  GEOLOCATION: 'geolocation', // Has been cut over to the new global storage
   INTENTS: 'intents',
   QUESTION_SUBMISSION: 'question-submission',
   SEARCH_CONFIG: 'search-config',

--- a/src/ui/components/filters/geolocationcomponent.js
+++ b/src/ui/components/filters/geolocationcomponent.js
@@ -300,7 +300,7 @@ export default class GeoLocationComponent extends Component {
     this.core.setStaticFilterNodes(this.name, filterNode);
 
     if (position) {
-      this.core.globalStorage.set(StorageKeys.GEOLOCATION, {
+      this.core.storage.set(StorageKeys.GEOLOCATION, {
         lat: position.coords.latitude,
         lng: position.coords.longitude,
         radius: position.coords.accuracy

--- a/src/ui/components/search/locationbiascomponent.js
+++ b/src/ui/components/search/locationbiascomponent.js
@@ -96,7 +96,7 @@ export default class LocationBiasComponent extends Component {
     DOM.on(this._updateLocationEl, 'click', (e) => {
       if ('geolocation' in navigator) {
         navigator.geolocation.getCurrentPosition((position) => {
-          this.core.globalStorage.set(StorageKeys.GEOLOCATION, {
+          this.core.storage.set(StorageKeys.GEOLOCATION, {
             lat: position.coords.latitude,
             lng: position.coords.longitude,
             radius: position.coords.accuracy
@@ -177,7 +177,7 @@ export default class LocationBiasComponent extends Component {
   }
 
   _disableLocationUpdate () {
-    this.core.globalStorage.delete(StorageKeys.GEOLOCATION);
+    this.core.storage.delete(StorageKeys.GEOLOCATION);
     this._allowUpdate = false;
     this.setState({
       locationDisplayName: this._locationDisplayName,

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -608,11 +608,11 @@ export default class SearchComponent extends Component {
       this.fetchQueryIntents(query)
         .then(queryIntents => queryIntents.includes('NEAR_ME'))
         .then(queryHasNearMeIntent => {
-          if (queryHasNearMeIntent && !this.core.globalStorage.getState(StorageKeys.GEOLOCATION)) {
+          if (queryHasNearMeIntent && !this.core.storage.get(StorageKeys.GEOLOCATION)) {
             return new Promise((resolve, reject) =>
               navigator.geolocation.getCurrentPosition(
                 position => {
-                  this.core.globalStorage.set(StorageKeys.GEOLOCATION, {
+                  this.core.storage.set(StorageKeys.GEOLOCATION, {
                     lat: position.coords.latitude,
                     lng: position.coords.longitude,
                     radius: position.coords.accuracy


### PR DESCRIPTION
TEST=manual

test ANSWERS.setGeolocation(31, 99) in ANSWERS.init, see my location
being recognized as in china in the location bias component

test clicking the location bias component will rerun the search
and set my location to VA

test that after clicking the location bias component, selecting "block"
when prompted for location will prevent the location update and hide
the button

test clicking the geolocation filter will rerun a search and
set my location to VA. the filtersearch half of the geolocation filter
doesn't set GEOLOCATIOn, and instead adds a new static filter, as expected

test that running a near me search will trigger a search with a location
param. this will not happen if ANSWERS.setGeolocation was already ran,
which is expected.