### PR TITLE
cut over NO_RESULTS_CONFIG to new storage

### DIFF
--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -168,6 +168,7 @@ class Answers {
     parsedConfig.search = new SearchConfig(parsedConfig.search);
     parsedConfig.verticalPages = new VerticalPagesConfig(parsedConfig.verticalPages);
 
+    const storage = new Storage().init(window.location.search);
     const globalStorage = new GlobalStorage();
     const persistentStorage = new PersistentStorage({
       updateListener: parsedConfig.onStateChange,
@@ -205,7 +206,7 @@ class Answers {
         { value: (/^true$/i).test(sessionOptIn), setDynamically: true });
     }
 
-    parsedConfig.noResults && globalStorage.set(StorageKeys.NO_RESULTS_CONFIG, parsedConfig.noResults);
+    parsedConfig.noResults && storage.set(StorageKeys.NO_RESULTS_CONFIG, parsedConfig.noResults);
     const isSuggestQueryTrigger =
       globalStorage.getState(StorageKeys.QUERY_TRIGGER) === QueryTriggers.SUGGEST;
     if (globalStorage.getState(StorageKeys.QUERY) && !isSuggestQueryTrigger) {
@@ -254,8 +255,6 @@ class Answers {
       this.components.setAnalyticsReporter(this._analyticsReporterService);
       initScrollListener(this._analyticsReporterService);
     }
-
-    const storage = new Storage().init(window.location.search);
 
     this.core = new Core({
       apiKey: parsedConfig.apiKey,

--- a/src/core/storage/storagekeys.js
+++ b/src/core/storage/storagekeys.js
@@ -31,7 +31,7 @@ export default {
   VERTICAL_PAGES_CONFIG: 'vertical-pages-config',
   LOCALE: 'locale',
   SORT_BYS: 'sort-bys', // Has been cut over to the new global storage
-  NO_RESULTS_CONFIG: 'no-results-config',
+  NO_RESULTS_CONFIG: 'no-results-config', // Has been cut over to the new global storage
   LOCATION_RADIUS: 'location-radius', // Has been cut over to the new global storage
   RESULTS_HEADER: 'results-header',
   API_CONTEXT: 'context',

--- a/src/ui/components/map/mapcomponent.js
+++ b/src/ui/components/map/mapcomponent.js
@@ -29,7 +29,7 @@ export default class MapComponent extends Component {
       displayAllResults: false,
       visible: undefined,
       template: '',
-      ...(opts.noResults || this.core.globalStorage.getState(StorageKeys.NO_RESULTS_CONFIG))
+      ...(opts.noResults || this.core.storage.get(StorageKeys.NO_RESULTS_CONFIG))
     };
 
     /**

--- a/src/ui/components/results/paginationcomponent.js
+++ b/src/ui/components/results/paginationcomponent.js
@@ -136,7 +136,7 @@ export default class PaginationComponent extends Component {
      * Configuration for the behavior when there are no vertical results.
      */
     this._noResults = config.noResults ||
-      this.core.globalStorage.getState(StorageKeys.NO_RESULTS_CONFIG) ||
+      this.core.storage.get(StorageKeys.NO_RESULTS_CONFIG) ||
       {};
   }
 

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -178,7 +178,7 @@ export default class VerticalResultsComponent extends Component {
     super(new VerticalResultsConfig(APPLY_SYNONYMS(config)), systemConfig);
 
     const noResultsConfig = this._config.noResults ||
-      this.core.globalStorage.getState(StorageKeys.NO_RESULTS_CONFIG);
+      this.core.storage.get(StorageKeys.NO_RESULTS_CONFIG);
     /**
      * A parsed version of the noResults config provided to the component.
      * Applies sensible defaults if certain values are not set.

--- a/tests/ui/components/map/mapcomponent.js
+++ b/tests/ui/components/map/mapcomponent.js
@@ -3,8 +3,8 @@ import MapComponent from '../../../../src/ui/components/map/mapcomponent';
 describe('map component config', () => {
   let defaultConfig;
   const core = {
-    globalStorage: {
-      getState: () => {}
+    storage: {
+      get: () => {}
     }
   };
   const systemConfig = { core };

--- a/tests/ui/components/results/paginationcomponent.js
+++ b/tests/ui/components/results/paginationcomponent.js
@@ -17,6 +17,7 @@ const createCore = () => {
   const persistentStorage = {};
   const storage = new Storage().init();
   storage.set(StorageKeys.VERTICAL_RESULTS, { searchState: SearchStates.SEARCH_COMPLETE, resultsCount: 21 });
+  storage.set(StorageKeys.NO_RESULTS_CONFIG, { displayAllResults: true });
 
   return {
     verticalSearch: () => {},

--- a/tests/ui/components/results/paginationcomponent.js
+++ b/tests/ui/components/results/paginationcomponent.js
@@ -11,8 +11,7 @@ const createCore = () => {
   // pagination will hide itself if there are no results, so we fake the relevant global storage.
   const globalStorage = {
     [StorageKeys.SEARCH_OFFSET]: 0,
-    [StorageKeys.SEARCH_CONFIG]: { limit: 5 },
-    [StorageKeys.NO_RESULTS_CONFIG]: { displayAllResults: true }
+    [StorageKeys.SEARCH_CONFIG]: { limit: 5 }
   };
   const persistentStorage = {};
   const storage = new Storage().init();


### PR DESCRIPTION
TEST=manual

see that vertical results will use the global no results config's template
setting, and also displayAllResults will control whether to view all possible
results

see that pagination will use the global no results config's visible
setting