### PR TITLE
Update SortBys for Core

### DIFF
--- a/src/core/core-adapter.js
+++ b/src/core/core-adapter.js
@@ -484,7 +484,7 @@ export default class CoreAdapter {
         direction: option.direction
       };
     });
-    this.storage.set(StorageKeys.SORT_BYS, JSON.stringify(sortBys));
+    this.storage.set(StorageKeys.SORT_BYS, sortBys);
   }
 
   /**


### PR DESCRIPTION
Don't stringify the SortBys so that it is compatible with core

The core library already stringifies sortBys, so no need to stringify it here.

J=SLAP-839
TEST=manual

Use a test site with a sortoptions component and set a sort. View the proper params being sent in the request and confirm that results on the page are sorted accordingly