### PR TITLE
Update facets adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2636,9 +2636,9 @@
       }
     },
     "@yext/answers-core": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@yext/answers-core/-/answers-core-1.0.0-beta.4.tgz",
-      "integrity": "sha512-tqrO3RVHqKUT3mmRzQOQhv+7pPVkg0fhKrkO5w8mYy98k6VeRV6vDLb/aQV9laLvEGVjzPzhrnic23RGjqJE5Q==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@yext/answers-core/-/answers-core-1.0.0-beta.5.tgz",
+      "integrity": "sha512-lRe0zBZz2SGppJA5xI02gaqOioehbC9+oi3q0b/VyHIJf7FFl+gXJ5xlxE5VxLB+rGGc1MI3B+0l373pWhyQqA==",
       "requires": {
         "@babel/runtime-corejs3": "^7.12.5",
         "cross-fetch": "^3.0.6"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@mapbox/mapbox-gl-language": "^0.10.1",
     "@yext/answers-storage": "^1.0.0-beta.0",
-    "@yext/answers-core": "^1.0.0-beta.4",
+    "@yext/answers-core": "^1.0.0-beta.5",
     "@yext/rtf-converter": "^1.2.0",
     "css-vars-ponyfill": "^2.3.1",
     "gulp-sourcemaps": "^2.6.5",
@@ -106,7 +106,7 @@
   },
   "jest": {
     "bail": 0,
-    "verbose": true,
+    "verbose": false,
     "setupFilesAfterEnv": [
       "./tests/setup/setup.js"
     ],

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
   },
   "jest": {
     "bail": 0,
-    "verbose": false,
+    "verbose": true,
     "setupFilesAfterEnv": [
       "./tests/setup/setup.js"
     ],

--- a/src/core/core-adapter.js
+++ b/src/core/core-adapter.js
@@ -196,7 +196,7 @@ export default class CoreAdapter {
       .verticalSearch({
         verticalKey: verticalKey || searchConfig.verticalKey,
         limit: this.storage.get(StorageKeys.SEARCH_CONFIG).limit,
-        location: this.storage.get(StorageKeys.GEOLOCATION),
+        coordinates: this.storage.get(StorageKeys.GEOLOCATION),
         query: parsedQuery.input,
         retrieveFacets: this._isDynamicFiltersEnabled,
         facets: this.filterRegistry.getFacetsPayload(),

--- a/src/core/core-adapter.js
+++ b/src/core/core-adapter.js
@@ -196,10 +196,10 @@ export default class CoreAdapter {
       .verticalSearch({
         verticalKey: verticalKey || searchConfig.verticalKey,
         limit: this.storage.get(StorageKeys.SEARCH_CONFIG).limit,
-        coordinates: this.storage.get(StorageKeys.GEOLOCATION),
+        location: this.storage.get(StorageKeys.GEOLOCATION),
         query: parsedQuery.input,
         retrieveFacets: this._isDynamicFiltersEnabled,
-        facetFilters: this.filterRegistry.getFacetFilterPayload(),
+        facets: this.filterRegistry.getFacetsPayload(),
         staticFilters: this.filterRegistry.getStaticFilterPayload(),
         offset: this.storage.get(StorageKeys.SEARCH_OFFSET) || 0,
         skipSpellCheck: this.storage.get(StorageKeys.SKIP_SPELL_CHECK),

--- a/src/core/filters/filterregistry.js
+++ b/src/core/filters/filterregistry.js
@@ -1,6 +1,7 @@
 /** @module FilterRegistry */
 
 import FilterCombinators from './filtercombinators';
+import Facet from '../models/facet';
 import StorageKeys from '../storage/storagekeys';
 
 /** @typedef {import('../storage/storage').default} Storage */
@@ -66,9 +67,9 @@ export default class FilterRegistry {
   }
 
   /**
-   * Gets the static filters as a {@link SimpleFilter|CombinedFilter} to send to the answers-core
+   * Gets the static filters as a {@link Filter|CombinedFilter} to send to the answers-core
    *
-   * @returns {CombinedFilter|SimpleFilter|null} Returns null if no filters with
+   * @returns {CombinedFilter|Filter|null} Returns null if no filters with
    *                                             filtering logic are present.
    */
   getStaticFilterPayload () {
@@ -83,11 +84,11 @@ export default class FilterRegistry {
 
   /**
    * Transforms a list of filter nodes {@link CombinedFilterNode} or {@link SimpleFilterNode} to
-   * answers-core's {@link SimpleFilter} or {@link CombinedFilter}
+   * answers-core's {@link Filter} or {@link CombinedFilter}
    *
    * @param {Array<CombinedFilterNode|SimpleFilterNode>} filterNodes
    * @param {FilterCombinator} combinator from answers-core
-   * @returns {CombinedFilter|SimpleFilter} from answers-core
+   * @returns {CombinedFilter|Filter} from answers-core
    */
   _transformFilterNodes (filterNodes, combinator) {
     const filters = filterNodes.flatMap(filterNode => {
@@ -107,35 +108,54 @@ export default class FilterRegistry {
   }
 
   /**
-   * Transforms a {@link SimpleFilterNode} to answers-core's {@link SimpleFilter}
+   * Transforms a {@link SimpleFilterNode} to answers-core's {@link Filter}
    *
    * @param {SimpleFilterNode} filterNode
-   * @returns {SimpleFilter}
+   * @returns {Filter}
    */
   _transformSimpleFilterNode (filterNode) {
     const fieldId = Object.keys(filterNode.filter)[0];
     const filterComparison = filterNode.filter[fieldId];
-    const comparator = Object.keys(filterComparison)[0];
-    const comparedValue = filterComparison[comparator];
+    const matcher = Object.keys(filterComparison)[0];
+    const value = filterComparison[matcher];
     return {
       fieldId: fieldId,
-      comparator: comparator,
-      comparedValue: comparedValue
+      matcher: matcher,
+      value: value
     };
   }
 
   /**
-   * Gets the facet filters as an array of SimpleFilters to send to the answers-core.
+   * Gets the facet filters as an array of Filters to send to the answers-core.
    *
-   * @returns {SimpleFilter[]} from the answers-core
+   * @returns {Filter[]} from the answers-core
    */
-  getFacetFilterPayload () {
-    return this.getFacetFilterNodes()
-      .flatMap(filterNode => {
-        const childNodes = filterNode.getChildren();
-        return childNodes.length > 0 ? childNodes : filterNode;
-      })
-      .map(simpleFilterNode => simpleFilterNode.getFilter());
+  getFacetsPayload () {
+    const getFilters = fn => fn.getChildren().length
+      ? fn.getChildren().flatMap(getFilters)
+      : fn.getFilter();
+    const filters = this.getFacetFilterNodes().flatMap(getFilters);
+    const facets = Facet.fromFilters(this.availableFieldIds, ...filters);
+
+    const transformFilter = filter => {
+      const fieldId = Object.keys(filter)[0];
+      const filterComparison = filter[fieldId];
+      const matcher = Object.keys(filterComparison)[0];
+      const value = filterComparison[matcher];
+      return {
+        matcher: matcher,
+        value: value
+      };
+    };
+
+    const coreFacets = Object.entries(facets).map(([fieldId, filterArray]) => {
+      return {
+        fieldId: fieldId,
+        options: filterArray.map(transformFilter)
+      };
+    });
+
+    return coreFacets;
   }
 
   /**

--- a/src/core/filters/filterregistry.js
+++ b/src/core/filters/filterregistry.js
@@ -126,9 +126,26 @@ export default class FilterRegistry {
   }
 
   /**
+   * Transforms a {@link Filter} into answers-core's {@link FacetOption}
+   *
+   * @param {Filter} filter
+   * @returns {FacetOption} from answers-core
+   */
+  _transformSimpleFilterNodeIntoFacetOption (filter) {
+    const fieldId = Object.keys(filter)[0];
+    const filterComparison = filter[fieldId];
+    const matcher = Object.keys(filterComparison)[0];
+    const value = filterComparison[matcher];
+    return {
+      matcher: matcher,
+      value: value
+    };
+  }
+
+  /**
    * Gets the facet filters as an array of Filters to send to the answers-core.
    *
-   * @returns {Filter[]} from the answers-core
+   * @returns {Facet[]} from answers-core
    */
   getFacetsPayload () {
     const getFilters = fn => fn.getChildren().length
@@ -137,21 +154,10 @@ export default class FilterRegistry {
     const filters = this.getFacetFilterNodes().flatMap(getFilters);
     const facets = Facet.fromFilters(this.availableFieldIds, ...filters);
 
-    const transformFilter = filter => {
-      const fieldId = Object.keys(filter)[0];
-      const filterComparison = filter[fieldId];
-      const matcher = Object.keys(filterComparison)[0];
-      const value = filterComparison[matcher];
-      return {
-        matcher: matcher,
-        value: value
-      };
-    };
-
     const coreFacets = Object.entries(facets).map(([fieldId, filterArray]) => {
       return {
         fieldId: fieldId,
-        options: filterArray.map(transformFilter)
+        options: filterArray.map(this._transformSimpleFilterNodeIntoFacetOption)
       };
     });
 

--- a/src/core/models/dynamicfilters.js
+++ b/src/core/models/dynamicfilters.js
@@ -35,7 +35,11 @@ export default class DynamicFilters {
         label: o['displayName'],
         countLabel: o['count'],
         selected: o['selected'],
-        filter: o['filter']
+        filter: {
+          [f['fieldId']]: {
+            [o['matcher']]: o['value']
+          }
+        }
       }))
     }));
 

--- a/tests/core/filters/filterregistry.js
+++ b/tests/core/filters/filterregistry.js
@@ -234,7 +234,6 @@ describe('FilterRegistry', () => {
     expect(registry.getFacetFilterNodes()).toEqual(facetNodes);
     expect(registry.availableFieldIds).toEqual(['random_field', 'another_field']);
     expect(registry.getFacetsPayload()).toEqual(expectedFacets);
-    console.log(expectedFacets);
   });
 
   it('can set locationRadius FilterNodes', () => {

--- a/tests/core/filters/filterregistry.js
+++ b/tests/core/filters/filterregistry.js
@@ -200,9 +200,36 @@ describe('FilterRegistry', () => {
 
     registry.setFacetFilterNodes([ 'random_field', 'another_field' ], facetNodes);
     const expectedFacets = [
-      Filter.from(filter1),
-      Filter.from(filter3),
-      Filter.from(filter2)
+      {
+        fieldId: 'random_field',
+        options: []
+      },
+      {
+        fieldId: 'another_field',
+        options: []
+      },
+      {
+        fieldId: 'c_1',
+        options: [
+          {
+            matcher: '$eq',
+            value: '1'
+          },
+          {
+            matcher: '$eq',
+            value: '2'
+          }
+        ]
+      },
+      {
+        fieldId: 'c_2',
+        options: [
+          {
+            matcher: '$eq',
+            value: '2'
+          }
+        ]
+      }
     ];
     expect(registry.getFacetFilterNodes()).toEqual(facetNodes);
     expect(registry.availableFieldIds).toEqual(['random_field', 'another_field']);

--- a/tests/core/filters/filterregistry.js
+++ b/tests/core/filters/filterregistry.js
@@ -155,7 +155,7 @@ describe('FilterRegistry', () => {
 
   it('can set facet filter nodes, always overriding previous facets', () => {
     registry.setFacetFilterNodes([ 'random_field', 'another_field' ], [node1, node2]);
-    const expectedFacets = [ 
+    const expectedFacets = [
       {
         fieldId: 'random_field',
         options: []
@@ -181,7 +181,7 @@ describe('FilterRegistry', () => {
             value: '2'
           }
         ]
-      },
+      }
     ];
     expect(registry.availableFieldIds).toEqual(['random_field', 'another_field']);
     expect(registry.getFacetsPayload()).toEqual(expectedFacets);

--- a/tests/core/filters/filterregistry.js
+++ b/tests/core/filters/filterregistry.js
@@ -52,13 +52,13 @@ describe('FilterRegistry', () => {
   it('can correctly set simple filter nodes', () => {
     const transformedFilter1 = {
       fieldId: 'c_1',
-      comparator: '$eq',
-      comparedValue: filter1.c_1['$eq']
+      matcher: '$eq',
+      value: filter1.c_1['$eq']
     };
     const transformedFilter2 = {
       fieldId: 'c_2',
-      comparator: '$eq',
-      comparedValue: filter2.c_2['$eq']
+      matcher: '$eq',
+      value: filter2.c_2['$eq']
     };
     registry.setStaticFilterNodes('namespace1', node1);
     expect(registry.getStaticFilterNodes()).toHaveLength(1);
@@ -95,13 +95,13 @@ describe('FilterRegistry', () => {
   it('can correctly set nested filter nodes', () => {
     const transformedFilter1 = {
       fieldId: 'c_1',
-      comparator: '$eq',
-      comparedValue: filter1.c_1['$eq']
+      matcher: '$eq',
+      value: filter1.c_1['$eq']
     };
     const transformedFilter2 = {
       fieldId: 'c_2',
-      comparator: '$eq',
-      comparedValue: filter2.c_2['$eq']
+      matcher: '$eq',
+      value: filter2.c_2['$eq']
     };
     const orNode = FilterNodeFactory.or(node1, node2);
     registry.setStaticFilterNodes('namespace1', orNode);
@@ -155,9 +155,36 @@ describe('FilterRegistry', () => {
 
   it('can set facet filter nodes, always overriding previous facets', () => {
     registry.setFacetFilterNodes([ 'random_field', 'another_field' ], [node1, node2]);
-    const expectedFacets = [ filter1, filter2 ];
+    const expectedFacets = [ 
+      {
+        fieldId: 'random_field',
+        options: []
+      },
+      {
+        fieldId: 'another_field',
+        options: []
+      },
+      {
+        fieldId: 'c_1',
+        options: [
+          {
+            matcher: '$eq',
+            value: '1'
+          }
+        ]
+      },
+      {
+        fieldId: 'c_2',
+        options: [
+          {
+            matcher: '$eq',
+            value: '2'
+          }
+        ]
+      },
+    ];
     expect(registry.availableFieldIds).toEqual(['random_field', 'another_field']);
-    expect(registry.getFacetFilterPayload()).toEqual(expectedFacets);
+    expect(registry.getFacetsPayload()).toEqual(expectedFacets);
   });
 
   it('facets can combine multiple filter nodes', () => {
@@ -179,7 +206,8 @@ describe('FilterRegistry', () => {
     ];
     expect(registry.getFacetFilterNodes()).toEqual(facetNodes);
     expect(registry.availableFieldIds).toEqual(['random_field', 'another_field']);
-    expect(registry.getFacetFilterPayload()).toEqual(expectedFacets);
+    expect(registry.getFacetsPayload()).toEqual(expectedFacets);
+    console.log(expectedFacets);
   });
 
   it('can set locationRadius FilterNodes', () => {


### PR DESCRIPTION
Update the facets adapter to match the new core library facet models

On the request side, I am reverting the change to getFacetFilterPayload which appeared in #1205 and transforming the api facets request model to the new core facets request model. I also had to updated the response transformer. I updated the tests which covert this code.

Although this PR points to a beta release of the core library, it was tested with this version locally: https://github.com/yext/answers-core/pull/65

J=SLAP-839
TEST=manual

In rosetest, use the facets component and select and deselect various facets. Confirm that the request query params are correct. Observe the deselected facets being sent in the request, and the UI updating properly based on the response.