### PR TITLE
provide helpful error messages for missing apiKey or experienceKey

### DIFF
--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -32,7 +32,7 @@ import { isValidContext } from './core/utils/apicontext';
 import FilterNodeFactory from './core/filters/filternodefactory';
 import { urlWithoutQueryParamsAndHash } from './core/utils/urlutils';
 import TranslationProcessor from './core/i18n/translationprocessor';
-import AnswersConfigBuilder from './core/models/answersconfig';
+import AnswersConfigBuilder from './core/models/answersconfigbuilder';
 
 /** @typedef {import('./core/services/searchservice').default} SearchService */
 /** @typedef {import('./core/services/autocompleteservice').default} AutoCompleteService */

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -274,7 +274,10 @@ class Answers {
       onUniversalSearch: answersConfig.onUniversalSearch
     });
 
-    answersConfig.onStateChange(Object.fromEntries(storage.getAll()), this.core.storage.getCurrentStateUrlMerged());
+    answersConfig.onStateChange(
+      Object.fromEntries(storage.getAll()),
+      this.core.storage.getCurrentStateUrlMerged()
+    );
 
     this.components
       .setCore(this.core)

--- a/src/core/models/answersconfig.js
+++ b/src/core/models/answersconfig.js
@@ -27,20 +27,20 @@ export default class AnswersConfig {
     this.experienceKey = rawConfig.experienceKey;
 
     /**
-     *  Optional, initialize components here, invoked when the Answers component library is loaded/ready.
-     *  If components are not added here, they can also be added when the init promise resolves
+     * Optional, initialize components here, invoked when the Answers component library is loaded/ready.
+     * If components are not added here, they can also be added when the init promise resolves
      * @type {function()}
      */
     this.onReady = rawConfig.onReady;
 
     /**
-     * Optional*, Yext businessId, *required to send analytics events
-     * @type {number|string|*}
+     * Optional, Yext businessId, required to send analytics events
+     * @type {string}
      */
     this.businessId = rawConfig.businessId;
 
     /**
-     * Optional, if false, the library will not fetch pre-made templates. Only use change this to false if you provide a
+     * Optional, if false, the library will not fetch pre-made templates. Only change this to false if you provide a
      *  template bundle in the `templateBundle` config option or implement custom renders for every component
      * @type {boolean}
      */
@@ -101,13 +101,13 @@ export default class AnswersConfig {
     this.onStateChange = rawConfig.onStateChange;
 
     /**
-     * Optional, analytics callback after a vertical search, see onVerticalSearch Configuration for additional details
+     * Optional, analytics callback after a vertical search
      * @type {function()}
      */
     this.onVerticalSearch = rawConfig.onVerticalSearch;
 
     /**
-     * Optional, analytics callback after a universal search, see onUniversalSearch Configuration for additional details
+     * Optional, analytics callback after a universal search
      * @type {function()}
      */
     this.onUniversalSearch = rawConfig.onUniversalSearch;
@@ -132,13 +132,13 @@ export default class AnswersConfig {
 
     /**
      * Global options to include with every analytic event reported to the server
-     * @type {object}
+     * @type {Object}
      */
     this.analyticsOptions = rawConfig.analyticsOptions;
 
     /**
      * A map of field formatters used to format results, if present
-     * @type {object}
+     * @type {Object}
      */
     this.fieldFormatters = rawConfig.fieldFormatters;
 

--- a/src/core/models/answersconfig.js
+++ b/src/core/models/answersconfig.js
@@ -3,7 +3,7 @@ import SearchConfig from '../models/searchconfig';
 import VerticalPagesConfig from '../models/verticalpagesconfig';
 
 /**
- * AnswersConfig is a model that is used that is used to turn a raw configuration into a data model.
+ * AnswersConfig is a model that is used to turn a raw configuration into a data model.
  * It is used to initialize the Answers SDK
  */
 export default class AnswersConfig {
@@ -27,9 +27,10 @@ export default class AnswersConfig {
     this.experienceKey = rawConfig.experienceKey;
 
     /**
-     * Optional, initialize components here, invoked when the Answers component library is loaded/ready.
-     * If components are not added here, they can also be added when the init promise resolves
-     * @type {function()}
+     * Optional, initialize components here, invoked when the Answers component library is
+     * loaded/ready. If components are not added here, they can also be added when the init
+     * promise resolves
+     * @type {function}
      */
     this.onReady = rawConfig.onReady;
 
@@ -83,7 +84,7 @@ export default class AnswersConfig {
     this.experienceVersion = rawConfig.experienceVersion;
 
     /**
-     * Optional, prints full Answers error details when set to \`true\`. Defaults to false.
+     * Optional, prints full Answers error details when set to true.
      * @type {boolean}
      */
     this.debug = rawConfig.debug;
@@ -119,7 +120,8 @@ export default class AnswersConfig {
     this.disableCssVariablesPonyfill = rawConfig.disableCssVariablesPonyfill;
 
     /**
-     * Optional, the analytics key describing the Answers integration type. Accepts 'STANDARD' or 'OVERLAY', defaults to 'STANDARD'
+     * Optional, the analytics key describing the Answers integration type.
+     * Accepts 'STANDARD' or 'OVERLAY'
      * @type {string}
      */
     this.querySource = rawConfig.querySource;

--- a/src/core/models/answersconfig.js
+++ b/src/core/models/answersconfig.js
@@ -3,6 +3,7 @@
 import { LOCALE, PRODUCTION, QUERY_SOURCE, SANDBOX } from '../constants';
 import SearchConfig from '../models/searchconfig';
 import VerticalPagesConfig from '../models/verticalpagesconfig';
+import { AnswersConfigError } from '../errors/errors';
 
 const sandboxPrefix = `${SANDBOX}-`;
 const DEFAULTS = {
@@ -20,197 +21,194 @@ const DEFAULTS = {
   querySource: QUERY_SOURCE
 };
 
-export default class AnswersConfig {
-  constructor (config) {
-    const parsedConfig = this.parseConfig(config);
+/**
+ * AnswersConfig is a model that is used that is used to turn a raw configuration into a data model that also storesVerticalPagesConfig}. It is used to initialze the Answers SDK
+ */
+class AnswersConfig {
+  constructor (rawConfig) {
+    /**
+     * Required, the Yext Answers API Key
+     * @type {string}
+     * @private
+     */
+    this.apiKey = rawConfig.apiKey;
 
     /**
      * The internal Yext environment
      * @type {string}
      * @private
      */
-    this._environment = parsedConfig.environment;
-
-    /**
-     * Required, the Yext Answers API Key
-     * @private
-     * @type {string}
-     */
-    this._apiKey = parsedConfig.apiKey;
+    this.environment = rawConfig.environment;
 
     /**
      * Required, the key used for your Answers Experience
      * @type {string}
      */
-    this.experienceKey = parsedConfig.experienceKey;
+    this.experienceKey = rawConfig.experienceKey;
 
     /**
      *  Optional, initialize components here, invoked when the Answers component library is loaded/ready.
      *  If components are not added here, they can also be added when the init promise resolves
      * @type {function()}
      */
-    this.onReady = parsedConfig.onReady;
+    this.onReady = rawConfig.onReady;
 
     /**
      * Optional*, Yext businessId, *required to send analytics events
      * @type {number|string|*}
      */
-    this.businessId = parsedConfig.businessId;
+    this.businessId = rawConfig.businessId;
 
     /**
      * Optional, if false, the library will not fetch pre-made templates. Only use change this to false if you provide a
      *  template bundle in the `templateBundle` config option or implement custom renders for every component
      * @type {boolean}
      */
-    this.useTemplates = parsedConfig.useTemplates;
+    this.useTemplates = rawConfig.useTemplates;
 
     /**
      * Optional, additional templates to register with the renderer
      * @type {Object}
      */
-    this.templateBundle = parsedConfig.templateBundle;
+    this.templateBundle = rawConfig.templateBundle;
 
     /**
      * Optional, provide configuration for each vertical that is shared across components
      * @type {VerticalPagesConfig}
      */
-    this.verticalPages = new VerticalPagesConfig(parsedConfig.verticalPages);
+    this.verticalPages = new VerticalPagesConfig(rawConfig.verticalPages);
 
     /**
      * Optional, search specific settings
      * @type {SearchConfig}
      */
-    this.search = new SearchConfig(parsedConfig.search);
+    this.search = new SearchConfig(rawConfig.search);
 
     /**
      * Optional, vertical no results settings. See Vertical No Results
      * @type {Object}
      */
-    this.noResults = parsedConfig.noResults;
+    this.noResults = rawConfig.noResults;
 
     /**
      * Optional, the locale will affect how queries are interpreted and the results returned. Defaults to 'en'
      * @type {string}
      */
-    this.locale = parsedConfig.locale;
+    this.locale = rawConfig.locale;
 
     /**
      * Optional, the Answers Experience version to use for api requests
      * @type {string}
      */
-    this.experienceVersion = parsedConfig.experienceVersion;
+    this.experienceVersion = rawConfig.experienceVersion;
 
     /**
      * Optional, prints full Answers error details when set to \`true\`. Defaults to false.
      * @type {boolean}
      */
-    this.debug = parsedConfig.debug;
+    this.debug = rawConfig.debug;
 
     /**
      * Optional, If true, the search session is tracked. If false, there is no tracking. Defaults to true.
      * @type {boolean}
      */
-    this.sessionTrackingEnabled = parsedConfig.sessionTrackingEnabled;
+    this.sessionTrackingEnabled = rawConfig.sessionTrackingEnabled;
 
     /**
      * Optional, invoked when the state of any component changes
      * @type {function()}
      */
-    this.onStateChange = parsedConfig.onStateChange;
+    this.onStateChange = rawConfig.onStateChange;
 
     /**
      * Optional, analytics callback after a vertical search, see onVerticalSearch Configuration for additional details
      * @type {function()}
      */
-    this.onVerticalSearch = parsedConfig.onVerticalSearch;
+    this.onVerticalSearch = rawConfig.onVerticalSearch;
 
     /**
      * Optional, analytics callback after a universal search, see onUniversalSearch Configuration for additional details
      * @type {function()}
      */
-    this.onUniversalSearch = parsedConfig.onUniversalSearch;
+    this.onUniversalSearch = rawConfig.onUniversalSearch;
 
     /**
      * Optional, opt-out of automatic css variable resolution on init for legacy browsers
      * @type {boolean}
      */
-    this.disableCssVariablesPonyfill = parsedConfig.disableCssVariablesPonyfill;
+    this.disableCssVariablesPonyfill = rawConfig.disableCssVariablesPonyfill;
 
     /**
      * Optional, the analytics key describing the Answers integration type. Accepts 'STANDARD' or 'OVERLAY', defaults to 'STANDARD'
      * @type {string}
      */
-    this.querySource = parsedConfig.querySource;
+    this.querySource = rawConfig.querySource;
 
-    this.mock = parsedConfig.mock;
-    this.analyticsOptions = parsedConfig.analyticsOptions;
-    this.fieldFormatters = parsedConfig.fieldFormatters;
+    /**
+     * Used to signify if mocked versions of services should be used
+     * @type{boolean}
+     */
+    this.useMock = rawConfig.mock;
 
-    this.validate();
+    /**
+     * Global options to include with every analytic event reported to the server
+     * @type {object}
+     */
+    this.analyticsOptions = rawConfig.analyticsOptions;
+
+    /**
+     * A map of field formatters used to format results, if present
+     * @type {object}
+     */
+    this.fieldFormatters = rawConfig.fieldFormatters;
+
     Object.freeze(this);
   }
+}
 
-  /**
-   * Validates the Answers config object to ensure things like api key and experience key are
-   * properly set.
-   */
-  validate () {
-    if (typeof this._apiKey !== 'string') {
-      throw new Error('Missing required `apiKey`. Type must be {string}');
-    }
-
-    if (typeof this.onStateChange !== 'function') {
-      throw new Error('onStateChange must be a function. Current type is: ' + typeof this.onStateChange);
-    }
-
-    if (typeof this.experienceKey !== 'string') {
-      throw new Error('Missing required `experienceKey`. Type must be {string}');
-    }
-
-    if (typeof this.onVerticalSearch !== 'function') {
-      throw new Error('onVerticalSearch must be a function. Current type is: ' + typeof this.onVerticalSearch);
-    }
-
-    if (typeof this.onUniversalSearch !== 'function') {
-      throw new Error('onUniversalSearch must be a function. Current type is: ' + typeof this.onUniversalSearch);
-    }
+export default class AnswersConfigBuilder {
+  setRawConfig (rawConfig) {
+    this.rawConfig = rawConfig;
+    return this;
   }
 
   /**
-   * The Yext Answers API Key. If the apiKey contains the sandbox prefix, then it is removed leaving only the API key.
-   * @returns {string}
+   * Validates and builds the Answers config object to ensure things like api key and experience key are
+   * properly set. Any options in rawConfig not supplied by the user are given default values.
    */
-  get apiKey () {
-    return this._apiKey.replace(sandboxPrefix, '');
-  }
-
-  /**
-   * The internal Yext Environment.
-   *  Defaults to Production
-   *  If the apiKey contains the sandbox prefix, then the environment returned is Sandbox.
-   * @returns {string}
-   */
-  get environment () {
-    if (this._apiKey.includes(sandboxPrefix)) {
-      return SANDBOX;
-    } else {
-      return this._environment;
+  build () {
+    if (this.rawConfig.apiKey === undefined || typeof this.rawConfig.apiKey !== 'string') {
+      throw new AnswersConfigError('Missing required `apiKey`. Type must be {string}', 'AnswersConfig');
     }
-  }
 
-  /**
-   * Parses the config provided by the user. In the parsed config, any options not supplied by the
-   * user are given default values.
-   * @param {Object} config The user supplied config.
-   */
-  parseConfig (config) {
-    const parsedConfig = Object.assign({}, DEFAULTS, config);
-    let sessionTrackingEnabled = true;
-
-    if (typeof config.sessionTrackingEnabled === 'boolean') {
-      sessionTrackingEnabled = config.sessionTrackingEnabled;
+    if (this.rawConfig.experienceKey === undefined || typeof this.rawConfig.experienceKey !== 'string') {
+      throw new AnswersConfigError('Missing required `experienceKey`. Type must be {string}', 'AnswersConfig');
     }
-    parsedConfig.sessionTrackingEnabled = sessionTrackingEnabled;
-    return parsedConfig;
+
+    if (this.rawConfig.onStateChange && typeof this.rawConfig.onStateChange !== 'function') {
+      throw new AnswersConfigError('onStateChange must be a function. Current type is: ' + typeof this.rawConfig.onStateChange, 'AnswersConfig');
+    }
+
+    if (this.rawConfig.onVerticalSearch && typeof this.rawConfig.onVerticalSearch !== 'function') {
+      throw new AnswersConfigError('onVerticalSearch must be a function. Current type is: ' + typeof this.rawConfig.onVerticalSearch, 'AnswersConfig');
+    }
+
+    if (this.rawConfig.onUniversalSearch && typeof this.rawConfig.onUniversalSearch !== 'function') {
+      throw new AnswersConfigError('onUniversalSearch must be a function. Current type is: ' + typeof this.rawConfig.onUniversalSearch, 'AnswersConfig');
+    }
+
+    if (this.rawConfig.sessionTrackingEnabled !== undefined && typeof this.rawConfig.sessionTrackingEnabled !== 'boolean') {
+      throw new AnswersConfigError('sessionTrackingEnabled must be a boolean. Current type is: ' + typeof this.rawConfig.sessionTrackingEnabled, 'AnswersConfig');
+    }
+
+    // Apply default values to the rawConfig before creating the AnswersConfig object
+    const rawConfig = Object.assign({}, DEFAULTS, this.rawConfig);
+
+    // Update apiKey and environment values if sandboxPrefix is included
+    if (rawConfig.apiKey.includes(sandboxPrefix)) {
+      rawConfig.apiKey = rawConfig.apiKey.replace(sandboxPrefix, '');
+      rawConfig.environment = SANDBOX;
+    }
+    return new AnswersConfig(rawConfig);
   }
 }

--- a/src/core/models/answersconfig.js
+++ b/src/core/models/answersconfig.js
@@ -1,0 +1,216 @@
+/** @module AnswersConfig */
+
+import { LOCALE, PRODUCTION, QUERY_SOURCE, SANDBOX } from '../constants';
+import SearchConfig from '../models/searchconfig';
+import VerticalPagesConfig from '../models/verticalpagesconfig';
+
+const sandboxPrefix = `${SANDBOX}-`;
+const DEFAULTS = {
+  environment: PRODUCTION,
+  onReady: function () {},
+  useTemplates: true,
+  locale: LOCALE,
+  experienceVersion: 'PRODUCTION',
+  debug: false,
+  sessionTrackingEnabled: true,
+  onStateChange: function () {},
+  onVerticalSearch: function () {},
+  onUniversalSearch: function () {},
+  disableCssVariablesPonyfill: false,
+  querySource: QUERY_SOURCE
+};
+
+export default class AnswersConfig {
+  constructor (config) {
+    const parsedConfig = this.parseConfig(config);
+
+    /**
+     * The internal Yext environment
+     * @type {string}
+     * @private
+     */
+    this._environment = parsedConfig.environment;
+
+    /**
+     * Required, the Yext Answers API Key
+     * @private
+     * @type {string}
+     */
+    this._apiKey = parsedConfig.apiKey;
+
+    /**
+     * Required, the key used for your Answers Experience
+     * @type {string}
+     */
+    this.experienceKey = parsedConfig.experienceKey;
+
+    /**
+     *  Optional, initialize components here, invoked when the Answers component library is loaded/ready.
+     *  If components are not added here, they can also be added when the init promise resolves
+     * @type {function()}
+     */
+    this.onReady = parsedConfig.onReady;
+
+    /**
+     * Optional*, Yext businessId, *required to send analytics events
+     * @type {number|string|*}
+     */
+    this.businessId = parsedConfig.businessId;
+
+    /**
+     * Optional, if false, the library will not fetch pre-made templates. Only use change this to false if you provide a
+     *  template bundle in the `templateBundle` config option or implement custom renders for every component
+     * @type {boolean}
+     */
+    this.useTemplates = parsedConfig.useTemplates;
+
+    /**
+     * Optional, additional templates to register with the renderer
+     * @type {Object}
+     */
+    this.templateBundle = parsedConfig.templateBundle;
+
+    /**
+     * Optional, provide configuration for each vertical that is shared across components
+     * @type {VerticalPagesConfig}
+     */
+    this.verticalPages = new VerticalPagesConfig(parsedConfig.verticalPages);
+
+    /**
+     * Optional, search specific settings
+     * @type {SearchConfig}
+     */
+    this.search = new SearchConfig(parsedConfig.search);
+
+    /**
+     * Optional, vertical no results settings. See Vertical No Results
+     * @type {Object}
+     */
+    this.noResults = parsedConfig.noResults;
+
+    /**
+     * Optional, the locale will affect how queries are interpreted and the results returned. Defaults to 'en'
+     * @type {string}
+     */
+    this.locale = parsedConfig.locale;
+
+    /**
+     * Optional, the Answers Experience version to use for api requests
+     * @type {string}
+     */
+    this.experienceVersion = parsedConfig.experienceVersion;
+
+    /**
+     * Optional, prints full Answers error details when set to \`true\`. Defaults to false.
+     * @type {boolean}
+     */
+    this.debug = parsedConfig.debug;
+
+    /**
+     * Optional, If true, the search session is tracked. If false, there is no tracking. Defaults to true.
+     * @type {boolean}
+     */
+    this.sessionTrackingEnabled = parsedConfig.sessionTrackingEnabled;
+
+    /**
+     * Optional, invoked when the state of any component changes
+     * @type {function()}
+     */
+    this.onStateChange = parsedConfig.onStateChange;
+
+    /**
+     * Optional, analytics callback after a vertical search, see onVerticalSearch Configuration for additional details
+     * @type {function()}
+     */
+    this.onVerticalSearch = parsedConfig.onVerticalSearch;
+
+    /**
+     * Optional, analytics callback after a universal search, see onUniversalSearch Configuration for additional details
+     * @type {function()}
+     */
+    this.onUniversalSearch = parsedConfig.onUniversalSearch;
+
+    /**
+     * Optional, opt-out of automatic css variable resolution on init for legacy browsers
+     * @type {boolean}
+     */
+    this.disableCssVariablesPonyfill = parsedConfig.disableCssVariablesPonyfill;
+
+    /**
+     * Optional, the analytics key describing the Answers integration type. Accepts 'STANDARD' or 'OVERLAY', defaults to 'STANDARD'
+     * @type {string}
+     */
+    this.querySource = parsedConfig.querySource;
+
+    this.mock = parsedConfig.mock;
+    this.analyticsOptions = parsedConfig.analyticsOptions;
+    this.fieldFormatters = parsedConfig.fieldFormatters;
+
+    this.validate();
+    Object.freeze(this);
+  }
+
+  /**
+   * Validates the Answers config object to ensure things like api key and experience key are
+   * properly set.
+   */
+  validate () {
+    if (typeof this._apiKey !== 'string') {
+      throw new Error('Missing required `apiKey`. Type must be {string}');
+    }
+
+    if (typeof this.onStateChange !== 'function') {
+      throw new Error('onStateChange must be a function. Current type is: ' + typeof this.onStateChange);
+    }
+
+    if (typeof this.experienceKey !== 'string') {
+      throw new Error('Missing required `experienceKey`. Type must be {string}');
+    }
+
+    if (typeof this.onVerticalSearch !== 'function') {
+      throw new Error('onVerticalSearch must be a function. Current type is: ' + typeof this.onVerticalSearch);
+    }
+
+    if (typeof this.onUniversalSearch !== 'function') {
+      throw new Error('onUniversalSearch must be a function. Current type is: ' + typeof this.onUniversalSearch);
+    }
+  }
+
+  /**
+   * The Yext Answers API Key. If the apiKey contains the sandbox prefix, then it is removed leaving only the API key.
+   * @returns {string}
+   */
+  get apiKey () {
+    return this._apiKey.replace(sandboxPrefix, '');
+  }
+
+  /**
+   * The internal Yext Environment.
+   *  Defaults to Production
+   *  If the apiKey contains the sandbox prefix, then the environment returned is Sandbox.
+   * @returns {string}
+   */
+  get environment () {
+    if (this._apiKey.includes(sandboxPrefix)) {
+      return SANDBOX;
+    } else {
+      return this._environment;
+    }
+  }
+
+  /**
+   * Parses the config provided by the user. In the parsed config, any options not supplied by the
+   * user are given default values.
+   * @param {Object} config The user supplied config.
+   */
+  parseConfig (config) {
+    const parsedConfig = Object.assign({}, DEFAULTS, config);
+    let sessionTrackingEnabled = true;
+
+    if (typeof config.sessionTrackingEnabled === 'boolean') {
+      sessionTrackingEnabled = config.sessionTrackingEnabled;
+    }
+    parsedConfig.sessionTrackingEnabled = sessionTrackingEnabled;
+    return parsedConfig;
+  }
+}

--- a/src/core/models/answersconfig.js
+++ b/src/core/models/answersconfig.js
@@ -1,42 +1,22 @@
 /** @module AnswersConfig */
-
-import { LOCALE, PRODUCTION, QUERY_SOURCE, SANDBOX } from '../constants';
 import SearchConfig from '../models/searchconfig';
 import VerticalPagesConfig from '../models/verticalpagesconfig';
-import { AnswersConfigError } from '../errors/errors';
-
-const sandboxPrefix = `${SANDBOX}-`;
-const DEFAULTS = {
-  environment: PRODUCTION,
-  onReady: function () {},
-  useTemplates: true,
-  locale: LOCALE,
-  experienceVersion: 'PRODUCTION',
-  debug: false,
-  sessionTrackingEnabled: true,
-  onStateChange: function () {},
-  onVerticalSearch: function () {},
-  onUniversalSearch: function () {},
-  disableCssVariablesPonyfill: false,
-  querySource: QUERY_SOURCE
-};
 
 /**
- * AnswersConfig is a model that is used that is used to turn a raw configuration into a data model that also storesVerticalPagesConfig}. It is used to initialze the Answers SDK
+ * AnswersConfig is a model that is used that is used to turn a raw configuration into a data model.
+ * It is used to initialize the Answers SDK
  */
-class AnswersConfig {
+export default class AnswersConfig {
   constructor (rawConfig) {
     /**
      * Required, the Yext Answers API Key
      * @type {string}
-     * @private
      */
     this.apiKey = rawConfig.apiKey;
 
     /**
      * The internal Yext environment
      * @type {string}
-     * @private
      */
     this.environment = rawConfig.environment;
 
@@ -163,52 +143,5 @@ class AnswersConfig {
     this.fieldFormatters = rawConfig.fieldFormatters;
 
     Object.freeze(this);
-  }
-}
-
-export default class AnswersConfigBuilder {
-  setRawConfig (rawConfig) {
-    this.rawConfig = rawConfig;
-    return this;
-  }
-
-  /**
-   * Validates and builds the Answers config object to ensure things like api key and experience key are
-   * properly set. Any options in rawConfig not supplied by the user are given default values.
-   */
-  build () {
-    if (this.rawConfig.apiKey === undefined || typeof this.rawConfig.apiKey !== 'string') {
-      throw new AnswersConfigError('Missing required `apiKey`. Type must be {string}', 'AnswersConfig');
-    }
-
-    if (this.rawConfig.experienceKey === undefined || typeof this.rawConfig.experienceKey !== 'string') {
-      throw new AnswersConfigError('Missing required `experienceKey`. Type must be {string}', 'AnswersConfig');
-    }
-
-    if (this.rawConfig.onStateChange && typeof this.rawConfig.onStateChange !== 'function') {
-      throw new AnswersConfigError('onStateChange must be a function. Current type is: ' + typeof this.rawConfig.onStateChange, 'AnswersConfig');
-    }
-
-    if (this.rawConfig.onVerticalSearch && typeof this.rawConfig.onVerticalSearch !== 'function') {
-      throw new AnswersConfigError('onVerticalSearch must be a function. Current type is: ' + typeof this.rawConfig.onVerticalSearch, 'AnswersConfig');
-    }
-
-    if (this.rawConfig.onUniversalSearch && typeof this.rawConfig.onUniversalSearch !== 'function') {
-      throw new AnswersConfigError('onUniversalSearch must be a function. Current type is: ' + typeof this.rawConfig.onUniversalSearch, 'AnswersConfig');
-    }
-
-    if (this.rawConfig.sessionTrackingEnabled !== undefined && typeof this.rawConfig.sessionTrackingEnabled !== 'boolean') {
-      throw new AnswersConfigError('sessionTrackingEnabled must be a boolean. Current type is: ' + typeof this.rawConfig.sessionTrackingEnabled, 'AnswersConfig');
-    }
-
-    // Apply default values to the rawConfig before creating the AnswersConfig object
-    const rawConfig = Object.assign({}, DEFAULTS, this.rawConfig);
-
-    // Update apiKey and environment values if sandboxPrefix is included
-    if (rawConfig.apiKey.includes(sandboxPrefix)) {
-      rawConfig.apiKey = rawConfig.apiKey.replace(sandboxPrefix, '');
-      rawConfig.environment = SANDBOX;
-    }
-    return new AnswersConfig(rawConfig);
   }
 }

--- a/src/core/models/answersconfigbuilder.js
+++ b/src/core/models/answersconfigbuilder.js
@@ -1,0 +1,73 @@
+import { LOCALE, PRODUCTION, QUERY_SOURCE, SANDBOX } from '../constants';
+import { AnswersConfigError } from '../errors/errors';
+import AnswersConfig from './answersconfig';
+
+const sandboxPrefix = `${SANDBOX}-`;
+const DEFAULTS = {
+  environment: PRODUCTION,
+  onReady: function () {},
+  useTemplates: true,
+  locale: LOCALE,
+  experienceVersion: 'PRODUCTION',
+  debug: false,
+  sessionTrackingEnabled: true,
+  onStateChange: function () {},
+  onVerticalSearch: function () {},
+  onUniversalSearch: function () {},
+  disableCssVariablesPonyfill: false,
+  querySource: QUERY_SOURCE
+};
+
+/**
+ * AnswersConfigBuilder builds a valid AnswersConfig object, validating a rawConfig before defaults are applied.
+ */
+export default class AnswersConfigBuilder {
+  setRawConfig (rawConfig) {
+    this.rawConfig = rawConfig;
+    return this;
+  }
+
+  /**
+   * Validates and builds the Answers config object to ensure things like api key and experience key are
+   * properly set. A helpful error message is thrown when the rawConfig fails validation. Any options in rawConfig
+   * not supplied by the user are given default values.
+   */
+  build () {
+    if (this.rawConfig === undefined) {
+      throw new AnswersConfigError('You must supply a configuration', 'AnswersConfigBuilder');
+    }
+    if (this.rawConfig.apiKey === undefined || typeof this.rawConfig.apiKey !== 'string') {
+      throw new AnswersConfigError('Missing required `apiKey`. Type must be {string}', 'AnswersConfigBuilder');
+    }
+
+    if (this.rawConfig.experienceKey === undefined || typeof this.rawConfig.experienceKey !== 'string') {
+      throw new AnswersConfigError('Missing required `experienceKey`. Type must be {string}', 'AnswersConfigBuilder');
+    }
+
+    if (this.rawConfig.onStateChange && typeof this.rawConfig.onStateChange !== 'function') {
+      throw new AnswersConfigError('onStateChange must be a function. Current type is: ' + typeof this.rawConfig.onStateChange, 'AnswersConfigBuilder');
+    }
+
+    if (this.rawConfig.onVerticalSearch && typeof this.rawConfig.onVerticalSearch !== 'function') {
+      throw new AnswersConfigError('onVerticalSearch must be a function. Current type is: ' + typeof this.rawConfig.onVerticalSearch, 'AnswersConfigBuilder');
+    }
+
+    if (this.rawConfig.onUniversalSearch && typeof this.rawConfig.onUniversalSearch !== 'function') {
+      throw new AnswersConfigError('onUniversalSearch must be a function. Current type is: ' + typeof this.rawConfig.onUniversalSearch, 'AnswersConfigBuilder');
+    }
+
+    if (this.rawConfig.sessionTrackingEnabled !== undefined && typeof this.rawConfig.sessionTrackingEnabled !== 'boolean') {
+      throw new AnswersConfigError('sessionTrackingEnabled must be a boolean. Current type is: ' + typeof this.rawConfig.sessionTrackingEnabled, 'AnswersConfigBuilder');
+    }
+
+    // Apply default values to the rawConfig before creating the AnswersConfig object
+    const rawConfig = Object.assign({}, DEFAULTS, this.rawConfig);
+
+    // Update apiKey and environment values if sandboxPrefix is included
+    if (rawConfig.apiKey.includes(sandboxPrefix)) {
+      rawConfig.apiKey = rawConfig.apiKey.replace(sandboxPrefix, '');
+      rawConfig.environment = SANDBOX;
+    }
+    return new AnswersConfig(rawConfig);
+  }
+}

--- a/tests/core/models/answersconfig.js
+++ b/tests/core/models/answersconfig.js
@@ -1,0 +1,131 @@
+import AnswersConfigBuilder from '../../../src/core/models/answersconfig';
+import { AnswersConfigError } from '../../../src/core/errors/errors';
+import { LOCALE, PRODUCTION, QUERY_SOURCE, SANDBOX } from '../../../src/core/constants';
+
+describe('constructing AnswersConfig', () => {
+  const key = 'someRandomKey';
+  it('throws an error when the api key is missing from the raw answers config', () => {
+    const config = {
+      experienceKey: key
+    };
+    const buildingAnswersConfig = () => new AnswersConfigBuilder().setRawConfig(config).build();
+    expect(buildingAnswersConfig).toThrow(AnswersConfigError);
+    expect(buildingAnswersConfig).toThrow('Missing required `apiKey`. Type must be {string}');
+  });
+
+  it('throws an error when the api key is missing from the raw answers config', () => {
+    const config = {
+      apiKey: key
+    };
+    const buildingAnswersConfig = () => new AnswersConfigBuilder().setRawConfig(config).build();
+    expect(buildingAnswersConfig).toThrow(AnswersConfigError);
+    expect(buildingAnswersConfig).toThrow('Missing required `experienceKey`. Type must be {string}');
+  });
+
+  it('throws an error when onStateChange is not a function', () => {
+    const config = {
+      apiKey: key,
+      experienceKey: key,
+      onStateChange: 'not a function'
+    };
+    const buildingAnswersConfig = () => new AnswersConfigBuilder().setRawConfig(config).build();
+    expect(buildingAnswersConfig).toThrow(AnswersConfigError);
+    expect(buildingAnswersConfig).toThrow('onStateChange must be a function. Current type is: string');
+  });
+
+  it('throws an error when onVerticalSearch is not a function', () => {
+    const config = {
+      apiKey: key,
+      experienceKey: key,
+      onVerticalSearch: 'not a function'
+    };
+    const buildingAnswersConfig = () => new AnswersConfigBuilder().setRawConfig(config).build();
+    expect(buildingAnswersConfig).toThrow(AnswersConfigError);
+    expect(buildingAnswersConfig).toThrow('onVerticalSearch must be a function. Current type is: string');
+  });
+
+  it('throws an error when onUniversalSearch is not a function', () => {
+    const config = {
+      apiKey: key,
+      experienceKey: key,
+      onUniversalSearch: 'not a function'
+    };
+    const buildingAnswersConfig = () => new AnswersConfigBuilder().setRawConfig(config).build();
+    expect(buildingAnswersConfig).toThrow(AnswersConfigError);
+    expect(buildingAnswersConfig).toThrow('onUniversalSearch must be a function. Current type is: string');
+  });
+
+  it('throws an error when sessionTrackingEnabled is not a boolean', () => {
+    const config = {
+      apiKey: key,
+      experienceKey: key,
+      sessionTrackingEnabled: 'not a boolean'
+    };
+    const buildingAnswersConfig = () => new AnswersConfigBuilder().setRawConfig(config).build();
+    expect(buildingAnswersConfig).toThrow(AnswersConfigError);
+    expect(buildingAnswersConfig).toThrow('sessionTrackingEnabled must be a boolean. Current type is: string');
+  });
+
+  it('properly handles the inclusion of sandboxPrefix in the apiKey', () => {
+    const config = {
+      apiKey: `${SANDBOX}-${key}`,
+      experienceKey: key
+    };
+    const answersConfig = new AnswersConfigBuilder().setRawConfig(config).build();
+    expect(answersConfig.apiKey).toBe(key);
+    expect(answersConfig.environment).toBe(SANDBOX);
+  });
+
+  it('has defaults properly applied', () => {
+    const config = {
+      apiKey: key,
+      experienceKey: key
+    };
+
+    const answersConfig = new AnswersConfigBuilder().setRawConfig(config).build();
+    expect(answersConfig.environment).toBe(PRODUCTION);
+    expect(typeof answersConfig.onReady).toBe('function');
+    expect(answersConfig.locale).toBe(LOCALE);
+    expect(answersConfig.experienceVersion).toBe('PRODUCTION');
+    expect(answersConfig.debug).toBe(false);
+    expect(answersConfig.sessionTrackingEnabled).toBe(true);
+    expect(typeof answersConfig.onStateChange).toBe('function');
+    expect(typeof answersConfig.onVerticalSearch).toBe('function');
+    expect(typeof answersConfig.onUniversalSearch).toBe('function');
+    expect(answersConfig.disableCssVariablesPonyfill).toBe(false);
+    expect(answersConfig.querySource).toBe(QUERY_SOURCE);
+  });
+
+  it('has defaults to not override explicitly declared parameters', () => {
+    const correctFunction = () => 'correct function';
+    const config = {
+      apiKey: key,
+      experienceKey: key,
+      environment: SANDBOX,
+      onReady: correctFunction,
+      useTemplates: false,
+      locale: 'new locale',
+      experienceVersion: 'SANDBOX',
+      debug: true,
+      sessionTrackingEnabled: false,
+      onStateChange: correctFunction,
+      onVerticalSearch: correctFunction,
+      onUniversalSearch: correctFunction,
+      disableCssVariablesPonyfill: true,
+      querySource: 'CUSTOM'
+    };
+
+    const answersConfig = new AnswersConfigBuilder().setRawConfig(config).build();
+    expect(answersConfig.environment).toBe(SANDBOX);
+    expect(answersConfig.onReady).toBe(correctFunction);
+    expect(answersConfig.locale).toBe('new locale');
+    expect(answersConfig.experienceVersion).toBe('SANDBOX');
+    expect(answersConfig.debug).toBe(true);
+    expect(answersConfig.sessionTrackingEnabled).toBe(false);
+    expect(answersConfig.onStateChange).toBe(correctFunction);
+    expect(answersConfig.onVerticalSearch).toBe(correctFunction);
+    expect(answersConfig.onUniversalSearch).toBe(correctFunction);
+    expect(answersConfig.disableCssVariablesPonyfill).toBe(true);
+    expect(answersConfig.querySource).toBe('CUSTOM');
+  });
+});

--- a/tests/core/models/answersconfigbuilder.js
+++ b/tests/core/models/answersconfigbuilder.js
@@ -1,6 +1,6 @@
-import AnswersConfigBuilder from '../../../src/core/models/answersconfig';
 import { AnswersConfigError } from '../../../src/core/errors/errors';
 import { LOCALE, PRODUCTION, QUERY_SOURCE, SANDBOX } from '../../../src/core/constants';
+import AnswersConfigBuilder from '../../../src/core/models/answersconfigbuilder';
 
 describe('constructing AnswersConfig', () => {
   const key = 'someRandomKey';
@@ -13,7 +13,7 @@ describe('constructing AnswersConfig', () => {
     expect(buildingAnswersConfig).toThrow('Missing required `apiKey`. Type must be {string}');
   });
 
-  it('throws an error when the api key is missing from the raw answers config', () => {
+  it('throws an error when the experienceKey key is missing from the raw answers config', () => {
     const config = {
       apiKey: key
     };


### PR DESCRIPTION
The SDK does not provide a helpful error message when either apiKey or
experienceKey are missing. Instead, it produces a cruptic error that is
hard to diagnose.

This commit adds an AnswersConfig class that parses a raw answers
configuration object and validates it to ensure things like the apiKey
and experienceKey are properly set. If they are not set, it provides a
helpful error messsage. Optional configuration options not supplied by
the user are given default values.

J=SLAP-1016
TEST=manual

used dev.html to run an  answers configuration without an apiKey or
experienceKey and confirmed that helpful messages appeared in the console.

Ran all acceptance tests and unit tests and confirmed that all we're
still passing.