### PR TITLE
Speed up component lifecycle

### DIFF
--- a/src/ui/components/component.js
+++ b/src/ui/components/component.js
@@ -293,7 +293,7 @@ export default class Component {
     return this;
   }
 
-  _attachListeners() {
+  _attachListeners () {
     // Attach analytics hooks as necessary
     if (this.analyticsReporter) {
       let domHooks = DOM.queryAll(this._container, '[data-eventtype]:not([data-is-analytics-attached])');


### PR DESCRIPTION
This commit has 3 speed improvements to the component lifecycle.
Overall the time it takes to process a universal query dropped from
~150ms -> ~115ms
- remove cloneDeep call before transformData, 13.1ms (11.8%) -> 0.8ms (0.7%)
- remove unnecessary DOM.create call, which removes extra createContextualFragment call
  21.0ms (13.6%) -> 0ms
- only call _attachEventListeners() for the top level parent component, 4.2ms (2.9%) -> 4.4ms (1.6%)

I also tried using document.createDocumentFragment in the UniversalResults component, and
having all its children components (vertical results + theme cards) append to the fragment
instead of to the current "live" DOM. I thought doing this in memory would reduce the
"Parse HTML" steps in the chrome performance tools, but these numbers seemed almost
completely unaffected by this, and overall performance seemed the same whether I had that change
or not.

TEST=manual

test that mercy loads properly, measure speed improvements using chrome dev tools by looking
at the call stack chart that shows the percent of time as well as flat time different methods
take to complete.