### PR TITLE
Add back MasterSwitch

### DIFF
--- a/conf/gulp-tasks/bundle/bundle.js
+++ b/conf/gulp-tasks/bundle/bundle.js
@@ -68,7 +68,7 @@ exports.legacyBundle = function (callback, outputConfig, bundleName, locale, lib
       babel({
         runtimeHelpers: true,
         babelrc: false,
-        exclude: /node_modules\/(?!whatwg-fetch)(?!cross-fetch)(?!@yext\/answers-storage)(?!@yext\/answers-core).*/,
+        exclude: /node_modules\/(?!cross-fetch)(?!@yext\/answers-storage)(?!@yext\/answers-core).*/,
         presets: [
           [
             '@babel/preset-env',

--- a/conf/gulp-tasks/bundle/bundle.js
+++ b/conf/gulp-tasks/bundle/bundle.js
@@ -68,7 +68,7 @@ exports.legacyBundle = function (callback, outputConfig, bundleName, locale, lib
       babel({
         runtimeHelpers: true,
         babelrc: false,
-        exclude: /node_modules\/(?!cross-fetch)(?!@yext\/answers-storage)(?!@yext\/answers-core).*/,
+        exclude: /node_modules\/(?!whatwg-fetch)(?!cross-fetch)(?!@yext\/answers-storage)(?!@yext\/answers-core).*/,
         presets: [
           [
             '@babel/preset-env',

--- a/package-lock.json
+++ b/package-lock.json
@@ -22311,12 +22311,6 @@
         "iconv-lite": "0.4.24"
       }
     },
-    "whatwg-fetch": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz",
-      "integrity": "sha512-jXkLtsR42xhXg7akoDKvKWE40eJeI+2KZqcp2h3NsOrRnDvtWX36KcKl30dy+hxECivdk2BVUHVNrPtoMBUx6A==",
-      "dev": true
-    },
     "whatwg-mimetype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,10 @@
   ],
   "dependencies": {
     "@mapbox/mapbox-gl-language": "^0.10.1",
-    "@yext/answers-storage": "^1.0.0-beta.0",
     "@yext/answers-core": "^1.0.0-beta.7",
+    "@yext/answers-storage": "^1.0.0-beta.0",
     "@yext/rtf-converter": "^1.2.0",
+    "cross-fetch": "^3.0.6",
     "css-vars-ponyfill": "^2.3.1",
     "gulp-sourcemaps": "^2.6.5",
     "handlebars": "^4.7.2",

--- a/package.json
+++ b/package.json
@@ -87,8 +87,7 @@
     "testcafe": "^1.9.4",
     "testcafe-browser-provider-browserstack": "^1.13.0",
     "vinyl-buffer": "^1.0.1",
-    "vinyl-source-stream": "^2.0.0",
-    "whatwg-fetch": "^3.0.0"
+    "vinyl-source-stream": "^2.0.0"
   },
   "scripts": {
     "build": "gulp && size-limit",

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -282,6 +282,8 @@ class Answers {
 
     this._setDefaultInitialSearch(parsedConfig.search);
 
+    this.core.init();
+
     this._onReady = parsedConfig.onReady || function () {};
 
     const asyncDeps = this._loadAsyncDependencies(parsedConfig);

--- a/src/core/http/httprequester.js
+++ b/src/core/http/httprequester.js
@@ -2,7 +2,7 @@
 
 /* global fetch, XMLHttpRequest, ActiveXObject */
 
-import { fetch as fetchPolyfill } from 'whatwg-fetch';
+import { fetch as fetchPolyfill } from 'cross-fetch';
 
 /**
  * Types of HTTP requests


### PR DESCRIPTION
Add back masterswitch because the core library no longer performs the check

Make the init to core synchronous because it is no longer async.

Also update the HttpRequester to use cross-fetch. This prevents us from needing to include both whatwg-fetch and cross-fetch and saves us  a few KBs on the bundle size.

J=SLAP-1097
TEST=manual

Smoke test a site and confirm that the page loads. Manually test setting the masterswitch to disabled and confirm that the proper error is thrown.