### PR TITLE
universalresults,verticalresults: remove default start icons

### DIFF
--- a/src/ui/components/results/universalresultscomponent.js
+++ b/src/ui/components/results/universalresultscomponent.js
@@ -91,7 +91,7 @@ export default class UniversalResultsComponent extends Component {
       // Label for the vertical in the titlebar.
       title: config.sectionTitle || verticalKey,
       // Icon in the titlebar
-      icon: config.sectionTitleIconName || config.sectionTitleIconUrl || 'star',
+      icon: config.sectionTitleIconName || config.sectionTitleIconUrl,
       // Url that links to the vertical search for this vertical.
       verticalURL: config.url,
       // Show a view more link by default, which also links to verticalURL.

--- a/src/ui/templates/results/verticalresults.hbs
+++ b/src/ui/templates/results/verticalresults.hbs
@@ -26,17 +26,17 @@
 {{#*inline "titleBar"}}
   {{#if _config.isUniversal}}
     <div class="yxt-Results-titleBar">
-    {{#if _config.icon}}
-      {{#if iconIsBuiltIn}}
-        <div class="yxt-Results-titleIconWrapper"
-          data-component="IconComponent"
-          data-opts='{ "iconName": "{{ _config.icon }}" }'></div>
-      {{else}}
-        <div class="yxt-Results-titleIconWrapper"
-          data-component="IconComponent"
-          data-opts='{ "iconUrl": "{{ _config.icon }}" }'></div>
+      {{#if _config.icon}}
+        {{#if iconIsBuiltIn}}
+          <div class="yxt-Results-titleIconWrapper"
+            data-component="IconComponent"
+            data-opts='{ "iconName": "{{ _config.icon }}" }'></div>
+        {{else}}
+          <div class="yxt-Results-titleIconWrapper"
+            data-component="IconComponent"
+            data-opts='{ "iconUrl": "{{ _config.icon }}" }'></div>
+        {{/if}}
       {{/if}}
-    {{/if}}
       <h2 class="yxt-Results-title">{{_config.title}}</h2>
     </div>
   {{/if}}

--- a/src/ui/templates/results/verticalresults.hbs
+++ b/src/ui/templates/results/verticalresults.hbs
@@ -26,6 +26,7 @@
 {{#*inline "titleBar"}}
   {{#if _config.isUniversal}}
     <div class="yxt-Results-titleBar">
+    {{#if _config.icon}}
       {{#if iconIsBuiltIn}}
         <div class="yxt-Results-titleIconWrapper"
           data-component="IconComponent"
@@ -35,6 +36,7 @@
           data-component="IconComponent"
           data-opts='{ "iconUrl": "{{ _config.icon }}" }'></div>
       {{/if}}
+    {{/if}}
       <h2 class="yxt-Results-title">{{_config.title}}</h2>
     </div>
   {{/if}}


### PR DESCRIPTION
Remove default star icons from SDK

If you don't specify an iconin the SDK in any of the following:
1. The top level verticals object
2. The component that is using it (vertical results for the no results
template, and universal results)

It should default to not showing an icon at all instead of a "star"

J=SLAP-1043
TEST=manual

- Performed universal search and confirmed that "star" icon no longer
  showed up in the DOM