### PR TITLE
universalresults,verticalresults: remove default star icons (#1306)

### DIFF
--- a/src/ui/components/results/universalresultscomponent.js
+++ b/src/ui/components/results/universalresultscomponent.js
@@ -91,7 +91,7 @@ export default class UniversalResultsComponent extends Component {
       // Label for the vertical in the titlebar.
       title: config.sectionTitle || verticalKey,
       // Icon in the titlebar
-      icon: config.sectionTitleIconName || config.sectionTitleIconUrl || 'star',
+      icon: config.sectionTitleIconName || config.sectionTitleIconUrl,
       // Url that links to the vertical search for this vertical.
       verticalURL: config.url,
       // Show a view more link by default, which also links to verticalURL.

--- a/src/ui/templates/results/verticalresults.hbs
+++ b/src/ui/templates/results/verticalresults.hbs
@@ -26,14 +26,16 @@
 {{#*inline "titleBar"}}
   {{#if _config.isUniversal}}
     <div class="yxt-Results-titleBar">
-      {{#if iconIsBuiltIn}}
-        <div class="yxt-Results-titleIconWrapper"
-          data-component="IconComponent"
-          data-opts='{ "iconName": "{{ _config.icon }}" }'></div>
-      {{else}}
-        <div class="yxt-Results-titleIconWrapper"
-          data-component="IconComponent"
-          data-opts='{ "iconUrl": "{{ _config.icon }}" }'></div>
+      {{#if _config.icon}}
+        {{#if iconIsBuiltIn}}
+          <div class="yxt-Results-titleIconWrapper"
+            data-component="IconComponent"
+            data-opts='{ "iconName": "{{ _config.icon }}" }'></div>
+        {{else}}
+          <div class="yxt-Results-titleIconWrapper"
+            data-component="IconComponent"
+            data-opts='{ "iconUrl": "{{ _config.icon }}" }'></div>
+        {{/if}}
       {{/if}}
       <h2 class="yxt-Results-title">{{_config.title}}</h2>
     </div>


### PR DESCRIPTION
universalresults,verticalresults: Remove default star icons

Remove default star icons from SDK

If you don't specify an icon in the SDK in any of the following:
1. The top level verticals object
2. The component that is using it (vertical results for the no results
template, and universal results)

It should default to not showing an icon at all instead of a "star"

J=SLAP-1043
TEST=manual

- Performed universal search and confirmed that "star" icon no longer
  showed up in the DOM