### PR TITLE
Allow `cardOverrides` to be specified by direct answer type. (#1278)

### DIFF
--- a/src/ui/components/results/directanswercomponent.js
+++ b/src/ui/components/results/directanswercomponent.js
@@ -119,6 +119,7 @@ export default class DirectAnswerComponent extends Component {
       return true;
     }
     const directAnswerPropeties = {
+      type: directAnswer.type,
       entityType: directAnswer.relatedItem.data.type,
       fieldName: directAnswer.answer.fieldName,
       fieldType: directAnswer.answer.fieldType

--- a/tests/ui/components/results/directanswercomponent.js
+++ b/tests/ui/components/results/directanswercomponent.js
@@ -1,0 +1,130 @@
+import DOM from '../../../../src/ui/dom/dom';
+import mockManager from '../../../setup/managermocker';
+
+DOM.setup(document, new DOMParser());
+const COMPONENT_MANAGER = mockManager();
+
+describe('cardOverrides logic works properly', () => {
+  let defaultConfig;
+
+  const directAnswer = {
+    type: 'FIELD_VALUE',
+    answer: {
+      entityName: 'Amani Farooque',
+      fieldName: 'Phone Number',
+      fieldApiName: 'mainPhone',
+      value: '+18003332222',
+      fieldType: 'phone'
+    },
+    relatedItem: {
+      verticalConfigId: 'people',
+      data: {
+        type: 'Location'
+      }
+    }
+  };
+
+  beforeEach(() => {
+    const bodyEl = DOM.query('body');
+    DOM.empty(bodyEl);
+    DOM.append(bodyEl, DOM.createEl('div', { id: 'test-component' }));
+
+    defaultConfig = {
+      container: '#test-component'
+    };
+  });
+
+  it('if no overrides match, default is used', () => {
+    const component = COMPONENT_MANAGER.create('DirectAnswer', {
+      ...defaultConfig,
+      defaultCard: 'default-card',
+      cardOverrides: [
+        {
+          fieldName: 'Some field',
+          cardType: 'some-card'
+        },
+        {
+          type: 'FEATURED_SNIPPET',
+          cardType: 'other-card'
+        }
+      ]
+    });
+
+    expect(component._getCustomCard(directAnswer)).toEqual('default-card');
+  });
+
+  it('can specify override by type', () => {
+    const component = COMPONENT_MANAGER.create('DirectAnswer', {
+      ...defaultConfig,
+      cardOverrides: [
+        {
+          type: 'FIELD_VALUE',
+          cardType: 'some-card'
+        }
+      ]
+    });
+
+    expect(component._getCustomCard(directAnswer)).toEqual('some-card');
+  });
+
+  it('can specify override by entityType', () => {
+    const component = COMPONENT_MANAGER.create('DirectAnswer', {
+      ...defaultConfig,
+      cardOverrides: [
+        {
+          entityType: 'Location',
+          cardType: 'some-card'
+        }
+      ]
+    });
+
+    expect(component._getCustomCard(directAnswer)).toEqual('some-card');
+  });
+
+  it('can specify override by fieldName', () => {
+    const component = COMPONENT_MANAGER.create('DirectAnswer', {
+      ...defaultConfig,
+      cardOverrides: [
+        {
+          fieldName: 'Phone Number',
+          cardType: 'some-card'
+        }
+      ]
+    });
+
+    expect(component._getCustomCard(directAnswer)).toEqual('some-card');
+  });
+
+  it('can specify override by fieldType', () => {
+    const component = COMPONENT_MANAGER.create('DirectAnswer', {
+      ...defaultConfig,
+      cardOverrides: [
+        {
+          fieldType: 'phone',
+          cardType: 'some-card'
+        }
+      ]
+    });
+
+    expect(component._getCustomCard(directAnswer)).toEqual('some-card');
+  });
+
+  it('if multiple overrides match, first match is used', () => {
+    const component = COMPONENT_MANAGER.create('DirectAnswer', {
+      ...defaultConfig,
+      cardOverrides: [
+        {
+          type: 'FIELD_VALUE',
+          fieldName: 'Phone Number',
+          cardType: 'some-card'
+        },
+        {
+          fieldType: 'phone',
+          cardType: 'other-card'
+        }
+      ]
+    });
+
+    expect(component._getCustomCard(directAnswer)).toEqual('some-card');
+  });
+});


### PR DESCRIPTION
This PR updates the `cardOverrides` logic in the `DirectAnswer` component.
Now, an override can include the top-level direct answer type in its
specification.

J=SLAP-996
TEST=auto, manual

Added unit tests for the override selection logic. Pointed a local Jambo site
to my SDK build. I added a `cardOverride` for the `FEATURED_SNIPPET` type.
I saw the that override was correctly applied for that type of direct answer.