### PR TITLE
cut over FACETS_LOADED to new storage

### DIFF
--- a/src/ui/components/filters/facetscomponent.js
+++ b/src/ui/components/filters/facetscomponent.js
@@ -275,6 +275,6 @@ export default class FacetsComponent extends Component {
     );
 
     this._filterbox.mount();
-    this.core.globalStorage.set(StorageKeys.FACETS_LOADED, true);
+    this.core.storage.set(StorageKeys.FACETS_LOADED, true);
   }
 }


### PR DESCRIPTION
TEST=manual

checked that searching "technology" will create a removable
filter in the AppliedFilters component, due to the "technology"
querying causing the backend to apply a facet to the search.