### PR TITLE
cut over non StorageKey usages of storage

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -557,7 +557,12 @@ export default class Core {
     this._isDynamicFiltersEnabled = true;
   }
 
-  on (evt, moduleId, cb) {
-    return this.globalStorage.on(evt, moduleId, cb);
+  on (evt, storageKey, cb) {
+    this.storage.registerListener({
+      eventType: evt,
+      storageKey: storageKey,
+      callback: cb
+    });
+    return this.storage;
   }
 }

--- a/src/core/storage/storagekeys.js
+++ b/src/core/storage/storagekeys.js
@@ -7,35 +7,35 @@
  * @enum {string}
  */
 export default {
-  NAVIGATION: 'navigation', // Has been cut over to the new global storage
-  UNIVERSAL_RESULTS: 'universal-results', // Has been cut over to the new global storage
-  VERTICAL_RESULTS: 'vertical-results', // Has been cut over to the new global storage
-  ALTERNATIVE_VERTICALS: 'alternative-verticals', // Has been cut over to the new global storage
-  AUTOCOMPLETE: 'autocomplete', // Has been cut over to the new global storage
-  DIRECT_ANSWER: 'direct-answer', // Has been cut over to the new global storage
-  FILTER: 'filter', // DEPRECATED // Has been cut over to the new global storage
-  STATIC_FILTER_NODE: 'static-filter-node', // Has been cut over to the new global storage
-  QUERY: 'query', // Has been cut over to the new global storage
-  QUERY_ID: 'query-id', // Has been cut over to the new global storage
-  FACET_FILTER_NODE: 'facet-filter-node', // Has been cut over to the new global storage
-  DYNAMIC_FILTERS: 'dynamic-filters', // Has been cut over to the new global storage
-  GEOLOCATION: 'geolocation', // Has been cut over to the new global storage
-  QUESTION_SUBMISSION: 'question-submission', // Has been cut over to the new global storage
-  SEARCH_CONFIG: 'search-config', // Has been cut over to the new global storage
-  SEARCH_OFFSET: 'search-offset', // Has been cut over to the new global storage
-  SPELL_CHECK: 'spell-check', // Has been cut over to the new global storage
-  SKIP_SPELL_CHECK: 'skipSpellCheck', // Has been cut over to the new global storage
-  LOCATION_BIAS: 'location-bias', // Has been cut over to the new global storage
+  NAVIGATION: 'navigation',
+  UNIVERSAL_RESULTS: 'universal-results',
+  VERTICAL_RESULTS: 'vertical-results',
+  ALTERNATIVE_VERTICALS: 'alternative-verticals',
+  AUTOCOMPLETE: 'autocomplete',
+  DIRECT_ANSWER: 'direct-answer',
+  FILTER: 'filter', // DEPRECATED
+  STATIC_FILTER_NODE: 'static-filter-node',
+  QUERY: 'query',
+  QUERY_ID: 'query-id',
+  FACET_FILTER_NODE: 'facet-filter-node',
+  DYNAMIC_FILTERS: 'dynamic-filters',
+  GEOLOCATION: 'geolocation',
+  QUESTION_SUBMISSION: 'question-submission',
+  SEARCH_CONFIG: 'search-config',
+  SEARCH_OFFSET: 'search-offset',
+  SPELL_CHECK: 'spell-check',
+  SKIP_SPELL_CHECK: 'skipSpellCheck',
+  LOCATION_BIAS: 'location-bias',
   SESSIONS_OPT_IN: 'sessions-opt-in',
-  VERTICAL_PAGES_CONFIG: 'vertical-pages-config', // Has been cut over to the new global storage
-  LOCALE: 'locale', // Has been cut over to the new global storage
-  SORT_BYS: 'sort-bys', // Has been cut over to the new global storage
-  NO_RESULTS_CONFIG: 'no-results-config', // Has been cut over to the new global storage
-  LOCATION_RADIUS: 'location-radius', // Has been cut over to the new global storage
-  RESULTS_HEADER: 'results-header', // DEPRECATED // Has been cut over to the new global storage
-  API_CONTEXT: 'context', // Has been cut over to the new global storage
+  VERTICAL_PAGES_CONFIG: 'vertical-pages-config',
+  LOCALE: 'locale',
+  SORT_BYS: 'sort-bys',
+  NO_RESULTS_CONFIG: 'no-results-config',
+  LOCATION_RADIUS: 'location-radius',
+  RESULTS_HEADER: 'results-header', // DEPRECATED
+  API_CONTEXT: 'context',
   REFERRER_PAGE_URL: 'referrerPageUrl',
   QUERY_TRIGGER: 'queryTrigger',
   FACETS_LOADED: 'facets-loaded',
-  QUERY_SOURCE: 'query-source' // Has been cut over to the new global storage
+  QUERY_SOURCE: 'query-source'
 };

--- a/src/ui/components/filters/daterangefiltercomponent.js
+++ b/src/ui/components/filters/daterangefiltercomponent.js
@@ -66,8 +66,8 @@ export default class DateRangeFilterComponent extends Component {
 
     const today = new Date();
     const todayString = `${today.getFullYear()}-${`${today.getMonth() + 1}`.padStart(2, '0')}-${`${today.getDate()}`.padStart(2, '0')}`;
-    const minDate = this.core.globalStorage.getState(`${this.name}.min`);
-    const maxDate = this.core.globalStorage.getState(`${this.name}.max`);
+    const minDate = this.core.storage.get(`${this.name}.min`);
+    const maxDate = this.core.storage.get(`${this.name}.max`);
 
     /**
      * The current date range

--- a/src/ui/components/filters/filteroptionscomponent.js
+++ b/src/ui/components/filters/filteroptionscomponent.js
@@ -269,8 +269,8 @@ export default class FilterOptionsComponent extends Component {
   constructor (config = {}, systemConfig = {}) {
     super(config, systemConfig);
 
-    let previousOptions = this.core.globalStorage.getState(this.name);
-    this.core.globalStorage.delete(this.name);
+    let previousOptions = this.core.storage.get(this.name);
+    this.core.storage.delete(this.name);
 
     /**
      * The component config
@@ -304,17 +304,21 @@ export default class FilterOptionsComponent extends Component {
       // Update listener for when navigating backwards in history. When we back nav, the
       // globalStorage is updated with the previous URL filter values. We should not update
       // this.name otherwise, instead opt for this.core.setStaticFilterNodes()
-      this.core.globalStorage.on('update', this.name, (data) => {
-        try {
-          const newOptions = JSON.parse(data);
-          this.config.options = this.config.getSelectedOptions(
-            this.config.initialOptions,
-            newOptions
-          );
-          this.updateListeners();
-          this.setState();
-        } catch (e) {
-          console.warn(`Filter option ${data} could not be parsed`);
+      this.core.storage.registerListener({
+        eventType: 'update',
+        storageKey: this.name,
+        callback: (data) => {
+          try {
+            const newOptions = JSON.parse(data);
+            this.config.options = this.config.getSelectedOptions(
+              this.config.initialOptions,
+              newOptions
+            );
+            this.updateListeners();
+            this.setState();
+          } catch (e) {
+            console.warn(`Filter option ${data} could not be parsed`);
+          }
         }
       });
     }

--- a/src/ui/components/filters/rangefiltercomponent.js
+++ b/src/ui/components/filters/rangefiltercomponent.js
@@ -44,13 +44,13 @@ export default class RangeFilterComponent extends Component {
      */
     this._storeOnChange = config.storeOnChange === undefined ? true : config.storeOnChange;
 
-    let minVal = this.core.globalStorage.getState(`${this.name}.min`);
+    let minVal = this.core.storage.get(`${this.name}.min`);
     if (typeof minVal === 'string') {
       try {
         minVal = Number.parseInt(minVal);
       } catch (e) {}
     }
-    let maxVal = this.core.globalStorage.getState(`${this.name}.max`);
+    let maxVal = this.core.storage.get(`${this.name}.max`);
     if (typeof minVal === 'string') {
       try {
         maxVal = Number.parseInt(maxVal);

--- a/src/ui/components/filters/sortoptionscomponent.js
+++ b/src/ui/components/filters/sortoptionscomponent.js
@@ -18,7 +18,7 @@ export default class SortOptionsComponent extends Component {
   constructor (config = {}, systemConfig = {}) {
     super(assignDefaults(config), systemConfig);
     this.options = this._config.options;
-    this.selectedOptionIndex = parseInt(this.core.globalStorage.getState(this.name)) || 0;
+    this.selectedOptionIndex = parseInt(this.core.storage.get(this.name)) || 0;
     this.options[this.selectedOptionIndex].isSelected = true;
     this.hideExcessOptions = this._config.showMore && this.selectedOptionIndex < this._config.showMoreLimit;
     this.searchOnChangeIsEnabled = this._config.searchOnChange;

--- a/src/ui/components/results/alternativeverticalscomponent.js
+++ b/src/ui/components/results/alternativeverticalscomponent.js
@@ -78,7 +78,7 @@ export default class AlternativeVerticalsComponent extends Component {
         this._baseUniversalUrl,
         new SearchParams(window.location.search.substring(1))
       );
-      this.setState(this.core.globalStorage.getState(StorageKeys.ALERNATIVE_VERTICALS));
+      this.setState(this.core.storage.get(StorageKeys.ALTERNATIVE_VERTICALS));
     };
 
     this.core.storage.registerListener({

--- a/tests/ui/components/filters/filteroptionscomponent.js
+++ b/tests/ui/components/filters/filteroptionscomponent.js
@@ -7,6 +7,7 @@ import FilterMetadata from 'src/core/filters/filtermetadata';
 import FilterType from '../../../../src/core/filters/filtertype';
 import StorageKeys from '../../../../src/core/storage/storagekeys';
 import PersistentStorage from 'src/ui/storage/persistentstorage';
+import Storage from '../../../../src/core/storage/storage';
 
 describe('filter options component', () => {
   DOM.setup(document, new DOMParser());
@@ -63,6 +64,8 @@ describe('filter options component', () => {
     DOM.empty(bodyEl);
     DOM.append(bodyEl, DOM.createEl('div', { id: 'test-component' }));
     setStaticFilterNodes = jest.fn();
+    const storage = new Storage().init();
+    storage.set(StorageKeys.SEARCH_CONFIG, { verticalKey: 'a vertical key' });
 
     const mockCore = {
       setStaticFilterNodes: setStaticFilterNodes,
@@ -70,18 +73,7 @@ describe('filter options component', () => {
       filterRegistry: {
         setStaticFilterNodes: setStaticFilterNodes
       },
-      globalStorage: {
-        getState: (key) => {
-          if (key === StorageKeys.SEARCH_CONFIG) {
-            return {
-              verticalKey: 'a vertical key'
-            };
-          }
-          return null;
-        },
-        delete: () => { },
-        on: () => {}
-      },
+      storage,
       persistentStorage: new PersistentStorage()
     };
 
@@ -398,17 +390,10 @@ describe('filter options component', () => {
       const bodyEl = DOM.query('body');
       DOM.empty(bodyEl);
       DOM.append(bodyEl, DOM.createEl('div', { id: 'test-component' }));
-
+      const storage = new Storage().init();
+      storage.set('test-previous-options', ['label1', 'label2']);
       COMPONENT_MANAGER = mockManager({
-        globalStorage: {
-          getState: key => {
-            if (key === 'test-previous-options') {
-              return ['label1', 'label2'];
-            }
-          },
-          delete: () => { },
-          on: () => {}
-        },
+        storage,
         setStaticFilterNodes: () => { }
       });
 
@@ -543,11 +528,6 @@ describe('filter options component', () => {
       setStaticFilterNodes = jest.fn();
 
       COMPONENT_MANAGER = mockManager({
-        globalStorage: {
-          getState: () => { },
-          delete: () => { },
-          on: () => {}
-        },
         persistentStorage: {
           set: () => { },
           get: () => { }

--- a/tests/ui/components/filters/sortoptionscomponent.js
+++ b/tests/ui/components/filters/sortoptionscomponent.js
@@ -12,17 +12,6 @@ const mockedCore = () => {
     },
     clearSortBys: () => {},
     verticalSearch: () => {},
-    globalStorage: {
-      on: () => {},
-      getState: storageKey => {
-        expect(['SortOptions', StorageKeys.QUERY]).toContain(storageKey);
-        return null;
-      },
-      getAll: storageKey => {
-        expect([StorageKeys.FACET_FILTER_NODE, StorageKeys.STATIC_FILTER_NODE]).toContain(storageKey);
-        return [];
-      }
-    },
     persistentStorage: {
       set: (namespace, optionIndex) => {
         expect(namespace).toBe('SortOptions');


### PR DESCRIPTION
Cuts over usages of storages that aren't
necessarily listed in storagekeys.js,
i.e. usages of this.name where this is the
component itself.

Also fix a typo from #916 (many moons ago) where
ALTERNATIVE_VERTICALS was mispelled ALERNATIVE_VERTICALS.
It looks like the AlternativeVertical component's setState() doesn't
depend on the data you pass it, so probably nothing was broken.

Since all the StorageKeys are cut over, we can
remove the cut over comment markers.

J=SLAP-1039
TEST=manual

checked that sortoptions, range, date range filters are
seeded on page load but don’t affect the initial search
checked that this is consistent with 1.7.1
check that facets still do the wonderful thing where they pretend to apply on load
also checked that 1.7.1 still does this