### PR TITLE
Set QUERY_PARAMETER query trigger even when query=""

### DIFF
--- a/src/answers-umd.js
+++ b/src/answers-umd.js
@@ -219,7 +219,7 @@ class Answers {
     parsedConfig.noResults && storage.set(StorageKeys.NO_RESULTS_CONFIG, parsedConfig.noResults);
     const isSuggestQueryTrigger =
       storage.get(StorageKeys.QUERY_TRIGGER) === QueryTriggers.SUGGEST;
-    if (storage.get(StorageKeys.QUERY) && !isSuggestQueryTrigger) {
+    if (storage.has(StorageKeys.QUERY) && !isSuggestQueryTrigger) {
       storage.set(StorageKeys.QUERY_TRIGGER, QueryTriggers.QUERY_PARAMETER);
     }
 

--- a/src/core/storage/storage.js
+++ b/src/core/storage/storage.js
@@ -167,6 +167,16 @@ export default class Storage {
   }
 
   /**
+   * Whether the specified key exists or not
+   *
+   * @param {string} key the storage key
+   * @return {boolean}
+   */
+  has (key) {
+    return this.storage.has(key);
+  }
+
+  /**
    * Returns the url representing the current persisted state, merged
    * with any additional query params currently in the url.
    *

--- a/tests/acceptance/acceptancesuites/acceptancesuite.js
+++ b/tests/acceptance/acceptancesuites/acceptancesuite.js
@@ -70,6 +70,19 @@ test('navigating and refreshing mantains that page number', async t => {
   await t.expect(pageNum).eql('Page 2');
 });
 
+test.only('navigating and refreshing mantains that page number with blank query', async t => {
+  const searchComponent = VerticalPage.getSearchComponent();
+  await searchComponent.submitQuery();
+
+  const paginationComponent = VerticalPage.getPaginationComponent();
+  await paginationComponent.clickNextButton();
+  let pageNum = await paginationComponent.getActivePageLabelAndNumber();
+  await t.expect(pageNum).eql('Page 2');
+  await browserRefreshPage();
+  pageNum = await paginationComponent.getActivePageLabelAndNumber();
+  await t.expect(pageNum).eql('Page 2');
+});
+
 test('spell check flow', async t => {
   const spellCheckLogger = RequestLogger({
     url: /v2\/accounts\/me\/answers\/vertical\/query/

--- a/tests/acceptance/acceptancesuites/acceptancesuite.js
+++ b/tests/acceptance/acceptancesuites/acceptancesuite.js
@@ -70,7 +70,7 @@ test('navigating and refreshing mantains that page number', async t => {
   await t.expect(pageNum).eql('Page 2');
 });
 
-test.only('navigating and refreshing mantains that page number with blank query', async t => {
+test('navigating and refreshing mantains that page number with blank query', async t => {
   const searchComponent = VerticalPage.getSearchComponent();
   await searchComponent.submitQuery();
 

--- a/tests/acceptance/fixtures/html/vertical.html
+++ b/tests/acceptance/fixtures/html/vertical.html
@@ -35,7 +35,8 @@
                         container: '.search-bar-container',
                         verticalKey:'KM',
                         clearButton: true,
-                        promptForLocation: true
+                        promptForLocation: true,
+                        allowEmptySearch: true
                     });
 
                     this.addComponent('Navigation', {


### PR DESCRIPTION
This commit fixes a bug where the QUERY_PARAMETER query trigger
was not being set when query was a blank string. This was causing
pagination to not be persisted on page refresh for blank string queries.

J=SLAP-1089
TEST=manual,auto

test that I can run a blank query, update the page, then refresh
and the page will be persisted

double checked that undoing this fix will cause the newly added
acceptance test to fail