### PR TITLE
Add transformFacets options to the Facets component

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -5,7 +5,7 @@ module.exports = [
   },
   {
     path: 'dist/answers-modern.min.js',
-    limit: '115kb'
+    limit: '120kb'
   },
   {
     path: 'dist/answerstemplates.compiled.min.js',

--- a/README.md
+++ b/README.md
@@ -1386,15 +1386,17 @@ Here's an example of using this option to customize a boolean facet.
 
 ```js
 transformFacets: facets => {
-  facets.forEach(facet => {
-    if (facet.fieldId === 'c_acceptingNewPatients') {
-      facet.options.forEach(option => {
-        if (option.value === false) { option.displayName = "Not Accepting Patients"; }
-        if (option.value === true) { option.displayName = "Accepting Patients"; }
-      });
-    }
+  return facets.map(facet => {
+    const options = facet.options.map(option => {
+      if (facet.fieldId === 'c_acceptingNewPatients') {
+        const displayName = option.value === true
+          ? "Accepting Patients"
+          : "Not Accepting Patients";
+      }
+      return Object.assign({}, option, { displayName });
+    });
+    return Object.assign({}, facet, { options });
   });
-  return facets;
 },
 ```
 

--- a/README.md
+++ b/README.md
@@ -1388,10 +1388,10 @@ Here's an example of using this option to customize a boolean facet.
 transformFacets: facets => {
   return facets.map(facet => {
     const options = facet.options.map(option => {
+      let displayName = option.displayName;
       if (facet.fieldId === 'c_acceptingNewPatients') {
-        const displayName = option.value === true
-          ? "Accepting Patients"
-          : "Not Accepting Patients";
+        if (option.value === false) { displayName = "Not Accepting Patients"; }
+        if (option.value === true) { displayName = "Accepting Patients"; }
       }
       return Object.assign({}, option, { displayName });
     });

--- a/README.md
+++ b/README.md
@@ -1336,9 +1336,9 @@ ANSWERS.addComponent('Facets', {
   // Optional, the form label text for the search input, defaults to 'Search for a filter option'
   searchLabelText: 'Search for a filter option',
   // Optional, a transform function which is applied to an array of facets
-  // See the [Transforming Facets](#transforming-facets) section below for more info
+  // See the "Transforming Facets" section below for more info
   transformFacets: (facets => facets),
-  // DEPRECATED, please use transformFacets instead
+  // DEPRECATED, please use transformFacets instead. This option is disabled if transformFacets is supplied
   // Optional, field-specific overrides for a filter
   fields: {
     'c_customFieldName':  { // Field id to override e.g. c_customFieldName, builtin.location
@@ -1379,7 +1379,7 @@ ANSWERS.addComponent('Facets', {
 
 ### Transforming Facets
 
-The transformFacets option of the Facets component allows facets data to be fully customized. The function takes in and returns an array of the answers-core DisplayableFacet which is described [here](https://github.com/yext/answers-core/blob/master/docs/answers-core.displayablefacet.md).
+The `transformFacets` option of the Facets component allows facets data to be fully customized. The function takes in and returns an array of the answers-core DisplayableFacet which is described [here](https://github.com/yext/answers-core/blob/master/docs/answers-core.displayablefacet.md).
 
 Here's an example of using this option to customize a boolean facet:
 

--- a/README.md
+++ b/README.md
@@ -1381,19 +1381,20 @@ ANSWERS.addComponent('Facets', {
 
 The `transformFacets` option of the Facets component allows facets data to be fully customized. The function takes in and returns an array of the answers-core DisplayableFacet which is described [here](https://github.com/yext/answers-core/blob/master/docs/answers-core.displayablefacet.md). The function also has access to the Facets config as the second parameter.
 
-Here's an example of using this option to customize a boolean facet:
+Here's an example of using this option to customize a boolean facet. The function creates a deep copy in order to prevent side effects.
 
 ```js
 transformFacets: facets => {
-  facets.forEach(facet => {
-    if (facet.fieldId === 'specialities') {
+  const facetsCopy = JSON.parse(JSON.stringify(facets));
+  facetsCopy.forEach(facet => {
+    if (facet.fieldId === 'c_acceptingNewPatients') {
       facet.options.forEach(option => {
-        if (option.value === false) { option.displayName = 'Not Accepting Patients'; }
-        if (option.value === true) { option.displayName = 'Accepting Patients'; }
+        if (option.value === false) { option.displayName = "Not Accepting Patients"; }
+        if (option.value === true) { option.displayName = "Accepting Patients"; }
       });
     }
   });
-  return facets;
+  return facetsCopy;
 },
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Outline:
    - [Pagination Component](#pagination-component)
    - [FilterBox Component](#filterbox-component)
    - [Facets Component](#facets-component)
+      - [Transforming Facets](#transforming-facets)
    - [FilterSearch Component](#filtersearch-component)
    - [Filter Components](#filter-components)
    - [Applied Filters Component](#applied-filters-component)

--- a/README.md
+++ b/README.md
@@ -1335,6 +1335,10 @@ ANSWERS.addComponent('Facets', {
   searchable: false,
   // Optional, the form label text for the search input, defaults to 'Search for a filter option'
   searchLabelText: 'Search for a filter option',
+  // Optional, a transform function which is applied to an array of facets
+  // See the [Transforming Facets](#transforming-facets) section below for more info
+  transformFacets: (facets => facets),
+  // DEPRECATED, please use transformFacets instead
   // Optional, field-specific overrides for a filter
   fields: {
     'c_customFieldName':  { // Field id to override e.g. c_customFieldName, builtin.location
@@ -1371,6 +1375,26 @@ ANSWERS.addComponent('Facets', {
   // Optional, the label to show on the apply button
   applyLabel: 'apply'
 });
+```
+
+### Transforming Facets
+
+The transformFacets option of the Facets component allows facets data to be fully customized. The function takes in and returns an array of the answers-core DisplayableFacet which is described [here](https://github.com/yext/answers-core/blob/master/docs/answers-core.displayablefacet.md).
+
+Here's an example of using this option to customize a boolean facet:
+
+```js
+transformFacets: facets => {
+  facets.forEach(facet => {
+    if (facet.fieldId === 'c_acceptingNewPatients') {
+      facet.options.forEach(option => {
+        if (option.value === false) { option.displayName = "Not Accepting Patients"}
+        if (option.value === true) { option.displayName = "Accepting Patients"}
+      })
+    }
+  })
+  return facets;
+},
 ```
 
 ## FilterSearch Component

--- a/README.md
+++ b/README.md
@@ -1382,12 +1382,11 @@ ANSWERS.addComponent('Facets', {
 
 The `transformFacets` option of the Facets component allows facets data to be fully customized. The function takes in and returns an array of the answers-core DisplayableFacet which is described [here](https://github.com/yext/answers-core/blob/master/docs/answers-core.displayablefacet.md). The function also has access to the Facets config as the second parameter.
 
-Here's an example of using this option to customize a boolean facet. Create a deep copy of the facets with lodash in order to prevent modifying the original facets object.
+Here's an example of using this option to customize a boolean facet.
 
 ```js
 transformFacets: facets => {
-  const facetsCopy = _.cloneDeep(facets);
-  facetsCopy.forEach(facet => {
+  facets.forEach(facet => {
     if (facet.fieldId === 'c_acceptingNewPatients') {
       facet.options.forEach(option => {
         if (option.value === false) { option.displayName = "Not Accepting Patients"; }
@@ -1395,7 +1394,7 @@ transformFacets: facets => {
       });
     }
   });
-  return facetsCopy;
+  return facets;
 },
 ```
 

--- a/README.md
+++ b/README.md
@@ -1337,7 +1337,7 @@ ANSWERS.addComponent('Facets', {
   searchLabelText: 'Search for a filter option',
   // Optional, a transform function which is applied to an array of facets
   // See the "Transforming Facets" section below for more info
-  transformFacets: (facets => facets),
+  transformFacets: (facets, config => facets),
   // DEPRECATED, please use transformFacets instead. This option is disabled if transformFacets is supplied
   // Optional, field-specific overrides for a filter
   fields: {
@@ -1379,20 +1379,20 @@ ANSWERS.addComponent('Facets', {
 
 ### Transforming Facets
 
-The `transformFacets` option of the Facets component allows facets data to be fully customized. The function takes in and returns an array of the answers-core DisplayableFacet which is described [here](https://github.com/yext/answers-core/blob/master/docs/answers-core.displayablefacet.md).
+The `transformFacets` option of the Facets component allows facets data to be fully customized. The function takes in and returns an array of the answers-core DisplayableFacet which is described [here](https://github.com/yext/answers-core/blob/master/docs/answers-core.displayablefacet.md). The function also has access to the Facets config as the second parameter.
 
 Here's an example of using this option to customize a boolean facet:
 
 ```js
 transformFacets: facets => {
   facets.forEach(facet => {
-    if (facet.fieldId === 'c_acceptingNewPatients') {
+    if (facet.fieldId === 'specialities') {
       facet.options.forEach(option => {
-        if (option.value === false) { option.displayName = "Not Accepting Patients"}
-        if (option.value === true) { option.displayName = "Accepting Patients"}
-      })
+        if (option.value === false) { option.displayName = 'Not Accepting Patients'; }
+        if (option.value === true) { option.displayName = 'Accepting Patients'; }
+      });
     }
-  })
+  });
   return facets;
 },
 ```

--- a/README.md
+++ b/README.md
@@ -1381,11 +1381,11 @@ ANSWERS.addComponent('Facets', {
 
 The `transformFacets` option of the Facets component allows facets data to be fully customized. The function takes in and returns an array of the answers-core DisplayableFacet which is described [here](https://github.com/yext/answers-core/blob/master/docs/answers-core.displayablefacet.md). The function also has access to the Facets config as the second parameter.
 
-Here's an example of using this option to customize a boolean facet. The function creates a deep copy in order to prevent side effects.
+Here's an example of using this option to customize a boolean facet. Create a deep copy of the facets with lodash in order to prevent modifying the original facets object.
 
 ```js
 transformFacets: facets => {
-  const facetsCopy = JSON.parse(JSON.stringify(facets));
+  const facetsCopy = _.cloneDeep(facets);
   facetsCopy.forEach(facet => {
     if (facet.fieldId === 'c_acceptingNewPatients') {
       facet.options.forEach(option => {

--- a/src/core/models/dynamicfilters.js
+++ b/src/core/models/dynamicfilters.js
@@ -8,8 +8,8 @@ import ResultsContext from '../storage/resultscontext';
 export default class DynamicFilters {
   constructor (data) {
     /**
-     * The list of filters this model holds
-     * @type {{label: string, fieldId: string, options: object[]}}
+     * The list of facets this model holds
+     * @type {DisplayableFacet[]} from answers-core
      */
     this.filters = data.filters || [];
 
@@ -23,28 +23,13 @@ export default class DynamicFilters {
 
   /**
    * Organize 'facets' from the answers-core into dynamic filters
-   * @param {Facet[]} facets from answers-core
+   * @param {DisplayableFacet[]} facets from answers-core
    * @param {ResultsContext} resultsContext
    * @returns {DynamicFilters}
    */
   static fromCore (facets = [], resultsContext = ResultsContext.NORMAL) {
-    const dynamicFilters = facets.map(f => ({
-      label: f['displayName'],
-      fieldId: f['fieldId'],
-      options: f.options.map(o => ({
-        label: o['displayName'],
-        countLabel: o['count'],
-        selected: o['selected'],
-        filter: {
-          [f['fieldId']]: {
-            [o['matcher']]: o['value']
-          }
-        }
-      }))
-    }));
-
     return new DynamicFilters({
-      filters: dynamicFilters,
+      filters: facets,
       resultsContext: resultsContext
     });
   }

--- a/src/core/models/facet.js
+++ b/src/core/models/facet.js
@@ -37,4 +37,28 @@ export default class Facet {
 
     return new Facet(groups);
   }
+
+  /**
+   * Transforms an answers-core DisplayableFacet array into a Facet array
+   *
+   * @param {DisplayableFacet[]} coreFacets from answers-core
+   * @returns {Facet[]}
+   */
+  static fromCore (coreFacets = []) {
+    const facets = coreFacets.map(f => ({
+      label: f['displayName'],
+      fieldId: f['fieldId'],
+      options: f.options.map(o => ({
+        label: o['displayName'],
+        countLabel: o['count'],
+        selected: o['selected'],
+        filter: {
+          [f['fieldId']]: {
+            [o['matcher']]: o['value']
+          }
+        }
+      }))
+    })).map(f => new Facet(f));
+    return facets;
+  }
 }

--- a/src/ui/components/filters/facetscomponent.js
+++ b/src/ui/components/filters/facetscomponent.js
@@ -254,7 +254,7 @@ export default class FacetsComponent extends Component {
 
     return super.setState({
       ...data,
-      filters: updatedFacets,
+      filters: Facet.fromCore(updatedFacets),
       isNoResults: data.resultsContext === ResultsContext.NO_RESULTS
     });
   }
@@ -273,10 +273,9 @@ export default class FacetsComponent extends Component {
       this._filterbox.remove();
     }
 
-    let filters = this._getFacets();
-    const resultsContext = this._getResultsContext();
+    let { filters, isNoResults } = this._state.get();
 
-    if (filters.length === 0 || resultsContext === ResultsContext.NO_RESULTS) {
+    if (filters.length === 0 || isNoResults) {
       return;
     }
 
@@ -315,27 +314,5 @@ export default class FacetsComponent extends Component {
 
     this._filterbox.mount();
     this.core.storage.set(StorageKeys.FACETS_LOADED, true);
-  }
-
-  /**
-   * Gets the answers-core DisplayableFacet array and converts it into an array of Facets
-   *
-   * @returns {Facets[]}
-   */
-  _getFacets () {
-    const dynamicFilters = this._state.get();
-    const coreFacets = dynamicFilters['filters'];
-
-    return Facet.fromCore(coreFacets);
-  }
-
-  /**
-   * Gets the current results context
-   *
-   * @returns {ResultsContext}
-   */
-  _getResultsContext () {
-    const dynamicFilters = this._state.get();
-    return dynamicFilters['resultsContext'];
   }
 }

--- a/src/ui/components/filters/facetscomponent.js
+++ b/src/ui/components/filters/facetscomponent.js
@@ -6,6 +6,7 @@ import ResultsContext from '../../../core/storage/resultscontext';
 import ComponentTypes from '../../components/componenttypes';
 import TranslationFlagger from '../../i18n/translationflagger';
 import Facet from '../../../core/models/facet';
+import cloneDeep from 'lodash/cloneDeep';
 
 class FacetsConfig {
   constructor (config) {
@@ -222,7 +223,7 @@ export default class FacetsComponent extends Component {
      * A transformation function which operates on the core library DisplayableFacet model
      * @type {Function}
      */
-    this.transformFacets = config.transformFacets || ((facets, config) => facets);
+    this._transformFacets = config.transformFacets;
   }
 
   static get type () {
@@ -312,7 +313,13 @@ export default class FacetsComponent extends Component {
   _getFacets () {
     const dynamicFilters = this._state.get();
     const coreFacets = dynamicFilters['filters'] || [];
-    const transformedFacets = this.transformFacets(coreFacets, this.config);
+
+    if (!this._transformFacets) {
+      return Facet.fromCore(coreFacets);
+    }
+
+    const facetsCopy = cloneDeep(coreFacets);
+    const transformedFacets = this._transformFacets(facetsCopy, this.config);
 
     return Facet.fromCore(transformedFacets);
   }

--- a/src/ui/components/filters/facetscomponent.js
+++ b/src/ui/components/filters/facetscomponent.js
@@ -222,7 +222,7 @@ export default class FacetsComponent extends Component {
      * A transformation function which operates on the core library DisplayableFacet model
      * @type {Function}
      */
-    this.transformFacets = config.transformFacets || (facets => facets);
+    this.transformFacets = config.transformFacets || ((facets, config) => facets);
   }
 
   static get type () {
@@ -262,7 +262,7 @@ export default class FacetsComponent extends Component {
     let filters = this._getFacets();
     const resultsContext = this._getResultsContext();
 
-    if (!filters || resultsContext === ResultsContext.NO_RESULTS) {
+    if (filters.length === 0 || resultsContext === ResultsContext.NO_RESULTS) {
       return;
     }
 
@@ -312,7 +312,7 @@ export default class FacetsComponent extends Component {
   _getFacets () {
     const dynamicFilters = this._state.get();
     const coreFacets = dynamicFilters['filters'] || [];
-    const transformedFacets = this.transformFacets(coreFacets);
+    const transformedFacets = this.transformFacets(coreFacets, this.config);
 
     return Facet.fromCore(transformedFacets);
   }

--- a/src/ui/components/filters/facetscomponent.js
+++ b/src/ui/components/filters/facetscomponent.js
@@ -240,8 +240,21 @@ export default class FacetsComponent extends Component {
   }
 
   setState (data) {
+    const previousFacets = data['filters'] || [];
+    let updatedFacets = [];
+
+    if (this._transformFacets) {
+      const facetsCopy = cloneDeep(previousFacets);
+      const transformedFacets = this._transformFacets(facetsCopy, this.config);
+
+      updatedFacets = transformedFacets;
+    } else {
+      updatedFacets = previousFacets;
+    }
+
     return super.setState({
       ...data,
+      filters: updatedFacets,
       isNoResults: data.resultsContext === ResultsContext.NO_RESULTS
     });
   }
@@ -305,23 +318,15 @@ export default class FacetsComponent extends Component {
   }
 
   /**
-   * Gets the answers-core DisplayableFacet array, applies transformFacets,
-   * and then converts it into an array of Facets
+   * Gets the answers-core DisplayableFacet array and converts it into an array of Facets
    *
    * @returns {Facets[]}
    */
   _getFacets () {
     const dynamicFilters = this._state.get();
-    const coreFacets = dynamicFilters['filters'] || [];
+    const coreFacets = dynamicFilters['filters'];
 
-    if (!this._transformFacets) {
-      return Facet.fromCore(coreFacets);
-    }
-
-    const facetsCopy = cloneDeep(coreFacets);
-    const transformedFacets = this._transformFacets(facetsCopy, this.config);
-
-    return Facet.fromCore(transformedFacets);
+    return Facet.fromCore(coreFacets);
   }
 
   /**

--- a/tests/ui/components/filters/facetscomponent.js
+++ b/tests/ui/components/filters/facetscomponent.js
@@ -1,0 +1,97 @@
+import DOM from 'src/ui/dom/dom';
+import { mount } from 'enzyme';
+import mockManager from '../../../setup/managermocker';
+import StorageKeys from '../../../../src/core/storage/storagekeys';
+import DynamicFilters from '../../../../src/core/models/dynamicfilters';
+import Storage from '../../../../src/core/storage/storage';
+import FilterRegistry from '../../../../src/core/filters/filterregistry';
+
+describe('Facets Component', () => {
+  DOM.setup(document, new DOMParser());
+  let COMPONENT_MANAGER, defaultConfig;
+
+  beforeEach(() => {
+    const bodyEl = DOM.query('body');
+    DOM.empty(bodyEl);
+    DOM.append(bodyEl, DOM.createEl('div', { id: 'test-component' }));
+
+    const storage = new Storage().init();
+    const filterRegistry = new FilterRegistry(storage);
+
+    const mockCore = {
+      verticalSearch: jest.fn(),
+      enableDynamicFilters: jest.fn(),
+      storage: storage,
+      filterRegistry: filterRegistry,
+      setFacetFilterNodes: (availableFieldids = [], filterNodes = []) => {
+        filterRegistry.setFacetFilterNodes(availableFieldids, filterNodes);
+      }
+    };
+    COMPONENT_MANAGER = mockManager(mockCore);
+
+    defaultConfig = {
+      container: '#test-component'
+    };
+  });
+
+  it('The facets component renders', () => {
+    const component = COMPONENT_MANAGER.create('Facets', defaultConfig);
+    const wrapper = mount(component);
+    expect(wrapper.find('.yxt-Facets-container')).toHaveLength(1);
+  });
+
+  it('The transformFacets option supports boolean facets', () => {
+    const transformFacets = facets => {
+      facets.forEach(facet => {
+        if (facet.fieldId === 'c_acceptingNewPatients') {
+          facet.options.forEach(option => {
+            if (option.value === false) { option.displayName = 'Not Accepting Patients'; }
+            if (option.value === true) { option.displayName = 'Accepting Patients'; }
+          });
+        }
+      });
+      return facets;
+    };
+    const coreFacets = [{
+      fieldId: 'c_acceptingNewPatients',
+      displayName: 'Accepting New Patients',
+      options: [
+        {
+          displayName: 'true',
+          count: 1,
+          selected: false,
+          matcher: '$eq',
+          value: true
+        },
+        {
+          displayName: 'false',
+          count: 1,
+          selected: false,
+          matcher: '$eq',
+          value: false
+        }
+      ]
+    }];
+
+    const component = COMPONENT_MANAGER.create('Facets', {
+      transformFacets,
+      ...defaultConfig
+    });
+    const dynamicFilters = DynamicFilters.fromCore(coreFacets);
+    component.core.storage.set(StorageKeys.DYNAMIC_FILTERS, dynamicFilters);
+    const wrapper = mount(component);
+
+    const expectedDisplayNames = [
+      'Not Accepting Patients',
+      'Accepting Patients'
+    ];
+    const actualDisplayNames = [];
+
+    wrapper.find('.js-yxt-FilterOptions-optionLabel--name').forEach(node => {
+      const displayName = node.text().trim();
+      actualDisplayNames.push(displayName);
+    });
+
+    expect(actualDisplayNames).toEqual(expect.arrayContaining(expectedDisplayNames));
+  });
+});


### PR DESCRIPTION
Add transformFacets options to the Facets component

Supports full customization of the facets data. One of the main use cases of this is to allow the displayNames to be customized for boolean facets.

This PR updates the DynamicFilters model to use the answers-core DisplayableFacet model internally. This allow us to apply `transformFacets` on the core data model and then finally convert it to the SDK model in the facet component's `setState()`

This PR deprecates the facets "fields" option

J=SLAP-1121
TEST=manual, unit

Use the config option to change the label name of boolean facets. Confirm that the fields option still works. Test that the field option is disabled if the transformFacets option is supplied
