### PR TITLE
Core sandbox support

### DIFF
--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -267,7 +267,8 @@ class Answers {
       locale: parsedConfig.locale,
       analyticsReporter: this._analyticsReporterService,
       onVerticalSearch: parsedConfig.onVerticalSearch,
-      onUniversalSearch: parsedConfig.onUniversalSearch
+      onUniversalSearch: parsedConfig.onUniversalSearch,
+      environment: parsedConfig.environment
     });
 
     if (parsedConfig.onStateChange && typeof parsedConfig.onStateChange === 'function') {

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -25,4 +25,4 @@ export const ENDPOINTS = {
   UNIVERSAL_AUTOCOMPLETE: '/v2/accounts/me/answers/autocomplete',
   VERTICAL_AUTOCOMPLETE: '/v2/accounts/me/answers/vertical/autocomplete',
   FILTER_SEARCH: '/v2/accounts/me/answers/filtersearch'
-}
+};

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -17,3 +17,12 @@ export const COMPILED_TEMPLATES_URL = `https://assets.sitescdn.net/answers/${LIB
 
 /** The query source, reported with analytics */
 export const QUERY_SOURCE = 'STANDARD';
+
+export const ENDPOINTS = {
+  UNIVERSAL_SEARCH: '/v2/accounts/me/answers/query',
+  VERTICAL_SEARCH: '/v2/accounts/me/answers/vertical/query',
+  QUESTION_SUBMISSION: '/v2/accounts/me/createQuestion',
+  UNIVERSAL_AUTOCOMPLETE: '/v2/accounts/me/answers/autocomplete',
+  VERTICAL_AUTOCOMPLETE: '/v2/accounts/me/answers/vertical/autocomplete',
+  FILTER_SEARCH: '/v2/accounts/me/answers/filtersearch'
+}

--- a/src/core/core-adapter.js
+++ b/src/core/core-adapter.js
@@ -17,6 +17,9 @@ import FilterRegistry from './filters/filterregistry';
 import DirectAnswer from './models/directanswer';
 import AutoCompleteResponseTransformer from './search/autocompleteresponsetransformer';
 
+import { PRODUCTION, ENDPOINTS } from './constants';
+import { getCachedLiveApiUrl, getLiveApiUrl, getKnowledgeApiUrl } from './utils/urlutils';
+
 /** @typedef {import('./storage/storage').default} Storage */
 
 /**
@@ -92,6 +95,12 @@ export default class CoreAdapter {
      * @type {Function}
      */
     this.onVerticalSearch = config.onVerticalSearch || function () {};
+
+    /**
+     * The environment which determines which URLs the requests use.
+     * @type {string}
+     */
+    this._environment = config.environment || PRODUCTION;
   }
 
   /**
@@ -102,10 +111,25 @@ export default class CoreAdapter {
       apiKey: this._apiKey,
       experienceKey: this._experienceKey,
       locale: this._locale,
-      experienceVersion: this._experienceVersion
+      experienceVersion: this._experienceVersion,
+      endpoints: this._getServiceUrls()
     };
 
     this._coreLibrary = provideCore(params);
+  }
+
+  /**
+   * Get the urls for each service based on the environment.
+   */
+  _getServiceUrls() {
+    return {
+      universalSearch: getLiveApiUrl(this._environment) + ENDPOINTS.UNIVERSAL_SEARCH,
+      verticalSearch: getLiveApiUrl(this._environment) + ENDPOINTS.VERTICAL_SEARCH,
+      questionSubmission: getKnowledgeApiUrl(this._environment) + ENDPOINTS.QUESTION_SUBMISSION,
+      universalAutocomplete: getCachedLiveApiUrl(this._environment) + ENDPOINTS.UNIVERSAL_AUTOCOMPLETE,
+      verticalAutocomplete: getCachedLiveApiUrl(this._environment) + ENDPOINTS.VERTICAL_AUTOCOMPLETE,
+      filterSearch: getCachedLiveApiUrl(this._environment) + ENDPOINTS.FILTER_SEARCH
+    }
   }
 
   /**

--- a/src/core/core-adapter.js
+++ b/src/core/core-adapter.js
@@ -121,7 +121,7 @@ export default class CoreAdapter {
   /**
    * Get the urls for each service based on the environment.
    */
-  _getServiceUrls() {
+  _getServiceUrls () {
     return {
       universalSearch: getLiveApiUrl(this._environment) + ENDPOINTS.UNIVERSAL_SEARCH,
       verticalSearch: getLiveApiUrl(this._environment) + ENDPOINTS.VERTICAL_SEARCH,
@@ -129,7 +129,7 @@ export default class CoreAdapter {
       universalAutocomplete: getCachedLiveApiUrl(this._environment) + ENDPOINTS.UNIVERSAL_AUTOCOMPLETE,
       verticalAutocomplete: getCachedLiveApiUrl(this._environment) + ENDPOINTS.VERTICAL_AUTOCOMPLETE,
       filterSearch: getCachedLiveApiUrl(this._environment) + ENDPOINTS.FILTER_SEARCH
-    }
+    };
   }
 
   /**

--- a/src/core/utils/urlutils.js
+++ b/src/core/utils/urlutils.js
@@ -19,12 +19,12 @@ export function getCachedLiveApiUrl (env = PRODUCTION) {
   return env === SANDBOX ? 'https://liveapi-sandbox.yext.com' : 'https://liveapi-cached.yext.com';
 }
 
-/**	
- * Returns the base url for the knowledge api backend in the desired environment.	
- * @param {string} env The desired environment.	
- */	
-export function getKnowledgeApiUrl (env = PRODUCTION) {	
-  return env === SANDBOX ? 'https://api-sandbox.yext.com' : 'https://api.yext.com';	
+/**
+ * Returns the base url for the knowledge api backend in the desired environment.
+ * @param {string} env The desired environment.
+ */
+export function getKnowledgeApiUrl (env = PRODUCTION) {
+  return env === SANDBOX ? 'https://api-sandbox.yext.com' : 'https://api.yext.com';
 }
 
 /**

--- a/src/core/utils/urlutils.js
+++ b/src/core/utils/urlutils.js
@@ -19,6 +19,14 @@ export function getCachedLiveApiUrl (env = PRODUCTION) {
   return env === SANDBOX ? 'https://liveapi-sandbox.yext.com' : 'https://liveapi-cached.yext.com';
 }
 
+/**	
+ * Returns the base url for the knowledge api backend in the desired environment.	
+ * @param {string} env The desired environment.	
+ */	
+export function getKnowledgeApiUrl (env = PRODUCTION) {	
+  return env === SANDBOX ? 'https://api-sandbox.yext.com' : 'https://api.yext.com';	
+}
+
 /**
  * Returns the base url for the analytics backend in the desired environment.
  * @param {string} env The desired environment.


### PR DESCRIPTION
Support sandbox in the core

Add back the getKnowledgeApiUrl url helper which was deleted in the feature branch.

J=SLAP-1097
TEST=manual

Use a test site with regular keys and see the requests hit the production urls. Use a sandbox-prefixed key and see the urls hit the sandbox endpoints