### PR TITLE
Support Experience Version

### DIFF
--- a/src/core/core-adapter.js
+++ b/src/core/core-adapter.js
@@ -101,7 +101,8 @@ export default class CoreAdapter {
     const params = {
       apiKey: this._apiKey,
       experienceKey: this._experienceKey,
-      locale: this._locale
+      locale: this._locale,
+      experienceVersion: this._experienceVersion
     };
 
     this._coreLibrary = provideCore(params);


### PR DESCRIPTION
Pass the experienceVersion when initializing core

J=SLAP-1097
TEST=manual

On a test site, set the experienceVersion to 'PRODUCTION' and 'STAGING' and confirm that the version param is being passed in the api request. Also confirm that no param is passed if the option is not supplied in the ANSWERS.init()