### PR TITLE
Update to Core Library v1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2636,9 +2636,9 @@
       }
     },
     "@yext/answers-core": {
-      "version": "1.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/@yext/answers-core/-/answers-core-1.0.0-beta.7.tgz",
-      "integrity": "sha512-hgDCx2hq8c+5t7JhC4/Y6J6M9Mn4NIZdUxYCXWnpTdOJwAfVrNUBQ3fxAj5oGnuOD6CScx0HRdih6QTGIFKUuw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@yext/answers-core/-/answers-core-1.0.0.tgz",
+      "integrity": "sha512-xdleJcMExj+WTsSLqy/+kre/mWATqDfJhqjfDRWx5wAqjz5xequ8K41nq66PX0RdHiplcvln2L+acbIYrrZmDA==",
       "requires": {
         "@babel/runtime-corejs3": "^7.12.5",
         "cross-fetch": "^3.0.6"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "@mapbox/mapbox-gl-language": "^0.10.1",
-    "@yext/answers-core": "^1.0.0-beta.7",
+    "@yext/answers-core": "^1.0.0",
     "@yext/answers-storage": "^1.0.0-beta.0",
     "@yext/rtf-converter": "^1.2.0",
     "cross-fetch": "^3.0.6",


### PR DESCRIPTION
Update the core library dependency to v1.0.0

The public interface of core hasn't chanced since the most recent beta, so there is no need for other code changes.

J=none
TEST=manual

Smoke test universal search, vertical search, and facets.