### PR TITLE
universalresults,verticalresults: Toggle CSS classes onto results con…

### DIFF
--- a/src/core/models/universalresults.js
+++ b/src/core/models/universalresults.js
@@ -11,7 +11,7 @@ export default class UniversalResults {
     /**
      * The current state of the search, used to render different templates before, during,
      * and after loading
-     * @type {string}
+     * @type {SearchState}
      */
     this.searchState = data.searchState || SearchStates.SEARCH_COMPLETE;
   }
@@ -30,7 +30,7 @@ export default class UniversalResults {
   }
 
   /**
-   * Construct a UnivervalResults object representing loading results
+   * Construct a UniversalResults object representing loading results
    * @return {UniversalResults}
    */
   static searchLoading () {

--- a/src/core/storage/searchstates.js
+++ b/src/core/storage/searchstates.js
@@ -1,9 +1,13 @@
 /** @module SearchStates */
 
 /**
+ * @typedef {string} SearchState
+ */
+
+/**
  * SearchStates is an ENUM for the various stages of searching,
  * used to show different templates
- * @enum {string}
+ * @enum {SearchState}
  */
 export default {
   PRE_SEARCH: 'pre-search',

--- a/src/core/utils/resultsutils.js
+++ b/src/core/utils/resultsutils.js
@@ -1,0 +1,20 @@
+import SearchStates from '../storage/searchstates';
+
+/**
+ * Returns a CSS class for the input searchState
+ * @param {SearchState} searchState
+ * @returns {string}
+ */
+export function getContainerClass (searchState) {
+  switch (searchState) {
+    case SearchStates.PRE_SEARCH:
+      return 'yxt-Results--preSearch';
+    case SearchStates.SEARCH_LOADING:
+      return 'yxt-Results--searchLoading';
+    case SearchStates.SEARCH_COMPLETE:
+      return 'yxt-Results--searchComplete';
+    default:
+      console.trace('encountered an unknown search state');
+      return '';
+  }
+}

--- a/src/ui/components/component.js
+++ b/src/ui/components/component.js
@@ -243,6 +243,22 @@ export default class Component {
     return this;
   }
 
+  /**
+   * Adds a class to the container of the component.
+   * @param {string} className A comma separated value of classes
+   */
+  addContainerClass (className) {
+    DOM.addClass(this._container, className);
+  }
+
+  /**
+   * Removes the specified classes from the container of the component
+   * @param {string} className A comma separated value of classes
+   */
+  removeContainerClass (className) {
+    DOM.removeClass(this._container, className);
+  }
+
   setState (data) {
     const newState = Object.assign({}, { _config: this._config }, data);
     this._state.set(newState);

--- a/src/ui/components/results/universalresultscomponent.js
+++ b/src/ui/components/results/universalresultscomponent.js
@@ -7,6 +7,7 @@ import SearchStates from '../../../core/storage/searchstates';
 import AccordionResultsComponent from './accordionresultscomponent.js';
 import { defaultConfigOption } from '../../../core/utils/configutils';
 import TranslationFlagger from '../../i18n/translationflagger';
+import { getContainerClass } from '../../../core/utils/resultsutils';
 
 export default class UniversalResultsComponent extends Component {
   constructor (config = {}, systemConfig = {}) {
@@ -55,6 +56,10 @@ export default class UniversalResultsComponent extends Component {
     const sections = data.sections || [];
     const query = this.core.storage.get(StorageKeys.QUERY);
     const searchState = data.searchState || SearchStates.PRE_SEARCH;
+    Object.entries(SearchStates).forEach(([k, searchState]) => {
+      this.removeContainerClass(getContainerClass(searchState));
+    });
+    this.addContainerClass(getContainerClass(searchState));
     return super.setState(Object.assign(data, {
       isPreSearch: searchState === SearchStates.PRE_SEARCH,
       isSearchLoading: searchState === SearchStates.SEARCH_LOADING,

--- a/src/ui/components/results/verticalresultscomponent.js
+++ b/src/ui/components/results/verticalresultscomponent.js
@@ -15,6 +15,7 @@ import { defaultConfigOption } from '../../../core/utils/configutils';
 import { getTabOrder } from '../../tools/taborder';
 import SearchParams from '../../dom/searchparams';
 import TranslationFlagger from '../../i18n/translationflagger';
+import { getContainerClass } from '../../../core/utils/resultsutils';
 
 class VerticalResultsConfig {
   constructor (config = {}) {
@@ -215,7 +216,8 @@ export default class VerticalResultsComponent extends Component {
       eventType: 'update',
       storageKey: StorageKeys.VERTICAL_RESULTS,
       callback: results => {
-        if (results.searchState === SearchStates.SEARCH_COMPLETE) {
+        if (results.searchState === SearchStates.SEARCH_COMPLETE ||
+          results.searchState === SearchStates.SEARCH_LOADING) {
           this.setState(results);
         }
       }
@@ -344,7 +346,13 @@ export default class VerticalResultsComponent extends Component {
       this._displayAllResults ||
       data.resultsContext === ResultsContext.NORMAL;
     this.query = this.core.storage.get(StorageKeys.QUERY);
+    Object.entries(SearchStates).forEach(([k, searchState]) => {
+      this.removeContainerClass(getContainerClass(searchState));
+    });
+
+    this.addContainerClass(getContainerClass(searchState));
     return super.setState(Object.assign({ results: [] }, data, {
+      searchState: searchState,
       isPreSearch: searchState === SearchStates.PRE_SEARCH,
       isSearchLoading: searchState === SearchStates.SEARCH_LOADING,
       isSearchComplete: searchState === SearchStates.SEARCH_COMPLETE,

--- a/src/ui/dom/dom.js
+++ b/src/ui/dom/dom.js
@@ -144,6 +144,20 @@ export default class DOM {
     }
   }
 
+  /**
+   * Removes classes from a specified element.
+   * @param {HTMLElement} node The html element to be acted upon
+   * @param {string} className A comma separated list of classes to be removed
+   */
+  static removeClass (node, className) {
+    if (!node) {
+      return;
+    }
+
+    const classes = className.split(',');
+    classes.forEach(className => node.classList.remove(className));
+  }
+
   static empty (parent) {
     parent.innerHTML = '';
   }

--- a/tests/ui/components/results/universalresultscomponent.js
+++ b/tests/ui/components/results/universalresultscomponent.js
@@ -1,0 +1,53 @@
+/* eslint no-undef: 0 */
+import Storage from '../../../../src/core/storage/storage';
+import DOM from '../../../../src/ui/dom/dom';
+import StorageKeys from '../../../../src/core/storage/storagekeys';
+import mockManager from '../../../setup/managermocker';
+import { mount } from 'enzyme';
+import SearchStates from '../../../../src/core/storage/searchstates';
+import UniversalResultsComponent from '../../../../src/ui/components/results/universalresultscomponent';
+import UniversalResults from '../../../../src/core/models/universalresults';
+
+const mockCore = {
+  storage: new Storage().init(),
+  getStaticFilterNodes: () => [],
+  getFacetFilterNodes: () => [],
+  getLocationRadiusFilterNode: () => null
+};
+
+DOM.setup(document, new DOMParser());
+
+mockCore.storage.set(StorageKeys.VERTICAL_PAGES_CONFIG, { get: () => [] });
+mockCore.storage.set(StorageKeys.REFERRER_PAGE_URL, '');
+
+const COMPONENT_MANAGER = mockManager(mockCore);
+COMPONENT_MANAGER.getComponentNamesForComponentTypes = () => {
+  return [];
+};
+
+describe('universal results component', () => {
+  let defaultConfig;
+
+  beforeEach(() => {
+    const bodyEl = DOM.query('body');
+    DOM.empty(bodyEl);
+    DOM.append(bodyEl, DOM.createEl('div', { id: 'test-component' }));
+
+    defaultConfig = {
+      container: '#test-component'
+    };
+  });
+
+  it('sets correct loading state css class', () => {
+    const component = COMPONENT_MANAGER.create(UniversalResultsComponent.type, defaultConfig);
+    const container = DOM.query('#test-component');
+    mount(component, { attachTo: container });
+    expect(container.classList.contains('yxt-Results--preSearch')).toBeTruthy();
+
+    component.core.storage.set(StorageKeys.UNIVERSAL_RESULTS, UniversalResults.searchLoading());
+    expect(container.classList.contains('yxt-Results--searchLoading')).toBeTruthy();
+
+    component.core.storage.set(StorageKeys.UNIVERSAL_RESULTS, { searchState: SearchStates.SEARCH_COMPLETE });
+    expect(container.classList.contains('yxt-Results--searchComplete')).toBeTruthy();
+  });
+});

--- a/tests/ui/components/results/verticalresultscomponent.js
+++ b/tests/ui/components/results/verticalresultscomponent.js
@@ -5,6 +5,7 @@ import StorageKeys from '../../../../src/core/storage/storagekeys';
 import SearchStates from '../../../../src/core/storage/searchstates';
 import VerticalResultsComponent from '../../../../src/ui/components/results/verticalresultscomponent';
 import Storage from '../../../../src/core/storage/storage';
+import VerticalResults from '../../../../src/core/models/verticalresults';
 
 const mockCore = {
   storage: new Storage().init(),
@@ -42,6 +43,19 @@ describe('vertical results component', () => {
     const component = COMPONENT_MANAGER.create(VerticalResultsComponent.type, defaultConfig);
 
     expect(component.getVerticalURL()).toContain('query=yext');
+  });
+
+  it('sets correct loading state css class', () => {
+    const component = COMPONENT_MANAGER.create(VerticalResultsComponent.type, defaultConfig);
+    const container = DOM.query('#test-component');
+    mount(component, { attachTo: container });
+    expect(container.classList.contains('yxt-Results--preSearch')).toBeTruthy();
+
+    component.core.storage.set(StorageKeys.VERTICAL_RESULTS, VerticalResults.searchLoading());
+    expect(container.classList.contains('yxt-Results--searchLoading')).toBeTruthy();
+
+    component.core.storage.set(StorageKeys.VERTICAL_RESULTS, { searchState: SearchStates.SEARCH_COMPLETE });
+    expect(container.classList.contains('yxt-Results--searchComplete')).toBeTruthy();
   });
 
   it('updates to storage vertical results update the component results', () => {


### PR DESCRIPTION
…tainers (#1316)

universalresults,verticalresults: Toggle CSS classes onto results containers

Toggle CSS classes onto results containers to ensure we can target them
in theme styling.

J=SLAP-957
TEST=manual

 - Checked loading states when making a search in both universal and
 vertical searches
 - Wrote a unit test for VerticalSearch that asserts that the correct
   class is rendered in all loading states