### PR TITLE
Add the `highlightedFields` attribute to a `Result`. (#1277)

### DIFF
--- a/src/core/models/result.js
+++ b/src/core/models/result.js
@@ -24,6 +24,12 @@ export default class Result {
     this._highlighted = data.highlighted;
 
     /**
+     * An object that lists the substrings to highlight for each applicable field.
+     * @type {Object}
+     */
+    this.highlightedFields = data.highlightedFields;
+
+    /**
      * The index number of the result
      * @type {Number}
      */

--- a/src/core/models/resultfactory.js
+++ b/src/core/models/resultfactory.js
@@ -197,7 +197,8 @@ export default class ResultFactory {
       id: data.id,
       ordinal: index + 1,
       distance: distance,
-      distanceFromFilter: distanceFromFilter
+      distanceFromFilter: distanceFromFilter,
+      highlightedFields
     });
   }
 


### PR DESCRIPTION
This PR adds a new attribute to the `Result` domain model: `highlightedFields`.
This attribute is distinct from the existing `_highlighted` attribute. It
contains the metadata needed by the Theme (and other consumers) to perform
text highlighting themselves. The existing attribute contains already
highlighted text. The naming of the two attributes is similar, however this
was the naming requested by Product.

Note that KM is the only back-end that currently supports highlighting of
results.

TEST=manual

Verified that I could now access the `highlightedFields` supplied by KG in the
front-end.