### PR TITLE
Empty universal search

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ ANSWERS.addComponent('SearchBar', {
   autoFocus: true,
   // Optional, when auto focus on load,  open the autocomplete
   autoCompleteOnLoad: false,
-  // Optional, on vertical search, allow a user to conduct an empty search. Should be set to true if the defaultInitialSearch is "".
+  // Optional, allows a user to conduct an empty search. Should be set to true if the defaultInitialSearch is "".
   allowEmptySearch: false,
   // Optional, defaults to 300ms (0.3 seconds)
   searchCooldown: 2000,

--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -479,14 +479,13 @@ class Answers {
   }
 
   /**
-   * Sets a search query on initialization for vertical searchers that have a
-   * defaultInitialSearch provided, if the user hasn't already provided their
-   * own via URL param.
+   * Sets a search query on initialization when defaultInitialSearch is provided
+   * if the user hasn't already provided their own via URL param.
    * @param {SearchConfig} searchConfig
    * @private
    */
   _setDefaultInitialSearch (searchConfig) {
-    if (searchConfig.defaultInitialSearch == null || !searchConfig.verticalKey) {
+    if (searchConfig.defaultInitialSearch == null) {
       return;
     }
     const prepopulatedQuery = this.core.storage.get(StorageKeys.QUERY);

--- a/src/core/models/searchconfig.js
+++ b/src/core/models/searchconfig.js
@@ -18,7 +18,7 @@ export default class SearchConfig {
     this.verticalKey = config.verticalKey || null;
 
     /**
-     * A default search to use on initialization for vertical searchers, when the user has't provided a query
+     * A default search to use on initialization when the user hasn't provided a query
      * @type {string}
      */
     this.defaultInitialSearch = config.defaultInitialSearch;

--- a/src/ui/components/results/universalresultscomponent.js
+++ b/src/ui/components/results/universalresultscomponent.js
@@ -59,7 +59,7 @@ export default class UniversalResultsComponent extends Component {
       isPreSearch: searchState === SearchStates.PRE_SEARCH,
       isSearchLoading: searchState === SearchStates.SEARCH_LOADING,
       isSearchComplete: searchState === SearchStates.SEARCH_COMPLETE,
-      showNoResults: sections.length === 0 && query,
+      showNoResults: sections.length === 0 && (query || query === ''),
       query: query,
       sections: sections
     }, val));

--- a/src/ui/components/search/searchcomponent.js
+++ b/src/ui/components/search/searchcomponent.js
@@ -225,7 +225,7 @@ export default class SearchComponent extends Component {
     this._showClearButton = this.clearButton && this.query;
 
     /**
-     * For vertical search bars, whether or not to allow empty searches.
+     * Whether or not to allow empty searches.
      * @type {boolean}
      * @private
      */
@@ -591,8 +591,7 @@ export default class SearchComponent extends Component {
    */
   debouncedSearch (query, searchOptions) {
     if (this._throttled ||
-      (!query && !this._verticalKey) ||
-      (!query && this._verticalKey && !this._allowEmptySearch) ||
+      (!query && !this._allowEmptySearch) ||
       this._isTwin) {
       return;
     }

--- a/tests/ui/components/search/searchcomponent.js
+++ b/tests/ui/components/search/searchcomponent.js
@@ -97,6 +97,6 @@ describe('SearchBar component', () => {
       });
     });
 
-    return expect(wasSearchRanPromise).resolves.toBe(true);
+    return expect(wasSearchRanPromise).resolves.toBeTruthy();
   });
 });

--- a/tests/ui/components/search/searchcomponent.js
+++ b/tests/ui/components/search/searchcomponent.js
@@ -22,8 +22,10 @@ describe('SearchBar component', () => {
         this.storage.set(StorageKeys.QUERY, query);
       },
       autoCompleteVertical: jest.fn(() => Promise.resolve({ inputIntents: [] })),
+      autoCompleteUniversal: jest.fn(() => Promise.resolve({ inputIntents: [] })),
       verticalSearch: jest.fn()
     });
+    COMPONENT_MANAGER.getActiveComponent = () => null;
     storage = COMPONENT_MANAGER.core.storage;
   });
 
@@ -88,11 +90,12 @@ describe('SearchBar component', () => {
 
     const component = COMPONENT_MANAGER.create('SearchBar', {
       ...defaultConfig,
+      verticalKey: null,
       allowEmptySearch: true
     });
 
     const wasSearchRanPromise = new Promise(resolve => {
-      component.search = jest.fn(() => {
+      component.core.search = jest.fn(() => {
         resolve(true);
       });
     });

--- a/tests/ui/components/search/searchcomponent.js
+++ b/tests/ui/components/search/searchcomponent.js
@@ -2,6 +2,7 @@ import DOM from '../../../../src/ui/dom/dom';
 import mockManager from '../../../setup/managermocker';
 import { mount } from 'enzyme';
 import StorageKeys from '../../../../src/core/storage/storagekeys';
+import QueryTriggers from '../../../../src/core/models/querytriggers';
 
 DOM.setup(document, new DOMParser());
 
@@ -78,5 +79,24 @@ describe('SearchBar component', () => {
 
       expect(storage.getUrlWithCurrentState()).toEqual('query=');
     });
+  });
+
+  it('default initial search works for universal', () => {
+    const defaultInitialSearch = '';
+    storage.set(StorageKeys.QUERY, defaultInitialSearch);
+    storage.set(StorageKeys.QUERY_TRIGGER, QueryTriggers.INITIALIZE);
+
+    const component = COMPONENT_MANAGER.create('SearchBar', {
+      ...defaultConfig,
+      allowEmptySearch: true
+    });
+
+    const wasSearchRanPromise = new Promise(resolve => {
+      component.search = jest.fn(() => {
+        resolve(true);
+      });
+    });
+
+    return expect(wasSearchRanPromise).resolves.toBe(true);
   });
 });


### PR DESCRIPTION
Support empty universal searches

J=SLAP-1153
TEST=manual, auto

Refer to the minispec and test the 5 listed use cases which are combinations of allowEmptySearch (true or false), defaultInitialSearch (empty string, string, or not supplied). Also modify the data transformer to mock empty universal search results and make sure that the "no results" message shows up in accordance with the spec.

Add a unit test to simulate a default initial search. I added a `wasSearchRanPromise` because the search method is ran asynchronously and if we try to use a standard mock function with expect().toHaveBeenCalled(), the test fails because the expect runs before the search method
