### PR TITLE
Fix template error when ANSWERS exists on the window

### DIFF
--- a/conf/templates/handlebarswrapper.txt
+++ b/conf/templates/handlebarswrapper.txt
@@ -27,7 +27,7 @@ context['_hb'] = Handlebars;
 <%= contents %>;
 
 const autoinit = function() {
-  if (window.ANSWERS) {
+  if (window.ANSWERS && window.ANSWERS.templates) {
     ANSWERS.templates.register(context);
   }
 }()


### PR DESCRIPTION
Fix the error "Cannot read property 'register' of undefined" when the
ANSWERS instance exists on the page when a templateBundle is supplied

The error occurs because the template bundle checks if the ANSWERS
instance exists on the window, and if it does, it attempts to call
ANSWERS.templates.register(). The name ANSWERS.templates is misleading
because it does not contain the templates themselves, but rather it
contains the DefaultTemplateLoader. When specifying a bundle in the
ANSWERS config, the DefaultTemplateLoader is not used. Therefore, the
template bundle should not try to call register on the
DefaultTemplateLoader since it does not exist on the ANSWERS instance.

This is not a problem on most integrations because the ANSWERS instance
is typically loaded after the template bundle.

J=SLAP-1127 
TEST=manual

Test that the page no longer throws an error when the bundle is loaded
while an ANSWERS instance exists on the window. Test both the IIFE
bundle and the regular template bundle. Test that the
DefaultTemplateLoader also still works.