### PR TITLE
cut over API_CONTEXT to new global storage

### DIFF
--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -168,6 +168,7 @@ class Answers {
     parsedConfig.search = new SearchConfig(parsedConfig.search);
     parsedConfig.verticalPages = new VerticalPagesConfig(parsedConfig.verticalPages);
 
+    const storage = new Storage().init(window.location.search);
     const globalStorage = new GlobalStorage();
     const persistentStorage = new PersistentStorage({
       updateListener: parsedConfig.onStateChange,
@@ -212,10 +213,10 @@ class Answers {
       globalStorage.set(StorageKeys.QUERY_TRIGGER, QueryTriggers.QUERY_PARAMETER);
     }
 
-    const context = globalStorage.getState(StorageKeys.API_CONTEXT);
+    const context = storage.get(StorageKeys.API_CONTEXT);
     if (context && !isValidContext(context)) {
       persistentStorage.delete(StorageKeys.API_CONTEXT, true);
-      globalStorage.delete(StorageKeys.API_CONTEXT);
+      storage.delete(StorageKeys.API_CONTEXT);
       console.error(`Context parameter "${context}" is invalid, omitting from the search.`);
     }
 
@@ -254,8 +255,6 @@ class Answers {
       this.components.setAnalyticsReporter(this._analyticsReporterService);
       initScrollListener(this._analyticsReporterService);
     }
-
-    const storage = new Storage().init(window.location.search);
 
     this.core = new Core({
       apiKey: parsedConfig.apiKey,
@@ -560,7 +559,7 @@ class Answers {
       return;
     }
 
-    this.core.globalStorage.set(StorageKeys.API_CONTEXT, contextString);
+    this.core.storage.set(StorageKeys.API_CONTEXT, contextString);
   }
 
   /**

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -159,7 +159,7 @@ export default class Core {
     }
 
     const { setQueryParams } = options;
-    const context = this.globalStorage.getState(StorageKeys.API_CONTEXT);
+    const context = this.storage.get(StorageKeys.API_CONTEXT);
     const referrerPageUrl = this.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL);
 
     const defaultQueryInput = this.globalStorage.getState(StorageKeys.QUERY) || '';
@@ -275,7 +275,7 @@ export default class Core {
   search (queryString, urls, options = {}) {
     window.performance.mark('yext.answers.universalQueryStart');
     const { setQueryParams } = options;
-    const context = this.globalStorage.getState(StorageKeys.API_CONTEXT);
+    const context = this.storage.get(StorageKeys.API_CONTEXT);
     const referrerPageUrl = this.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL);
 
     if (setQueryParams) {

--- a/src/core/storage/storagekeys.js
+++ b/src/core/storage/storagekeys.js
@@ -33,7 +33,7 @@ export default {
   NO_RESULTS_CONFIG: 'no-results-config',
   LOCATION_RADIUS: 'location-radius', // Has been cut over to the new global storage
   RESULTS_HEADER: 'results-header',
-  API_CONTEXT: 'context',
+  API_CONTEXT: 'context', // Has been cut over to the new global storage
   REFERRER_PAGE_URL: 'referrerPageUrl',
   QUERY_TRIGGER: 'queryTrigger',
   FACETS_LOADED: 'facets-loaded',

--- a/src/ui/components/navigation/navigationcomponent.js
+++ b/src/ui/components/navigation/navigationcomponent.js
@@ -193,7 +193,11 @@ export default class NavigationComponent extends Component {
       this.setState(this.core.storage.get(StorageKeys.NAVIGATION) || {});
     };
 
-    this.core.globalStorage.on('update', StorageKeys.API_CONTEXT, reRender);
+    this.core.storage.registerListener({
+      eventType: 'update',
+      storageKey: StorageKeys.API_CONTEXT,
+      callback: reRender
+    });
     this.core.globalStorage.on('update', StorageKeys.SESSIONS_OPT_IN, reRender);
   }
 
@@ -344,7 +348,7 @@ export default class NavigationComponent extends Component {
 
     const params = getUrlParams();
     params.set('tabOrder', this._tabOrder);
-    const context = this.core.globalStorage.getState(StorageKeys.API_CONTEXT);
+    const context = this.core.storage.get(StorageKeys.API_CONTEXT);
     if (context) {
       params.set(StorageKeys.API_CONTEXT, context);
     }

--- a/src/ui/components/results/alternativeverticalscomponent.js
+++ b/src/ui/components/results/alternativeverticalscomponent.js
@@ -42,7 +42,7 @@ export default class AlternativeVerticalsComponent extends Component {
     this.verticalSuggestions = this._buildVerticalSuggestions(
       this._alternativeVerticals,
       this._verticalsConfig,
-      this.core.globalStorage.getState(StorageKeys.API_CONTEXT),
+      this.core.storage.get(StorageKeys.API_CONTEXT),
       this.core.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL)
     );
 
@@ -71,7 +71,7 @@ export default class AlternativeVerticalsComponent extends Component {
       this.verticalSuggestions = this._buildVerticalSuggestions(
         this._alternativeVerticals,
         this._verticalsConfig,
-        this.core.globalStorage.getState(StorageKeys.API_CONTEXT),
+        this.core.storage.get(StorageKeys.API_CONTEXT),
         this.core.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL)
       );
       this._universalUrl = this._getUniversalURL(
@@ -81,7 +81,11 @@ export default class AlternativeVerticalsComponent extends Component {
       this.setState(this.core.globalStorage.getState(StorageKeys.ALERNATIVE_VERTICALS));
     };
 
-    this.core.globalStorage.on('update', StorageKeys.API_CONTEXT, reRender);
+    this.core.storage.registerListener({
+      eventType: 'update',
+      storageKey: StorageKeys.API_CONTEXT,
+      callback: reRender
+    });
     this.core.globalStorage.on('update', StorageKeys.SESSIONS_OPT_IN, reRender);
   }
 
@@ -184,7 +188,7 @@ export default class AlternativeVerticalsComponent extends Component {
 
     params.set(StorageKeys.QUERY, this.core.globalStorage.getState(StorageKeys.QUERY));
 
-    const context = this.core.globalStorage.getState(StorageKeys.API_CONTEXT);
+    const context = this.core.storage.get(StorageKeys.API_CONTEXT);
     if (context) {
       params.set(StorageKeys.API_CONTEXT, context);
     }

--- a/src/ui/components/results/universalresultscomponent.js
+++ b/src/ui/components/results/universalresultscomponent.js
@@ -27,7 +27,11 @@ export default class UniversalResultsComponent extends Component {
 
     const reRender = () =>
       this.setState(this.core.storage.get(StorageKeys.UNIVERSAL_RESULTS) || {});
-    this.core.globalStorage.on('update', StorageKeys.API_CONTEXT, reRender);
+    this.core.storage.registerListener({
+      eventType: 'update',
+      storageKey: StorageKeys.API_CONTEXT,
+      callback: reRender
+    });
     this.core.globalStorage.on('update', StorageKeys.SESSIONS_OPT_IN, reRender);
   }
 

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -308,7 +308,7 @@ export default class VerticalResultsComponent extends Component {
   _getExperienceURL (baseUrl, params) {
     params.set(StorageKeys.QUERY, this.query);
 
-    const context = this.core.globalStorage.getState(StorageKeys.API_CONTEXT);
+    const context = this.core.storage.get(StorageKeys.API_CONTEXT);
     if (context) {
       params.set(StorageKeys.API_CONTEXT, context);
     }

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -504,7 +504,7 @@ export default class SearchComponent extends Component {
     const params = new SearchParams(window.location.search.substring(1));
     params.set('query', query);
 
-    const context = this.core.globalStorage.getState(StorageKeys.API_CONTEXT);
+    const context = this.core.storage.get(StorageKeys.API_CONTEXT);
     if (context) {
       params.set(StorageKeys.API_CONTEXT, context);
     }


### PR DESCRIPTION
TEST=manual,auto

test that I can load up noresults, see that the
universal link does nto have a context param, enter
ANSWERS.setContext({'state': 'hi'}) into the console,
then see that the universal link DOES have a context param