### PR TITLE
Update location adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2636,9 +2636,9 @@
       }
     },
     "@yext/answers-core": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@yext/answers-core/-/answers-core-1.0.0-beta.4.tgz",
-      "integrity": "sha512-tqrO3RVHqKUT3mmRzQOQhv+7pPVkg0fhKrkO5w8mYy98k6VeRV6vDLb/aQV9laLvEGVjzPzhrnic23RGjqJE5Q==",
+      "version": "1.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@yext/answers-core/-/answers-core-1.0.0-beta.6.tgz",
+      "integrity": "sha512-wC/3zWK7EqnGPoOcs146ye8ZN9mo40hO/M5dWTvjkKhRQDGN6R/V6Ur0Bdq2lHdbEXK5n9RbxRM8/KOpUuDPeA==",
       "requires": {
         "@babel/runtime-corejs3": "^7.12.5",
         "cross-fetch": "^3.0.6"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@mapbox/mapbox-gl-language": "^0.10.1",
     "@yext/answers-storage": "^1.0.0-beta.0",
-    "@yext/answers-core": "^1.0.0-beta.4",
+    "@yext/answers-core": "^1.0.0-beta.6",
     "@yext/rtf-converter": "^1.2.0",
     "css-vars-ponyfill": "^2.3.1",
     "gulp-sourcemaps": "^2.6.5",

--- a/src/core/core-adapter.js
+++ b/src/core/core-adapter.js
@@ -196,7 +196,7 @@ export default class CoreAdapter {
       .verticalSearch({
         verticalKey: verticalKey || searchConfig.verticalKey,
         limit: this.storage.get(StorageKeys.SEARCH_CONFIG).limit,
-        coordinates: this.storage.get(StorageKeys.GEOLOCATION),
+        location: this._getLocationPayload(),
         query: parsedQuery.input,
         retrieveFacets: this._isDynamicFiltersEnabled,
         facetFilters: this.filterRegistry.getFacetFilterPayload(),
@@ -311,7 +311,7 @@ export default class CoreAdapter {
     return this._coreLibrary
       .universalSearch({
         query: queryString,
-        coordinates: this.storage.get(StorageKeys.GEOLOCATION),
+        location: this._getLocationPayload(),
         skipSpellCheck: this.storage.get(StorageKeys.SKIP_SPELL_CHECK),
         queryTrigger: queryTrigger,
         sessionTrackingEnabled: this.storage.get(StorageKeys.SESSIONS_OPT_IN).value,
@@ -585,6 +585,19 @@ export default class CoreAdapter {
    */
   clearLocationRadiusFilterNode () {
     this.filterRegistry.clearLocationRadiusFilterNode();
+  }
+
+  /**
+   * Gets the location object needed for answers-core
+   * 
+   * @returns {LatLong|undefined} from answers-core
+   */
+  _getLocationPayload () {
+    const geolocation = this.storage.get(StorageKeys.GEOLOCATION);
+    return geolocation && {
+      latitude: geolocation.lat,
+      longitude: geolocation.lng,
+    }
   }
 
   /**

--- a/src/core/core-adapter.js
+++ b/src/core/core-adapter.js
@@ -589,15 +589,15 @@ export default class CoreAdapter {
 
   /**
    * Gets the location object needed for answers-core
-   * 
+   *
    * @returns {LatLong|undefined} from answers-core
    */
   _getLocationPayload () {
     const geolocation = this.storage.get(StorageKeys.GEOLOCATION);
     return geolocation && {
       latitude: geolocation.lat,
-      longitude: geolocation.lng,
-    }
+      longitude: geolocation.lng
+    };
   }
 
   /**


### PR DESCRIPTION
Update the location adapter for vertical and universal searches

Update the param name and add a helper function which performs a transformation from storage to the model needed by core

J=SLAP-839
TEST=manual

Perform a search and confirm that no location is sent by default. Use ANSWERS.setGeolocation() and then perform another search. Confirm that location is properly sent. Test both for both universal and vertical.