### PR TITLE
cut over QUERY_TRIGGER to new global storage

### DIFF
--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -176,7 +176,7 @@ class Answers {
         if (!data[StorageKeys.QUERY]) {
           this.core.clearResults();
         } else {
-          this.core.globalStorage.set(StorageKeys.QUERY_TRIGGER, QueryTriggers.QUERY_PARAMETER);
+          this.core.storage.set(StorageKeys.QUERY_TRIGGER, QueryTriggers.QUERY_PARAMETER);
         }
 
         if (!data[StorageKeys.SEARCH_OFFSET]) {
@@ -219,9 +219,9 @@ class Answers {
 
     parsedConfig.noResults && storage.set(StorageKeys.NO_RESULTS_CONFIG, parsedConfig.noResults);
     const isSuggestQueryTrigger =
-      globalStorage.getState(StorageKeys.QUERY_TRIGGER) === QueryTriggers.SUGGEST;
+      storage.get(StorageKeys.QUERY_TRIGGER) === QueryTriggers.SUGGEST;
     if (storage.get(StorageKeys.QUERY) && !isSuggestQueryTrigger) {
-      globalStorage.set(StorageKeys.QUERY_TRIGGER, QueryTriggers.QUERY_PARAMETER);
+      storage.set(StorageKeys.QUERY_TRIGGER, QueryTriggers.QUERY_PARAMETER);
     }
 
     const context = storage.get(StorageKeys.API_CONTEXT);
@@ -493,7 +493,7 @@ class Answers {
     if (prepopulatedQuery != null) {
       return;
     }
-    this.core.globalStorage.set(StorageKeys.QUERY_TRIGGER, QueryTriggers.INITIALIZE);
+    this.core.storage.set(StorageKeys.QUERY_TRIGGER, QueryTriggers.INITIALIZE);
     this.core.setQuery(searchConfig.defaultInitialSearch);
   }
 

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -184,7 +184,7 @@ export default class Core {
 
     const locationRadiusFilterNode = this.getLocationRadiusFilterNode();
     const queryTrigger = this.getQueryTriggerForSearchApi(
-      this.globalStorage.getState(StorageKeys.QUERY_TRIGGER)
+      this.storage.get(StorageKeys.QUERY_TRIGGER)
     );
     return this._searcher
       .verticalSearch(verticalKey, {
@@ -229,7 +229,7 @@ export default class Core {
           this.storage.set(StorageKeys.LOCATION_BIAS, data[StorageKeys.LOCATION_BIAS]);
         }
         this.storage.delete(StorageKeys.SKIP_SPELL_CHECK);
-        this.globalStorage.delete(StorageKeys.QUERY_TRIGGER);
+        this.storage.delete(StorageKeys.QUERY_TRIGGER);
 
         const exposedParams = {
           verticalKey: verticalKey,
@@ -294,7 +294,7 @@ export default class Core {
     this.storage.set(StorageKeys.LOCATION_BIAS, {});
 
     const queryTrigger = this.getQueryTriggerForSearchApi(
-      this.globalStorage.getState(StorageKeys.QUERY_TRIGGER)
+      this.storage.get(StorageKeys.QUERY_TRIGGER)
     );
     return this._searcher
       .universalSearch(queryString, {
@@ -315,7 +315,7 @@ export default class Core {
         this.storage.set(StorageKeys.SPELL_CHECK, data[StorageKeys.SPELL_CHECK]);
         this.storage.set(StorageKeys.LOCATION_BIAS, data[StorageKeys.LOCATION_BIAS]);
         this.storage.delete(StorageKeys.SKIP_SPELL_CHECK);
-        this.globalStorage.delete(StorageKeys.QUERY_TRIGGER);
+        this.storage.delete(StorageKeys.QUERY_TRIGGER);
 
         const exposedParams = this._getOnUniversalSearchParams(
           data[StorageKeys.UNIVERSAL_RESULTS].sections,

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -182,14 +182,14 @@ export default class SearchComponent extends Component {
         }
         if (q === null) {
           if (this._defaultInitialSearch || this._defaultInitialSearch === '') {
-            this.core.globalStorage.set(StorageKeys.QUERY_TRIGGER, QueryTriggers.INITIALIZE);
+            this.core.storage.set(StorageKeys.QUERY_TRIGGER, QueryTriggers.INITIALIZE);
             this.core.setQuery(this._defaultInitialSearch);
           }
           return;
         }
         this._updateClearButtonVisibility(q);
 
-        const queryTrigger = this.core.globalStorage.getState(StorageKeys.QUERY_TRIGGER);
+        const queryTrigger = this.core.storage.get(StorageKeys.QUERY_TRIGGER);
         const resetPagination = this._verticalKey &&
           queryTrigger !== QueryTriggers.QUERY_PARAMETER &&
           queryTrigger !== QueryTriggers.INITIALIZE;


### PR DESCRIPTION
TEST=manual

check that queryTrigger is set to "initialize" if a
defaultInitialSearch is set and there is no preexisting query url param

check that clicking spellcheck will send queryTrigger=suggest in the search request, and further searches
will not send queryTrigger=suggest