### PR TITLE
cut over REFERRER_PAGE_URL to new global storage

### DIFF
--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -231,8 +231,8 @@ class Answers {
       console.error(`Context parameter "${context}" is invalid, omitting from the search.`);
     }
 
-    if (globalStorage.getState(StorageKeys.REFERRER_PAGE_URL) === null) {
-      globalStorage.set(
+    if (storage.get(StorageKeys.REFERRER_PAGE_URL) === undefined) {
+      storage.set(
         StorageKeys.REFERRER_PAGE_URL,
         urlWithoutQueryParamsAndHash(document.referrer)
       );

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -160,7 +160,7 @@ export default class Core {
 
     const { setQueryParams } = options;
     const context = this.storage.get(StorageKeys.API_CONTEXT);
-    const referrerPageUrl = this.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL);
+    const referrerPageUrl = this.storage.get(StorageKeys.REFERRER_PAGE_URL);
 
     const defaultQueryInput = this.storage.get(StorageKeys.QUERY) || '';
     const parsedQuery = Object.assign({}, { input: defaultQueryInput }, query);
@@ -169,7 +169,7 @@ export default class Core {
       if (context) {
         this.persistentStorage.set(StorageKeys.API_CONTEXT, context, true);
       }
-      if (referrerPageUrl !== null) {
+      if (referrerPageUrl !== undefined) {
         this.persistentStorage.set(StorageKeys.REFERRER_PAGE_URL, referrerPageUrl, true);
       }
     }
@@ -276,13 +276,13 @@ export default class Core {
     window.performance.mark('yext.answers.universalQueryStart');
     const { setQueryParams } = options;
     const context = this.storage.get(StorageKeys.API_CONTEXT);
-    const referrerPageUrl = this.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL);
+    const referrerPageUrl = this.storage.get(StorageKeys.REFERRER_PAGE_URL);
 
     if (setQueryParams) {
       if (context) {
         this.persistentStorage.set(StorageKeys.API_CONTEXT, context, true);
       }
-      if (referrerPageUrl !== null) {
+      if (referrerPageUrl !== undefined) {
         this.persistentStorage.set(StorageKeys.REFERRER_PAGE_URL, referrerPageUrl, true);
       }
     }

--- a/src/ui/components/navigation/navigationcomponent.js
+++ b/src/ui/components/navigation/navigationcomponent.js
@@ -352,8 +352,8 @@ export default class NavigationComponent extends Component {
     if (context) {
       params.set(StorageKeys.API_CONTEXT, context);
     }
-    const referrerPageUrl = this.core.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL);
-    if (referrerPageUrl !== null) {
+    const referrerPageUrl = this.core.storage.get(StorageKeys.REFERRER_PAGE_URL);
+    if (referrerPageUrl !== undefined) {
       params.set(StorageKeys.REFERRER_PAGE_URL, referrerPageUrl);
     }
 

--- a/src/ui/components/results/alternativeverticalscomponent.js
+++ b/src/ui/components/results/alternativeverticalscomponent.js
@@ -43,7 +43,7 @@ export default class AlternativeVerticalsComponent extends Component {
       this._alternativeVerticals,
       this._verticalsConfig,
       this.core.storage.get(StorageKeys.API_CONTEXT),
-      this.core.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL)
+      this.core.storage.get(StorageKeys.REFERRER_PAGE_URL)
     );
 
     /**
@@ -72,7 +72,7 @@ export default class AlternativeVerticalsComponent extends Component {
         this._alternativeVerticals,
         this._verticalsConfig,
         this.core.storage.get(StorageKeys.API_CONTEXT),
-        this.core.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL)
+        this.core.storage.get(StorageKeys.REFERRER_PAGE_URL)
       );
       this._universalUrl = this._getUniversalURL(
         this._baseUniversalUrl,
@@ -192,8 +192,8 @@ export default class AlternativeVerticalsComponent extends Component {
     if (context) {
       params.set(StorageKeys.API_CONTEXT, context);
     }
-    const referrerPageUrl = this.core.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL);
-    if (referrerPageUrl !== null) {
+    const referrerPageUrl = this.core.storage.get(StorageKeys.REFERRER_PAGE_URL);
+    if (referrerPageUrl !== undefined) {
       params.set(StorageKeys.REFERRER_PAGE_URL, referrerPageUrl);
     }
 

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -312,8 +312,8 @@ export default class VerticalResultsComponent extends Component {
     if (context) {
       params.set(StorageKeys.API_CONTEXT, context);
     }
-    const referrerPageUrl = this.core.globalStorage.getState(StorageKeys.REFERRER_PAGE_URL);
-    if (referrerPageUrl !== null) {
+    const referrerPageUrl = this.core.storage.get(StorageKeys.REFERRER_PAGE_URL);
+    if (referrerPageUrl !== undefined) {
       params.set(StorageKeys.REFERRER_PAGE_URL, referrerPageUrl);
     }
 

--- a/tests/ui/components/navigation/navigationcomponent.js
+++ b/tests/ui/components/navigation/navigationcomponent.js
@@ -135,7 +135,7 @@ describe('navigation tab links are correct', () => {
   });
 
   it('tab links contain the referrerPageUrl from global storage', () => {
-    COMPONENT_MANAGER.core.globalStorage.set(StorageKeys.REFERRER_PAGE_URL, 'yext.com');
+    COMPONENT_MANAGER.core.storage.set(StorageKeys.REFERRER_PAGE_URL, 'yext.com');
 
     const component = COMPONENT_MANAGER.create('Navigation', defaultConfig);
     const wrapper = mount(component);

--- a/tests/ui/components/results/verticalresultscomponent.js
+++ b/tests/ui/components/results/verticalresultscomponent.js
@@ -4,11 +4,9 @@ import mockManager from '../../../setup/managermocker';
 import StorageKeys from '../../../../src/core/storage/storagekeys';
 import SearchStates from '../../../../src/core/storage/searchstates';
 import VerticalResultsComponent from '../../../../src/ui/components/results/verticalresultscomponent';
-import GlobalStorage from '../../../../src/core/storage/globalstorage';
 import Storage from '../../../../src/core/storage/storage';
 
 const mockCore = {
-  globalStorage: new GlobalStorage(),
   storage: new Storage().init(),
   getStaticFilterNodes: () => [],
   getFacetFilterNodes: () => [],
@@ -18,7 +16,7 @@ const mockCore = {
 DOM.setup(document, new DOMParser());
 
 mockCore.storage.set(StorageKeys.VERTICAL_PAGES_CONFIG, { get: () => [] });
-mockCore.globalStorage.set(StorageKeys.REFERRER_PAGE_URL, '');
+mockCore.storage.set(StorageKeys.REFERRER_PAGE_URL, '');
 
 const COMPONENT_MANAGER = mockManager(mockCore);
 COMPONENT_MANAGER.getComponentNamesForComponentTypes = () => {


### PR DESCRIPTION
TEST=manual

check that referrerPageUrl is preserved across
navigation tabs, view all button on universal, and spellcheck

check that I clicking a link to an answers experience will
set referrerPageUrl to the page with the link