### PR TITLE
npm: Add name and version changes for the new NPM package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# Answers
-Answers Javascript API Library.
-
+# Answers Search UI
 Outline:
 1. [Install / Setup](#install-and-setup)
 2. [ANSWERS.init Configuration Options](#answersinit-configuration-options)

--- a/conf/npm/README.md
+++ b/conf/npm/README.md
@@ -1,4 +1,4 @@
 This is a javascript library that helps you build search experiences on top of
 the Yext Answers product. The library provides many out of the box components.
 A full list of the components and how to use them can be found here: 
-https://github.com/yext/answers
+https://github.com/yext/answers-search-ui

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
-  "name": "@yext/answers",
-  "version": "1.7.0",
+  "name": "@yext/answers-search-ui",
+  "version": "1.7.1",
   "description": "Javascript Answers Programming Interface",
   "main": "dist/answers-umd.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/yext/answers.git"
+    "url": "git+https://github.com/yext/answers-search-ui.git"
   },
   "bugs": {
-    "url": "https://github.com/yext/answers/issues"
+    "url": "https://github.com/yext/answers-search-ui/issues"
   },
-  "homepage": "https://github.com/yext/answers#readme",
+  "homepage": "https://github.com/yext/answers-search-ui#readme",
   "keywords": [
     "yext",
     "search",


### PR DESCRIPTION
We are changing the name of our Github and NPM package for the SDK.
Instead of `yext/answers`, the repository name will be
`yext/answers-search-ui`. Instead of `@yext/answers`, the NPM package
will be named `@yext/answers-search-ui`.

We can re-name the repository with via the Github UI settings and have
Github apply automatic redirects with links. This includes anyone using
the old github link in their package.json or referencing any files in the
repository via the old repository link.

This re-name will allow us to keep our (1) commit history, (2)
PRs/issues, and (3) functioning URLs to our repository, and (4) tags. If
we fork, our PRs and issues would not carry over. This would be the same
if we tried to push our old code to a new repository programmatically.

However, we cannot just re-name the NPM package. Thus we will deprecate
the old NPM package and create a new one with the new name. These
changes support thee name change for this new package.

J=SLAP-1146
TEST=manual

Tested on a separate personal repository that:
* You can re-name a repository and it will supply automatic redirects,
  for instance https://github.com/creotutar/answers-search (old name)
  redirects to https://github.com/creotutar/answers-search-ui (new
  name).
* You keep PRs/issues and tags through this re-name.
* You can reference our repository, nested files in our repositories,
  and use our old git URL in a package.json and refirects will apply in
  all cases.