### PR TITLE
Fix direct answer type location

### DIFF
--- a/src/core/models/directanswer.js
+++ b/src/core/models/directanswer.js
@@ -23,7 +23,6 @@ export default class DirectAnswer {
 
     const directAnswerData = {
       answer: {
-        type: directAnswer.type,
         snippet: directAnswer.snippet,
         entityName: directAnswer.entityName,
         fieldName: directAnswer.fieldName,
@@ -39,7 +38,8 @@ export default class DirectAnswer {
           website: relatedResult.link
         },
         verticalConfigId: directAnswer.verticalKey
-      }
+      },
+      type: directAnswer.type
     };
 
     const directAnswerFieldApiName = directAnswerData.answer.fieldApiName;


### PR DESCRIPTION
Fix the direct answer model by moving the type

When updating the core-extraction branch to incorporate the type, 
the location of the field didn't match the SDK develop branch. 
This PR fixes that.

J=SLAP-1125 
TEST=manual 

Point the theme develop branch to this build and test document 
search and field value direct answers
